### PR TITLE
Orientation constraints are inconsistent for path constraints vs goal constraints

### DIFF
--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/ompl_constraints.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/ompl_constraints.h
@@ -365,9 +365,9 @@ private:
  *
  *  And then the constraints can be written as
  *
- *     - absolute_x_axis_tolerance / 2 < error[0] < absolute_x_axis_tolerance / 2
- *     - absolute_y_axis_tolerance / 2 < error[1] < absolute_y_axis_tolerance / 2
- *     - absolute_z_axis_tolerance / 2 < error[2] < absolute_z_axis_tolerance / 2
+ *     - absolute_x_axis_tolerance < error[0] < absolute_x_axis_tolerance
+ *     - absolute_y_axis_tolerance < error[1] < absolute_y_axis_tolerance
+ *     - absolute_z_axis_tolerance < error[2] < absolute_z_axis_tolerance
  *
  * **IMPORTANT** It is NOT how orientation error is handled in the default MoveIt constraint samplers, where XYZ
  * intrinsic euler angles are used. Using exponential coordinates is analog to how orientation error is calculated in

--- a/moveit_planners/ompl/ompl_interface/src/detail/ompl_constraints.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/detail/ompl_constraints.cpp
@@ -345,8 +345,8 @@ Bounds positionConstraintMsgToBoundVector(const moveit_msgs::msg::PositionConstr
 
 Bounds orientationConstraintMsgToBoundVector(const moveit_msgs::msg::OrientationConstraint& ori_con)
 {
-  std::vector<double> dims = { ori_con.absolute_x_axis_tolerance, ori_con.absolute_y_axis_tolerance,
-                               ori_con.absolute_z_axis_tolerance };
+  std::vector<double> dims = { ori_con.absolute_x_axis_tolerance * 2.0, ori_con.absolute_y_axis_tolerance * 2.0,
+                               ori_con.absolute_z_axis_tolerance * 2.0 };
 
   // dimension of -1 signifies unconstrained parameter, so set to infinity
   for (auto& dim : dims)


### PR DESCRIPTION
Fixes https://github.com/ros-planning/moveit2/issues/1586. (There's a full description there)

Merge with this moveit_msgs PR to ensure the documentation stays up to date:  https://github.com/ros-planning/moveit2/pull/1592