### PR TITLE
Fix segmentation fault in mesh_filter/gl_renderer

### DIFF
--- a/moveit_ros/perception/mesh_filter/src/gl_renderer.cpp
+++ b/moveit_ros/perception/mesh_filter/src/gl_renderer.cpp
@@ -387,7 +387,8 @@ void mesh_filter::GLRenderer::createGLContext()
 
   if (context_it == s_context.end())
   {
-    s_context[thread_id] = std::pair<unsigned, GLuint>(1, 0);
+
+    s_context.insert({thread_id, std::pair<unsigned, GLuint>(1, 0)});
 
     glutInitWindowPosition(glutGet(GLUT_SCREEN_WIDTH) + 30000, 0);
     glutInitWindowSize(1, 1);

--- a/moveit_ros/perception/mesh_filter/src/gl_renderer.cpp
+++ b/moveit_ros/perception/mesh_filter/src/gl_renderer.cpp
@@ -387,8 +387,7 @@ void mesh_filter::GLRenderer::createGLContext()
 
   if (context_it == s_context.end())
   {
-
-    s_context.insert({thread_id, std::pair<unsigned, GLuint>(1, 0)});
+    s_context.insert({ thread_id, std::pair<unsigned, GLuint>(1, 0) });
 
     glutInitWindowPosition(glutGet(GLUT_SCREEN_WIDTH) + 30000, 0);
     glutInitWindowSize(1, 1);

--- a/moveit_ros/perception/mesh_filter/src/gl_renderer.cpp
+++ b/moveit_ros/perception/mesh_filter/src/gl_renderer.cpp
@@ -387,7 +387,7 @@ void mesh_filter::GLRenderer::createGLContext()
 
   if (context_it == s_context.end())
   {
-    s_context.at(thread_id) = std::pair<unsigned, GLuint>(1, 0);
+    s_context[thread_id] = std::pair<unsigned, GLuint>(1, 0);
 
     glutInitWindowPosition(glutGet(GLUT_SCREEN_WIDTH) + 30000, 0);
     glutInitWindowSize(1, 1);


### PR DESCRIPTION

### Description

The misusage of std::map is fixed.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
