### PR TITLE
Fix CI for Rolling / Ubuntu Noble

### DIFF
--- a/.docker/source/Dockerfile
+++ b/.docker/source/Dockerfile
@@ -4,7 +4,7 @@
 # Downloads the moveit source code and install remaining debian dependencies
 
 ARG ROS_DISTRO=rolling
-FROM moveit/moveit2:${ROS_DISTRO}-ci-testing
+FROM moveit/moveit2:${ROS_DISTRO}-ci
 LABEL maintainer Robert Haschke rhaschke@techfak.uni-bielefeld.de
 
 # Export ROS_UNDERLAY for downstream docker containers

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -30,6 +30,16 @@ jobs:
       PUSH: ${{ (github.event_name != 'pull_request') && (github.repository == 'ros-planning/moveit2') }}
 
     steps:
+      - uses: rhaschke/docker-run-action@v5
+        name: Check for apt updates
+        continue-on-error: true
+        id: apt
+        with:
+          image: ${{ env.IMAGE }}
+          run: |
+            apt-get update
+            have_updates=$(apt-get --simulate upgrade | grep -q "^0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.$" && echo false || echo true)
+            echo "no_cache=$have_updates" >> "$GITHUB_OUTPUT"
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to Github Container Registry
@@ -51,7 +61,9 @@ jobs:
           file: .docker/${{ github.job }}/Dockerfile
           build-args: ROS_DISTRO=${{ matrix.ROS_DISTRO }}
           push: ${{ env.PUSH }}
-          no-cache: true
+          no-cache: ${{ steps.apt.outputs.no_cache || github.event_name == 'workflow_dispatch' }}
+          cache-from: type=registry,ref=${{ env.GH_IMAGE }}
+          cache-to: type=inline
           tags: |
             ${{ env.GH_IMAGE }}
             ${{ env.DH_IMAGE }}
@@ -71,6 +83,16 @@ jobs:
       PUSH: ${{ (github.event_name != 'pull_request') && (github.repository == 'ros-planning/moveit2') }}
 
     steps:
+      - uses: rhaschke/docker-run-action@v5
+        name: Check for apt updates
+        continue-on-error: true
+        id: apt
+        with:
+          image: ${{ env.IMAGE }}
+          run: |
+            apt-get update
+            have_updates=$(apt-get --simulate upgrade | grep -q "^0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.$" && echo false || echo true)
+            echo "no_cache=$have_updates" >> "$GITHUB_OUTPUT"
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to Github Container Registry
@@ -92,7 +114,9 @@ jobs:
           file: .docker/${{ github.job }}/Dockerfile
           build-args: ROS_DISTRO=${{ matrix.ROS_DISTRO }}
           push: ${{ env.PUSH }}
-          no-cache: true
+          no-cache: ${{ steps.apt.outputs.no_cache || github.event_name == 'workflow_dispatch' }}
+          cache-from: type=registry,ref=${{ env.GH_IMAGE }}
+          cache-to: type=inline
           tags: |
             ${{ env.GH_IMAGE }}
             ${{ env.DH_IMAGE }}
@@ -112,6 +136,16 @@ jobs:
       PUSH: ${{ (github.event_name != 'pull_request') && (github.repository == 'ros-planning/moveit2') }}
 
     steps:
+      - uses: rhaschke/docker-run-action@v5
+        name: Check for apt updates
+        continue-on-error: true
+        id: apt
+        with:
+          image: ${{ env.IMAGE }}
+          run: |
+            apt-get update
+            have_updates=$(apt-get --simulate upgrade | grep -q "^0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.$" && echo false || echo true)
+            echo "no_cache=$have_updates" >> "$GITHUB_OUTPUT"
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to Github Container Registry
@@ -133,7 +167,9 @@ jobs:
           file: .docker/${{ github.job }}/Dockerfile
           build-args: OUR_ROS_DISTRO=${{ matrix.ROS_DISTRO }}
           push: ${{ env.PUSH }}
-          no-cache: true
+          no-cache: ${{ steps.apt.outputs.no_cache || github.event_name == 'workflow_dispatch' }}
+          cache-from: type=registry,ref=${{ env.GH_IMAGE }}
+          cache-to: type=inline
           tags: |
             ${{ env.GH_IMAGE }}
             ${{ env.DH_IMAGE }}
@@ -179,7 +215,8 @@ jobs:
           file: .docker/${{ github.job }}/Dockerfile
           build-args: ROS_DISTRO=${{ matrix.ROS_DISTRO }}
           push: ${{ env.PUSH }}
