### PR TITLE
Change `default_request_adapter_parameters.default_workspace_bounds` value

### DIFF
--- a/moveit_ros/planning/planning_request_adapter_plugins/res/default_request_adapter_params.yaml
+++ b/moveit_ros/planning/planning_request_adapter_plugins/res/default_request_adapter_params.yaml
@@ -8,5 +8,5 @@ default_request_adapter_parameters:
   default_workspace_bounds: {
     type: double,
     description: "ValidateWorkspaceBounds: Default workspace bounds representing a cube around the robot's origin whose edge length this parameter defines.",
-    default_value: 10.0,
+    default_value: 1000000000000.0, # TODO ideally, this should be inf or 1e308, but this notation is not working in version 0.3.8
   }


### PR DESCRIPTION
Currently, the `default_workspace_bounds`  is arbitrarily set to 10. This value can lead to confusion, especially when using a mobile robot. I think setting it to a large number may be a more appropriate default, e.g. no workspace bound exists unless explicitly specified. 
