### PR TITLE
Removing topic name parameter configuration and replacing with const strings

### DIFF
--- a/moveit_ros/moveit_servo/src/servo_parameters.cpp
+++ b/moveit_ros/moveit_servo/src/servo_parameters.cpp
@@ -105,7 +105,6 @@ void ServoParameters::declare(const std::string& ns,
 
   // Properties of incoming commands
 
-
   node_parameters->declare_parameter(
       ns + ".robot_link_command_frame", ParameterValue{ parameters.robot_link_command_frame },
       ParameterDescriptorBuilder{}

--- a/moveit_ros/moveit_servo/src/servo_parameters.cpp
+++ b/moveit_ros/moveit_servo/src/servo_parameters.cpp
@@ -102,16 +102,10 @@ void ServoParameters::declare(const std::string& ns,
       ParameterDescriptorBuilder{}
           .type(PARAMETER_BOOL)
           .description("Whether the robot is started in a Gazebo simulation environment"));
-  node_parameters->declare_parameter(
-      ns + ".status_topic", ParameterValue{ parameters.status_topic },
-      ParameterDescriptorBuilder{}.type(PARAMETER_STRING).description("Publish status to this topic"));
+
   // Properties of incoming commands
-  node_parameters->declare_parameter(
-      ns + ".cartesian_command_in_topic", ParameterValue{ parameters.cartesian_command_in_topic },
-      ParameterDescriptorBuilder{}.type(PARAMETER_STRING).description("Topic for incoming Cartesian twist commands"));
-  node_parameters->declare_parameter(
-      ns + ".joint_command_in_topic", ParameterValue{ parameters.joint_command_in_topic },
-      ParameterDescriptorBuilder{}.type(PARAMETER_STRING).description("Topic for incoming joint angle commands"));
+
+
   node_parameters->declare_parameter(
       ns + ".robot_link_command_frame", ParameterValue{ parameters.robot_link_command_frame },
       ParameterDescriptorBuilder{}
@@ -271,12 +265,11 @@ ServoParameters ServoParameters::get(const std::string& ns,
 
   // ROS Parameters
   parameters.use_gazebo = node_parameters->get_parameter(ns + ".use_gazebo").as_bool();
-  parameters.status_topic = node_parameters->get_parameter(ns + ".status_topic").as_string();
+  parameters.status_topic = "/servo_server/status";
 
   // Properties of incoming commands
-  parameters.cartesian_command_in_topic =
-      node_parameters->get_parameter(ns + ".cartesian_command_in_topic").as_string();
-  parameters.joint_command_in_topic = node_parameters->get_parameter(ns + ".joint_command_in_topic").as_string();
+  parameters.cartesian_command_in_topic = "/servo_server/cartesian_commands";
+  parameters.joint_command_in_topic = "/servo_server/joint_commands";
   parameters.robot_link_command_frame = node_parameters->get_parameter(ns + ".robot_link_command_frame").as_string();
   parameters.command_in_type = node_parameters->get_parameter(ns + ".command_in_type").as_string();
   parameters.linear_scale = node_parameters->get_parameter(ns + ".scale.linear").as_double();

--- a/moveit_ros/planning/moveit_cpp/include/moveit/moveit_cpp/moveit_cpp.h
+++ b/moveit_ros/planning/moveit_cpp/include/moveit/moveit_cpp/moveit_cpp.h
@@ -62,22 +62,18 @@ public:
       const std::string ns = "planning_scene_monitor_options";
       node->get_parameter_or(ns + ".name", name, std::string("planning_scene_monitor"));
       node->get_parameter_or(ns + ".robot_description", robot_description, std::string("robot_description"));
-      node->get_parameter_or(ns + ".joint_state_topic", joint_state_topic,
-                             planning_scene_monitor::PlanningSceneMonitor::DEFAULT_JOINT_STATES_TOPIC);
-      node->get_parameter_or(ns + ".attached_collision_object_topic", attached_collision_object_topic,
-                             planning_scene_monitor::PlanningSceneMonitor::DEFAULT_ATTACHED_COLLISION_OBJECT_TOPIC);
-      node->get_parameter_or(ns + ".monitored_planning_scene_topic", monitored_planning_scene_topic,
-                             planning_scene_monitor::PlanningSceneMonitor::MONITORED_PLANNING_SCENE_TOPIC);
-      node->get_parameter_or(ns + ".publish_planning_scene_topic", publish_planning_scene_topic,
-                             planning_scene_monitor::PlanningSceneMonitor::DEFAULT_PLANNING_SCENE_TOPIC);
       node->get_parameter_or(ns + ".wait_for_initial_state_timeout", wait_for_initial_state_timeout, 0.0);
     }
     std::string name;
     std::string robot_description;
-    std::string joint_state_topic;
-    std::string attached_collision_object_topic;
-    std::string monitored_planning_scene_topic;
-    std::string publish_planning_scene_topic;
+
+    const std::string joint_state_topic = planning_scene_monitor::PlanningSceneMonitor::DEFAULT_JOINT_STATES_TOPIC;
+    const std::string attached_collision_object_topic =
+        planning_scene_monitor::PlanningSceneMonitor::DEFAULT_ATTACHED_COLLISION_OBJECT_TOPIC;
+    const std::string monitored_planning_scene_topic =
+        planning_scene_monitor::PlanningSceneMonitor::MONITORED_PLANNING_SCENE_TOPIC;
+    const std::string publish_planning_scene_topic =
+        planning_scene_monitor::PlanningSceneMonitor::DEFAULT_PLANNING_SCENE_TOPIC;
     double wait_for_initial_state_timeout;
   };
 


### PR DESCRIPTION
### Description

This PR introduces changes to streamline the setup process for the `moveit_cpp::PlanningSceneMonitorOptions` and `moveit_servo::ServoParameters` by utilizing constant strings for topic names instead of parameter-based configurations. The changes ensure that topic names are now consistent and predefined. This modification also implies that users who need customized topic names will now have to use topic remapping in their launch files or at the ROS node level.

These updates are in direct response to the issue discussed in #2714 

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
In the tutorials, I see some files where changes need to be made to remove topic names from parameters, for example here: 
https://github.com/ros-planning/moveit2_tutorials/blob/main/doc/examples/moveit_cpp/config/moveit_cpp.yaml
I'm confused about the sequence of changes though since these are 2 separate repos. Do I make these changes before this PR is merged, do I make 2 simultaneous PR or do I raise an issue on that repo? Some guidance would be helpful to proceed on this point.
- [x] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit2/blob/main/MIGRATION.md) notes
Done included in the commit
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
As this PR stands, there are no scenarios where the code fails without this PR because it is an API enhancement. Yet, if needed, I can create tests- please let me know.
- [ ] Include a screenshot if changing a GUI
Not Applicable
- [x] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"