### PR TITLE
Add dependency on moveit_configs_utils to moveit_setup_assistant

### DIFF
--- a/moveit_setup_assistant/moveit_setup_assistant/package.xml
+++ b/moveit_setup_assistant/moveit_setup_assistant/package.xml
@@ -27,7 +27,7 @@
   <depend>rclcpp</depend>
   <depend>moveit_setup_framework</depend>
   <depend>moveit_setup_srdf_plugins</depend> <!-- For collision_updater executable -->
-  <exec_depend>moveit_configs_utils</<exec_depend>
+  <exec_depend>moveit_configs_utils</exec_depend>
   <exec_depend>moveit_setup_controllers</exec_depend>
   <exec_depend>moveit_setup_core_plugins</exec_depend>
   <exec_depend>moveit_setup_app_plugins</exec_depend>

--- a/moveit_setup_assistant/moveit_setup_assistant/package.xml
+++ b/moveit_setup_assistant/moveit_setup_assistant/package.xml
@@ -27,6 +27,7 @@
   <depend>rclcpp</depend>
   <depend>moveit_setup_framework</depend>
   <depend>moveit_setup_srdf_plugins</depend> <!-- For collision_updater executable -->
+  <exec_depend>moveit_configs_utils</<exec_depend>
   <exec_depend>moveit_setup_controllers</exec_depend>
   <exec_depend>moveit_setup_core_plugins</exec_depend>
   <exec_depend>moveit_setup_app_plugins</exec_depend>


### PR DESCRIPTION
### Description

moveit_setup_assistant [attempts to import moveit_configs_utils in its launch file](https://github.com/moveit/moveit2/blob/2.9.0/moveit_setup_assistant/moveit_setup_assistant/launch/setup_assistant.launch.py#L2), but does not declare it in its `package.xml`.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