-          no-cache: true
+          cache-from: type=registry,ref=${{ env.GH_IMAGE }}
+          cache-to: type=inline
           tags: |
             ${{ env.GH_IMAGE }}
             ${{ env.DH_IMAGE }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -121,61 +121,8 @@ jobs:
             ${{ env.GH_IMAGE }}
             ${{ env.DH_IMAGE }}
 
-  ci-testing:
-    strategy:
-      fail-fast: false
-      matrix:
-        ROS_DISTRO: [rolling]
-    runs-on: ubuntu-latest
-    permissions:
-      packages: write
-      contents: read
-    env:
-      GH_IMAGE: ghcr.io/ros-planning/moveit2:${{ matrix.ROS_DISTRO }}-${{ github.job }}
-      DH_IMAGE: moveit/moveit2:${{ matrix.ROS_DISTRO }}-${{ github.job }}
-      PUSH: ${{ (github.event_name != 'pull_request') && (github.repository == 'ros-planning/moveit2') }}
-
-    steps:
-      - uses: rhaschke/docker-run-action@v5
-        name: Check for apt updates
-        continue-on-error: true
-        id: apt
-        with:
-          image: ${{ env.IMAGE }}
-          run: |
-            apt-get update
-            have_updates=$(apt-get --simulate upgrade | grep -q "^0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.$" && echo false || echo true)
-            echo "no_cache=$have_updates" >> "$GITHUB_OUTPUT"
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Login to Github Container Registry
-        if: env.PUSH == 'true'
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Login to DockerHub
-        if: env.PUSH == 'true'
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build and Push
-        uses: docker/build-push-action@v5
-        with:
-          file: .docker/${{ github.job }}/Dockerfile
-          build-args: OUR_ROS_DISTRO=${{ matrix.ROS_DISTRO }}
-          push: ${{ env.PUSH }}
-          no-cache: ${{ steps.apt.outputs.no_cache || github.event_name == 'workflow_dispatch' }}
-          cache-from: type=registry,ref=${{ env.GH_IMAGE }}
-          cache-to: type=inline
-          tags: |
-            ${{ env.GH_IMAGE }}
-            ${{ env.DH_IMAGE }}
-
   source:
-    needs: ci-testing
+    needs: ci
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -119,7 +119,9 @@ jobs:
           cache-to: type=inline
           tags: |
             ${{ env.GH_IMAGE }}
+            ${{ env.GH_IMAGE }}-testing
             ${{ env.DH_IMAGE }}
+            ${{ env.DH_IMAGE }}-testing
 
   source:
     needs: ci

--- a/moveit2_rolling.repos
+++ b/moveit2_rolling.repos
@@ -1,0 +1,9 @@
+repositories:
+  octomap:
+      type: git
+      url: https://github.com/octomap/octomap.git
+      version: devel
+  geometric_shapes:
+      type: git
+      url: https://github.com/ros-planning/geometric_shapes.git
+      version: ros2

--- a/moveit_ros/benchmarks/src/BenchmarkExecutor.cpp
+++ b/moveit_ros/benchmarks/src/BenchmarkExecutor.cpp
@@ -43,13 +43,21 @@
 #include <tf2_eigen/tf2_eigen.hpp>
 #include <moveit/utils/logger.hpp>
 
-// TODO(henningkayser): Switch to boost/timer/progress_display.hpp with Boost 1.72
-// boost/progress.hpp is deprecated and will be replaced by boost/timer/progress_display.hpp in Boost 1.72.
-// Until then we need to suppress the deprecation warning.
-#define BOOST_ALLOW_DEPRECATED_HEADERS
 #include <boost/regex.hpp>
+
+#if __has_include(<boost/timer/progress_display.hpp>)
+#include <boost/timer/progress_display.hpp>
+using boost_progress_display = boost::timer::progress_display;
+#else
+// boost < 1.72
+#define BOOST_TIMER_ENABLE_DEPRECATED 1
 #include <boost/progress.hpp>
-#undef BOOST_ALLOW_DEPRECATED_HEADERS
+#undef BOOST_TIMER_ENABLE_DEPRECATED
+using boost_progress_display = boost::progress_display;
+#endif
+
+#include <boost/math/constants/constants.hpp>
+#include <boost/filesystem.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <math.h>
 #include <limits>
@@ -776,7 +784,7 @@ void BenchmarkExecutor::runBenchmark(moveit_msgs::msg::MotionPlanRequest request
   }
   num_planners += options.parallel_planning_pipelines.size();
 
-  boost::progress_display progress(num_planners * options.runs, std::cout);
+  boost_progress_display progress(num_planners * options.runs, std::cout);
 
   // Iterate through all planning pipelines
   auto planning_pipelines = moveit_cpp_->getPlanningPipelines();


### PR DESCRIPTION
CI builds for rolling are broken since a month or so. This PR fixes the docker images as well as some deprecated code.
I am surprised that nobody from the MoveIt2 maintainer team attempted to fix those issues yet.
Essentially, it was just about adding packages to moveit2.repos, which are not yet binary-released.

The `ci-testing` docker file, building upon `osrf/ros2:testing` is broken upstream. I skipped building this image for now as I don't know the intention of using `osrf/ros2:testing`.