### PR TITLE
Add `merge_group` event type to all PR CI jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,7 @@ name: CI
 on:
   workflow_dispatch:
   pull_request:
+  merge_group:
   push:
     branches:
       - main

--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -6,6 +6,7 @@ name: Formatting (pre-commit)
 on:
   workflow_dispatch:
   pull_request:
+  merge_group:
   push:
     branches:
       - main

--- a/.github/workflows/tutorial_docker.yaml
+++ b/.github/workflows/tutorial_docker.yaml
@@ -6,6 +6,7 @@ on:
     - cron:  '0 17 * * 6'
   workflow_dispatch:
   pull_request:
+  merge_group:
   push:
     branches:
       - main


### PR DESCRIPTION
### Description

This should allow us to begin adopting GitHub Merge Queues so that maintainers can hit "merge when ready" on every approved PR and CI will sort itself out to get all those things merged.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
