### PR TITLE
Rename ros-planning org

### DIFF
--- a/.docker/ci-testing/Dockerfile
+++ b/.docker/ci-testing/Dockerfile
@@ -1,4 +1,4 @@
-# ghcr.io/ros-planning/moveit2:${OUR_ROS_DISTRO}-ci-testing
+# ghcr.io/moveit/moveit2:${OUR_ROS_DISTRO}-ci-testing
 # CI image using the ROS testing repository
 
 FROM osrf/ros2:testing

--- a/.docker/ci/Dockerfile
+++ b/.docker/ci/Dockerfile
@@ -1,4 +1,4 @@
-# ghcr.io/ros-planning/moveit2:${ROS_DISTRO}-ci
+# ghcr.io/moveit/moveit2:${ROS_DISTRO}-ci
 # ROS base image augmented with all MoveIt dependencies to use for CI
 
 ARG ROS_DISTRO=rolling

--- a/.docker/release/Dockerfile
+++ b/.docker/release/Dockerfile
@@ -1,4 +1,4 @@
-# ghcr.io/ros-planning/moveit2:${ROS_DISTRO}-release
+# ghcr.io/moveit/moveit2:${ROS_DISTRO}-release
 # Full debian-based install of MoveIt using apt-get
 
 ARG ROS_DISTRO=rolling

--- a/.docker/source/Dockerfile
+++ b/.docker/source/Dockerfile
@@ -1,6 +1,6 @@
 # syntax = docker/dockerfile:1.3
 
-# ghcr.io/ros-planning/moveit2:${ROS_DISTRO}-source
+# ghcr.io/moveit/moveit2:${ROS_DISTRO}-source
 # Downloads the moveit source code and install remaining debian dependencies
 
 ARG ROS_DISTRO=rolling

--- a/.docker/tutorial-source/Dockerfile
+++ b/.docker/tutorial-source/Dockerfile
@@ -1,6 +1,6 @@
 # syntax = docker/dockerfile:1.3
 
-# ghcr.io/ros-planning/moveit2:main-${ROS_DISTRO}-tutorial-source
+# ghcr.io/moveit/moveit2:main-${ROS_DISTRO}-tutorial-source
 # Source build of the repos file from the tutorail site
 
 ARG ROS_DISTRO=rolling

--- a/.docker/tutorial-source/Dockerfile
+++ b/.docker/tutorial-source/Dockerfile
@@ -20,7 +20,7 @@ RUN --mount=type=cache,target=/root/.ccache/,sharing=locked \
         # Enable ccache
         PATH=/usr/lib/ccache:$PATH && \
         # Checkout the tutorial repo
-        git clone https://github.com/ros-planning/moveit2_tutorials src/moveit2_tutorials && \
+        git clone https://github.com/moveit/moveit2_tutorials src/moveit2_tutorials && \
         # Fetch required upstream sources for building
         vcs import --skip-existing src < src/moveit2_tutorials/moveit2_tutorials.repos && \
         # Source ROS install

--- a/.github/ISSUE_TEMPLATE/first_timers_only.md
+++ b/.github/ISSUE_TEMPLATE/first_timers_only.md
@@ -18,7 +18,7 @@ We're interested in helping you take the first step, and can answer questions an
 
 We know that creating a pull request is the biggest barrier for new contributors. This issue is for you 💝
 
-If you have contributed before, **consider leaving this PR for someone new**, and looking through our general [bug](https://github.com/ros-planning/moveit2/labels/bug) issues. Thanks!
+If you have contributed before, **consider leaving this PR for someone new**, and looking through our general [bug](https://github.com/moveit/moveit2/labels/bug) issues. Thanks!
 
 ### 🤔 What you will need to know.
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,9 +5,9 @@ Please explain the changes you made, including a reference to the related issue 
 ### Checklist
 - [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
 - [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
-- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit2/blob/main/MIGRATION.md) notes
+- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
 - [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
 - [ ] Include a screenshot if changing a GUI
-- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers
+- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers
 
 [//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -84,7 +84,7 @@ jobs:
           df -h
       - uses: actions/checkout@v4
       - uses: testspace-com/setup-testspace@v1
-        if: github.repository == 'ros-planning/moveit2'
+        if: github.repository == 'moveit/moveit2'
         with:
           domain: ros-planning
       - name: Get latest release date for rosdistro
@@ -141,7 +141,7 @@ jobs:
         uses: ros-industrial/industrial_ci@master
         env: ${{ matrix.env }}
       - name: Push result to Testspace
-        if: always() && (github.repository == 'ros-planning/moveit2')
+        if: always() && (github.repository == 'moveit/moveit2')
         run: |
           testspace "[ ${{ matrix.env.IMAGE }} ]${{ env.BASEDIR }}/target_ws/**/test_results/**/*.xml"
       - name: Upload test artifacts (on failure)

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -25,9 +25,9 @@ jobs:
       packages: write
       contents: read
     env:
-      GH_IMAGE: ghcr.io/ros-planning/moveit2:${{ matrix.ROS_DISTRO }}-${{ github.job }}
+      GH_IMAGE: ghcr.io/moveit/moveit2:${{ matrix.ROS_DISTRO }}-${{ github.job }}
       DH_IMAGE: moveit/moveit2:${{ matrix.ROS_DISTRO }}-${{ github.job }}
-      PUSH: ${{ (github.event_name != 'pull_request') && (github.repository == 'ros-planning/moveit2') }}
+      PUSH: ${{ (github.event_name != 'pull_request') && (github.repository == 'moveit/moveit2') }}
 
     steps:
       - uses: rhaschke/docker-run-action@v5
@@ -78,9 +78,9 @@ jobs:
       packages: write
       contents: read
     env:
-      GH_IMAGE: ghcr.io/ros-planning/moveit2:${{ matrix.ROS_DISTRO }}-${{ github.job }}
+      GH_IMAGE: ghcr.io/moveit/moveit2:${{ matrix.ROS_DISTRO }}-${{ github.job }}
       DH_IMAGE: moveit/moveit2:${{ matrix.ROS_DISTRO }}-${{ github.job }}
-      PUSH: ${{ (github.event_name != 'pull_request') && (github.repository == 'ros-planning/moveit2') }}
+      PUSH: ${{ (github.event_name != 'pull_request') && (github.repository == 'moveit/moveit2') }}
 
     steps:
       - uses: rhaschke/docker-run-action@v5
@@ -134,9 +134,9 @@ jobs:
       packages: write
       contents: read
     env:
-      GH_IMAGE: ghcr.io/ros-planning/moveit2:${{ matrix.ROS_DISTRO }}-${{ github.job }}
+      GH_IMAGE: ghcr.io/moveit/moveit2:${{ matrix.ROS_DISTRO }}-${{ github.job }}
       DH_IMAGE: moveit/moveit2:${{ matrix.ROS_DISTRO }}-${{ github.job }}
-      PUSH: ${{ (github.event_name != 'pull_request') && (github.repository == 'ros-planning/moveit2') }}
+      PUSH: ${{ (github.event_name != 'pull_request') && (github.repository == 'moveit/moveit2') }}
 
     steps:
       - uses: actions/checkout@v4
@@ -177,7 +177,7 @@ jobs:
       - source
     steps:
       - name: Delete Untagged Images
-        if: (github.event_name != 'pull_request') && (github.repository == 'ros-planning/moveit2')
+        if: (github.event_name != 'pull_request') && (github.repository == 'moveit/moveit2')
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.DELETE_PACKAGES_TOKEN }}
@@ -193,6 +193,6 @@ jobs:
                 }
             }
         env:
-          OWNER: ros-planning
+          OWNER: moveit
           PACKAGE_NAME: moveit2
           PER_PAGE: 100

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -57,7 +57,7 @@ jobs:
           df -h
       - uses: actions/checkout@v4
       - uses: testspace-com/setup-testspace@v1
-        if: github.repository == 'ros-planning/moveit2'
+        if: github.repository == 'moveit/moveit2'
         with:
           domain: ros-planning
       - name: Get latest release date for rosdistro

--- a/.github/workflows/tutorial_docker.yaml
+++ b/.github/workflows/tutorial_docker.yaml
@@ -22,9 +22,9 @@ jobs:
       packages: write
       contents: read
     env:
-      GH_IMAGE: ghcr.io/ros-planning/moveit2:main-${{ matrix.ROS_DISTRO }}-${{ github.job }}
+      GH_IMAGE: ghcr.io/moveit/moveit2:main-${{ matrix.ROS_DISTRO }}-${{ github.job }}
       DH_IMAGE: moveit/moveit2:main-${{ matrix.ROS_DISTRO }}-${{ github.job }}
-      PUSH: ${{ (github.event_name != 'pull_request') && (github.repository == 'ros-planning/moveit2') }}
+      PUSH: ${{ (github.event_name != 'pull_request') && (github.repository == 'moveit/moveit2') }}
 
     steps:
       - uses: actions/checkout@v4
@@ -74,7 +74,7 @@ jobs:
       - tutorial-source
     steps:
       - name: Delete Untagged Images
-        if: (github.event_name != 'pull_request') && (github.repository == 'ros-planning/moveit2')
+        if: (github.event_name != 'pull_request') && (github.repository == 'moveit/moveit2')
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.DELETE_PACKAGES_TOKEN }}
@@ -90,6 +90,6 @@ jobs:
                 }
             }
         env:
-          OWNER: ros-planning
+          OWNER: moveit
           PACKAGE_NAME: moveit2
           PER_PAGE: 100

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 <img src="https://moveit.ros.org/assets/logo/moveit_logo-black.png" alt="MoveIt Logo" width="200"/>
 
-The [MoveIt Motion Planning Framework for ROS 2](http://moveit.ros.org). For the ROS 1 repository see [MoveIt 1](https://github.com/ros-planning/moveit). For the commercially supported version see [MoveIt Pro](http://picknik.ai/pro).
+The [MoveIt Motion Planning Framework for ROS 2](http://moveit.ros.org). For the ROS 1 repository see [MoveIt 1](https://github.com/moveit/moveit). For the commercially supported version see [MoveIt Pro](http://picknik.ai/pro).
 
 *Easy-to-use open source robotics manipulation platform for developing commercial applications, prototyping designs, and benchmarking algorithms.*
 
 ## Continuous Integration Status
 
-[![Formatting (pre-commit)](https://github.com/ros-planning/moveit2/actions/workflows/format.yaml/badge.svg?branch=main)](https://github.com/ros-planning/moveit2/actions/workflows/format.yaml?query=branch%3Amain)
-[![CI (Rolling and Humble)](https://github.com/ros-planning/moveit2/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/ros-planning/moveit2/actions/workflows/ci.yaml?query=branch%3Amain)
+[![Formatting (pre-commit)](https://github.com/moveit/moveit2/actions/workflows/format.yaml/badge.svg?branch=main)](https://github.com/moveit/moveit2/actions/workflows/format.yaml?query=branch%3Amain)
+[![CI (Rolling and Humble)](https://github.com/moveit/moveit2/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/moveit/moveit2/actions/workflows/ci.yaml?query=branch%3Amain)
 [![Code Coverage](https://codecov.io/gh/ros-planning/moveit2/branch/main/graph/badge.svg?token=W7uHKcY0ly)](https://codecov.io/gh/ros-planning/moveit2)
 
 ## Getting Started

--- a/moveit/package.xml
+++ b/moveit/package.xml
@@ -12,8 +12,8 @@
   <license>BSD-3-Clause</license>
 
   <url type="website">http://moveit.ros.org</url>
-  <url type="repository">https://github.com/ros-planning/moveit2</url>
-  <url type="bugtracker">https://github.com/ros-planning/moveit2/issues</url>
+  <url type="repository">https://github.com/moveit/moveit2</url>
+  <url type="bugtracker">https://github.com/moveit/moveit2/issues</url>
 
   <author email="isucan@google.com">Ioan Sucan</author>
   <author email="robot.moveit@gmail.com">Sachin Chitta</author>

--- a/moveit/scripts/create_maintainer_table.py
+++ b/moveit/scripts/create_maintainer_table.py
@@ -161,7 +161,7 @@ def get_first_folder(path):
 
 def populate_package_data(path, package):
     output = (
-        "<td><a href='https://github.com/ros-planning/"
+        "<td><a href='https://github.com/moveit/"
         + get_first_folder(path)
         + "'>"
         + package.name

--- a/moveit2_rolling.repos
+++ b/moveit2_rolling.repos
@@ -5,5 +5,5 @@ repositories:
       version: devel
   geometric_shapes:
       type: git
-      url: https://github.com/ros-planning/geometric_shapes.git
+      url: https://github.com/moveit/geometric_shapes.git
       version: ros2

--- a/moveit_common/package.xml
+++ b/moveit_common/package.xml
@@ -11,8 +11,8 @@
   <license>BSD-3-Clause</license>
 
   <url type="website">http://moveit.ros.org</url>
-  <url type="bugtracker">https://github.com/ros-planning/moveit2/issues</url>
-  <url type="repository">https://github.com/ros-planning/moveit2</url>
+  <url type="bugtracker">https://github.com/moveit/moveit2/issues</url>
+  <url type="repository">https://github.com/moveit/moveit2</url>
 
   <author email="lior.lustgarten@microsoft.com">Lior Lustgarten</author>
 

--- a/moveit_configs_utils/moveit_configs_utils/moveit_configs_builder.py
+++ b/moveit_configs_utils/moveit_configs_utils/moveit_configs_builder.py
@@ -414,7 +414,7 @@ class MoveItConfigsBuilder(ParameterBuilder):
         if sensors_path.exists():
             sensors_data = load_yaml(sensors_path)
             # TODO(mikeferguson): remove the second part of this check once
-            # https://github.com/ros-planning/moveit_resources/pull/141 has made through buildfarm
+            # https://github.com/moveit/moveit_resources/pull/141 has made through buildfarm
             if len(sensors_data["sensors"]) > 0 and sensors_data["sensors"][0]:
                 self.__moveit_configs.sensors_3d = sensors_data
         return self

--- a/moveit_core/package.xml
+++ b/moveit_core/package.xml
@@ -13,8 +13,8 @@
   <license>BSD-3-Clause</license>
 
   <url type="website">http://moveit.ros.org</url>
-  <url type="bugtracker">https://github.com/ros-planning/moveit2/issues</url>
-  <url type="repository">https://github.com/ros-planning/moveit2</url>
+  <url type="bugtracker">https://github.com/moveit/moveit2/issues</url>
+  <url type="repository">https://github.com/moveit/moveit2</url>
 
   <author email="isucan@google.com">Ioan Sucan</author>
   <author email="robot.moveit@gmail.com">Sachin Chitta</author>

--- a/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
+++ b/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
@@ -586,7 +586,7 @@ bool Trajectory::integrateForward(std::list<TrajectoryStep>& trajectory, double 
     if (next_discontinuity != switching_points.end() && path_pos > next_discontinuity->first)
     {
       // Avoid having a TrajectoryStep with path_pos near a switching point which will cause an almost identical
-      // TrajectoryStep get added in the next run (https://github.com/ros-planning/moveit/issues/1665)
+      // TrajectoryStep get added in the next run (https://github.com/moveit/moveit/issues/1665)
       if (path_pos - next_discontinuity->first < EPS)
       {
         continue;

--- a/moveit_kinematics/ikfast_kinematics_plugin/README.md
+++ b/moveit_kinematics/ikfast_kinematics_plugin/README.md
@@ -7,4 +7,4 @@ Generates a IKFast kinematics plugin for MoveIt using [OpenRave](http://openrave
 
 Tested on ROS Hydro and greater with Catkin using OpenRave 0.8 with a 6dof and 7dof robot arm manipulator. Does not work with greater than 7dof.
 
-[Documentation on docs.ros.org](https://ros-planning.github.io/moveit_tutorials/doc/ikfast/ikfast_tutorial.html#creating-the-ikfast-moveit-plugin)
+[Documentation on docs.ros.org](https://moveit.github.io/moveit_tutorials/doc/ikfast/ikfast_tutorial.html#creating-the-ikfast-moveit-plugin)

--- a/moveit_kinematics/package.xml
+++ b/moveit_kinematics/package.xml
@@ -14,8 +14,8 @@
   <license>BSD-3-Clause</license>
 
   <url type="website">http://moveit.ros.org</url>
-  <url type="repository">https://github.com/ros-planning/moveit2</url>
-  <url type="bugtracker">https://github.com/ros-planning/moveit2/issues</url>
+  <url type="repository">https://github.com/moveit/moveit2</url>
+  <url type="bugtracker">https://github.com/moveit/moveit2/issues</url>
 
   <author email="dave@picknik.ai">Dave Coleman</author>
   <author email="isucan@google.com">Ioan Sucan</author>

--- a/moveit_kinematics/test/test_ikfast_plugins.sh
+++ b/moveit_kinematics/test/test_ikfast_plugins.sh
@@ -11,7 +11,7 @@ sudo apt-get -qq update
 sudo apt-get -qq install python3-lxml python3-yaml
 
 # Clone moveit_resources for URDFs. They are not available before running docker.
-git clone -q --depth=1 -b ros2 https://github.com/ros-planning/moveit_resources /tmp/resources
+git clone -q --depth=1 -b ros2 https://github.com/moveit/moveit_resources /tmp/resources
 fanuc=/tmp/resources/fanuc_description/urdf/fanuc.urdf
 panda=/tmp/resources/panda_description/urdf/panda.urdf
 

--- a/moveit_planners/chomp/README.md
+++ b/moveit_planners/chomp/README.md
@@ -1,3 +1,3 @@
 ## CHOMP Motion Planner
 
-See [Chomp Interface Tutorial](https://ros-planning.github.io/moveit_tutorials/doc/chomp_planner/chomp_planner_tutorial.html)
+See [Chomp Interface Tutorial](https://moveit.github.io/moveit_tutorials/doc/chomp_planner/chomp_planner_tutorial.html)

--- a/moveit_planners/moveit_planners/package.xml
+++ b/moveit_planners/moveit_planners/package.xml
@@ -11,8 +11,8 @@
   <license>BSD-3-Clause</license>
 
   <url type="website">http://moveit.ros.org</url>
-  <url type="bugtracker">https://github.com/ros-planning/moveit2/issues</url>
-  <url type="repository">https://github.com/ros-planning/moveit2</url>
+  <url type="bugtracker">https://github.com/moveit/moveit2/issues</url>
+  <url type="repository">https://github.com/moveit/moveit2</url>
 
   <author email="isucan@google.com">Ioan Sucan</author>
   <author email="sachinc@willowgarage.com">Sachin Chitta</author>

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/state_validity_checker.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/state_validity_checker.h
@@ -115,7 +115,7 @@ protected:
  *
  * We still check the path constraints, because not all states sampled by the constrained state space
  * satisfy the constraints unfortunately. This is a complicated issue. For more details see:
- * https://github.com/ros-planning/moveit/issues/2092#issuecomment-669911722.
+ * https://github.com/moveit/moveit/issues/2092#issuecomment-669911722.
  **/
 class ConstrainedPlanningStateValidityChecker : public StateValidityChecker
 {

--- a/moveit_planners/ompl/ompl_interface/test/test_ompl_constraints.cpp
+++ b/moveit_planners/ompl/ompl_interface/test/test_ompl_constraints.cpp
@@ -252,7 +252,7 @@ protected:
     // But these issues do not prevent us to use the ConstrainedPlanningStateSpace! :)
     // The jacobian test is expected to fail because of the discontinuous constraint derivative.
     // In addition not all samples returned from the state sampler will be valid.
-    // For more details: https://github.com/ros-planning/moveit/issues/2092#issuecomment-669911722
+    // For more details: https://github.com/moveit/moveit/issues/2092#issuecomment-669911722
     try
     {
       constrained_state_space->sanityChecks();

--- a/moveit_planners/ompl/ompl_interface/test/test_planning_context_manager.cpp
+++ b/moveit_planners/ompl/ompl_interface/test/test_planning_context_manager.cpp
@@ -46,7 +46,7 @@
  * TODO(jeroendm) I also tried something similar with position constraints, but get a segmentation fault
  * that occurs in the 'geometric_shapes' package, in the method 'useDimensions' in 'bodies.h'.
  * git permalink:
- * https://github.com/ros-planning/geometric_shapes/blob/df0478870b8592ce789ee1919f3124058c4327d7/include/geometric_shapes/bodies.h#L196
+ * https://github.com/moveit/geometric_shapes/blob/df0478870b8592ce789ee1919f3124058c4327d7/include/geometric_shapes/bodies.h#L196
  *
  **/
 

--- a/moveit_planners/ompl/package.xml
+++ b/moveit_planners/ompl/package.xml
@@ -11,8 +11,8 @@
   <license>BSD-3-Clause</license>
 
   <url type="website">http://moveit.ros.org</url>
-  <url type="bugtracker">https://github.com/ros-planning/moveit2/issues</url>
-  <url type="repository">https://github.com/ros-planning/moveit2</url>
+  <url type="bugtracker">https://github.com/moveit/moveit2/issues</url>
+  <url type="repository">https://github.com/moveit/moveit2</url>
 
   <author email="isucan@google.com">Ioan Sucan</author>
 

--- a/moveit_planners/pilz_industrial_motion_planner/package.xml
+++ b/moveit_planners/pilz_industrial_motion_planner/package.xml
@@ -11,8 +11,8 @@
   <license>BSD-3-Clause</license>
 
   <url type="website">http://moveit.ros.org</url>
-  <url type="bugtracker">https://github.com/ros-planning/moveit2/issues</url>
-  <url type="repository">https://github.com/ros-planning/moveit2</url>
+  <url type="bugtracker">https://github.com/moveit/moveit2/issues</url>
+  <url type="repository">https://github.com/moveit/moveit2</url>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>

--- a/moveit_planners/pilz_industrial_motion_planner_testutils/package.xml
+++ b/moveit_planners/pilz_industrial_motion_planner_testutils/package.xml
@@ -11,8 +11,8 @@
   <license>BSD-3-Clause</license>
 
   <url type="website">http://moveit.ros.org</url>
-  <url type="bugtracker">https://github.com/ros-planning/moveit2/issues</url>
-  <url type="repository">https://github.com/ros-planning/moveit2</url>
+  <url type="bugtracker">https://github.com/moveit/moveit2/issues</url>
+  <url type="repository">https://github.com/moveit/moveit2</url>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>

--- a/moveit_planners/stomp/package.xml
+++ b/moveit_planners/stomp/package.xml
@@ -7,8 +7,8 @@
   <maintainer email="henningkayser@picknik.ai">Henning Kayser</maintainer>
   <license>BSD-3-Clause</license>
 
-  <url type="bugtracker">https://github.com/ros-planning/moveit2/issues</url>
-  <url type="repository">https://github.com/ros-planning/moveit2</url>
+  <url type="bugtracker">https://github.com/moveit/moveit2/issues</url>
+  <url type="repository">https://github.com/moveit/moveit2</url>
 
   <author email="henningkayser@picknik.ai">Henning Kayser</author>
 

--- a/moveit_planners/test_configs/prbt_ikfast_manipulator_plugin/package.xml
+++ b/moveit_planners/test_configs/prbt_ikfast_manipulator_plugin/package.xml
@@ -10,8 +10,8 @@
   <license>Apache 2.0</license>
   <buildtool_depend>ament_cmake</buildtool_depend>
   <url type="website">http://moveit.ros.org</url>
-  <url type="bugtracker">https://github.com/ros-planning/moveit-resources/issues</url>
-  <url type="repository">https://github.com/ros-planning/moveit-resources</url>
+  <url type="bugtracker">https://github.com/moveit/moveit-resources/issues</url>
+  <url type="repository">https://github.com/moveit/moveit-resources</url>
 
   <depend>tf2_geometry_msgs</depend>
 

--- a/moveit_planners/test_configs/prbt_moveit_config/package.xml
+++ b/moveit_planners/test_configs/prbt_moveit_config/package.xml
@@ -17,8 +17,8 @@
   <license>BSD-3-Clause</license>
 
   <url type="website">http://moveit.ros.org</url>
-  <url type="bugtracker">https://github.com/ros-planning/moveit-resources/issues</url>
-  <url type="repository">https://github.com/ros-planning/moveit-resources</url>
+  <url type="bugtracker">https://github.com/moveit/moveit-resources/issues</url>
+  <url type="repository">https://github.com/moveit/moveit-resources</url>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/moveit_planners/test_configs/prbt_pg70_support/package.xml
+++ b/moveit_planners/test_configs/prbt_pg70_support/package.xml
@@ -11,8 +11,8 @@
   <license>Apache 2.0</license>
 
   <url type="website">http://moveit.ros.org</url>
-  <url type="bugtracker">https://github.com/ros-planning/moveit-resources/issues</url>
-  <url type="repository">https://github.com/ros-planning/moveit-resources</url>
+  <url type="bugtracker">https://github.com/moveit/moveit-resources/issues</url>
+  <url type="repository">https://github.com/moveit/moveit-resources</url>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/moveit_planners/test_configs/prbt_support/package.xml
+++ b/moveit_planners/test_configs/prbt_support/package.xml
@@ -12,8 +12,8 @@
   <license>Apache 2.0</license>
 
   <url type="website">http://moveit.ros.org</url>
-  <url type="bugtracker">https://github.com/ros-planning/moveit-resources/issues</url>
-  <url type="repository">https://github.com/ros-planning/moveit-resources</url>
+  <url type="bugtracker">https://github.com/moveit/moveit-resources/issues</url>
+  <url type="repository">https://github.com/moveit/moveit-resources</url>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/moveit_plugins/moveit_simple_controller_manager/package.xml
+++ b/moveit_plugins/moveit_simple_controller_manager/package.xml
@@ -12,8 +12,8 @@
   <license>BSD-3-Clause</license>
 
   <url type="website">http://moveit.ros.org</url>
-  <url type="bugtracker">https://github.com/ros-planning/moveit2/issues</url>
-  <url type="repository">https://github.com/ros-planning/moveit2</url>
+  <url type="bugtracker">https://github.com/moveit/moveit2/issues</url>
+  <url type="repository">https://github.com/moveit/moveit2</url>
 
   <author email="mferguson@fetchrobotics.com">Michael Ferguson</author>
 

--- a/moveit_py/CITATION.cff
+++ b/moveit_py/CITATION.cff
@@ -5,4 +5,4 @@ authors:
 date-released: 2023-03-20
 message: "If you use this software, please cite it as below."
 title: "MoveIt 2 Python Library: A Software Library for Robotics Education and Research"
-url: "https://github.com/ros-planning/moveit2/tree/main/moveit_py"
+url: "https://github.com/moveit/moveit2/tree/main/moveit_py"

--- a/moveit_py/README.md
+++ b/moveit_py/README.md
@@ -26,7 +26,7 @@ If you use this library in your work please use the following citation:
 @software{fagan2023moveitpy,
   author = {Fagan, Peter David},
   title = {{MoveIt 2 Python Library: A Software Library for Robotics Education and Research}},
-  url = {https://github.com/ros-planning/moveit2/tree/main/moveit_py},
+  url = {https://github.com/moveit/moveit2/tree/main/moveit_py},
   year = {2023}
 }
 ```

--- a/moveit_py/src/moveit/moveit_ros/trajectory_execution_manager/trajectory_execution_manager.cpp
+++ b/moveit_py/src/moveit/moveit_ros/trajectory_execution_manager/trajectory_execution_manager.cpp
@@ -153,7 +153,7 @@ void initTrajectoryExecutionManager(py::module& m)
            )")
 
       // ToDo(MatthijsBurgh)
-      // See https://github.com/ros-planning/moveit2/issues/2442
+      // See https://github.com/moveit/moveit2/issues/2442
       // get_trajectories
       .def("execute",
            py::overload_cast<const trajectory_execution_manager::TrajectoryExecutionManager::ExecutionCompleteCallback&,
@@ -187,7 +187,7 @@ void initTrajectoryExecutionManager(py::module& m)
            Wait for the current trajectory to finish execution.
            )")
       // ToDo(MatthijsBurgh)
-      // See https://github.com/ros-planning/moveit2/issues/2442
+      // See https://github.com/moveit/moveit2/issues/2442
       // get_current_expected_trajectory_index
       .def("get_last_execution_status",
            &trajectory_execution_manager::TrajectoryExecutionManager::getLastExecutionStatus,
@@ -283,7 +283,7 @@ void initTrajectoryExecutionManager(py::module& m)
            )");
 
   // ToDo(MatthijsBurgh)
-  // https://github.com/ros-planning/moveit2/issues/2442
+  // https://github.com/moveit/moveit2/issues/2442
   // get_controller_manager_node
 }
 }  // namespace bind_trajectory_execution_manager

--- a/moveit_ros/benchmarks/README.md
+++ b/moveit_ros/benchmarks/README.md
@@ -2,4 +2,4 @@
 
 This package provides methods to benchmark motion planning algorithms and aggregate/plot statistics. Results can be viewed in [Planner Arena](http://plannerarena.org/).
 
-For more information and usage example please see [moveit tutorials](https://ros-planning.github.io/moveit_tutorials/doc/benchmarking/benchmarking_tutorial.html).
+For more information and usage example please see [moveit tutorials](https://moveit.github.io/moveit_tutorials/doc/benchmarking/benchmarking_tutorial.html).

--- a/moveit_ros/benchmarks/package.xml
+++ b/moveit_ros/benchmarks/package.xml
@@ -11,8 +11,8 @@
   <license>BSD-3-Clause</license>
 
   <url type="website">http://moveit.ros.org</url>
-  <url type="bugtracker">https://github.com/ros-planning/moveit2/issues</url>
-  <url type="repository">https://github.com/ros-planning/moveit2</url>
+  <url type="bugtracker">https://github.com/moveit/moveit2/issues</url>
+  <url type="repository">https://github.com/moveit/moveit2</url>
 
   <author email="rluna@rice.edu">Ryan Luna</author>
 

--- a/moveit_ros/hybrid_planning/README.md
+++ b/moveit_ros/hybrid_planning/README.md
@@ -1,5 +1,5 @@
 # Hybrid Planning
-A Hybrid Planning architecture. You can find more information in the project's issues[#300](https://github.com/ros-planning/moveit2/issues/300), [#433](https://github.com/ros-planning/moveit2/issues/433) and on the [MoveIt 2 roadmap](https://moveit.ros.org/documentation/contributing/roadmap/). Furthermore, there is an extensive tutorial available [here](https://github.com/ros-planning/moveit2_tutorials/pull/97).
+A Hybrid Planning architecture. You can find more information in the project's issues[#300](https://github.com/moveit/moveit2/issues/300), [#433](https://github.com/moveit/moveit2/issues/433) and on the [MoveIt 2 roadmap](https://moveit.ros.org/documentation/contributing/roadmap/). Furthermore, there is an extensive tutorial available [here](https://github.com/moveit/moveit2_tutorials/pull/97).
 
 ## Getting started
 To start the demo run:

--- a/moveit_ros/hybrid_planning/local_planner/local_planner_component/src/local_planner_component.cpp
+++ b/moveit_ros/hybrid_planning/local_planner/local_planner_component/src/local_planner_component.cpp
@@ -318,7 +318,7 @@ void LocalPlannerComponent::executeIteration()
       }
 
       // Use a configurable message interface like MoveIt servo
-      // (See https://github.com/ros-planning/moveit2/blob/main/moveit_ros/moveit_servo/src/servo_calcs.cpp)
+      // (See https://github.com/moveit/moveit2/blob/main/moveit_ros/moveit_servo/src/servo_calcs.cpp)
       // Format outgoing msg in the right format
       // (trajectory_msgs/JointTrajectory or joint positions/velocities in form of std_msgs/Float64MultiArray).
       if (config_->local_solution_topic_type == "trajectory_msgs/JointTrajectory")

--- a/moveit_ros/hybrid_planning/package.xml
+++ b/moveit_ros/hybrid_planning/package.xml
@@ -9,8 +9,8 @@
   <license>BSD-3-Clause</license>
 
   <url type="website">http://moveit.ros.org</url>
-  <url type="bugtracker">https://github.com/ros-planning/moveit2/issues</url>
-  <url type="repository">https://github.com/ros-planning/moveit2</url>
+  <url type="bugtracker">https://github.com/moveit/moveit2/issues</url>
+  <url type="repository">https://github.com/moveit/moveit2</url>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <depend>moveit_common</depend>

--- a/moveit_ros/move_group/CMakeLists.txt
+++ b/moveit_ros/move_group/CMakeLists.txt
@@ -95,7 +95,7 @@ pluginlib_export_plugin_description_file(
 if(BUILD_TESTING)
   # TODO(henningkayser): enable rostests find_package(rostest REQUIRED) #
   # rostest under development in ROS2
-  # https://github.com/ros-planning/moveit2/issues/23 this test is flaky
+  # https://github.com/moveit/moveit2/issues/23 this test is flaky
   # add_rostest(test/test_cancel_before_plan_execution.test)
   # add_rostest(test/test_check_state_validity_in_empty_scene.test)
 endif()

--- a/moveit_ros/move_group/package.xml
+++ b/moveit_ros/move_group/package.xml
@@ -12,8 +12,8 @@
   <license>BSD-3-Clause</license>
 
   <url type="website">http://moveit.ros.org</url>
-  <url type="bugtracker">https://github.com/ros-planning/moveit2/issues</url>
-  <url type="repository">https://github.com/ros-planning/moveit2</url>
+  <url type="bugtracker">https://github.com/moveit/moveit2/issues</url>
+  <url type="repository">https://github.com/moveit/moveit2</url>
 
   <author email="isucan@google.com">Ioan Sucan</author>
   <author email="robot.moveit@gmail.com">Sachin Chitta</author>

--- a/moveit_ros/moveit_ros/package.xml
+++ b/moveit_ros/moveit_ros/package.xml
@@ -12,8 +12,8 @@
   <license>BSD-3-Clause</license>
 
   <url type="website">http://moveit.ros.org</url>
-  <url type="bugtracker">https://github.com/ros-planning/moveit2/issues</url>
-  <url type="repository">https://github.com/ros-planning/moveit2</url>
+  <url type="bugtracker">https://github.com/moveit/moveit2/issues</url>
+  <url type="repository">https://github.com/moveit/moveit2</url>
 
   <author email="isucan@google.com">Ioan Sucan</author>
   <author email="robot.moveit@gmail.com">Sachin Chitta</author>

--- a/moveit_ros/moveit_servo/config/panda_simulated_config.yaml
+++ b/moveit_ros/moveit_servo/config/panda_simulated_config.yaml
@@ -44,7 +44,7 @@ move_group_name:  panda_arm  # Often 'manipulator' or 'arm'
 lower_singularity_threshold:  17.0  # Start decelerating when the condition number hits this (close to singularity)
 hard_stop_singularity_threshold: 30.0  # Stop when the condition number hits this
 joint_limit_margins: [0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1]  # added as a buffer to joint limits [radians or meters]. If moving quickly, make this larger.
-leaving_singularity_threshold_multiplier: 2.0  # Multiply the hard stop limit by this when leaving singularity (see https://github.com/ros-planning/moveit2/pull/620)
+leaving_singularity_threshold_multiplier: 2.0  # Multiply the hard stop limit by this when leaving singularity (see https://github.com/moveit/moveit2/pull/620)
 
 ## Topic names
 cartesian_command_in_topic: ~/delta_twist_cmds  # Topic for incoming Cartesian twist commands

--- a/moveit_ros/moveit_servo/config/test_config_panda.yaml
+++ b/moveit_ros/moveit_servo/config/test_config_panda.yaml
@@ -43,7 +43,7 @@ move_group_name:  panda_arm  # Often 'manipulator' or 'arm'
 lower_singularity_threshold:  17.0  # Start decelerating when the condition number hits this (close to singularity)
 hard_stop_singularity_threshold: 30.0 # Stop when the condition number hits this
 joint_limit_margins: [0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1]  # added as a buffer to joint limits [radians or meters]. If moving quickly, make this larger.
-leaving_singularity_threshold_multiplier: 2.0 # Multiply the hard stop limit by this when leaving singularity (see https://github.com/ros-planning/moveit2/pull/620)
+leaving_singularity_threshold_multiplier: 2.0 # Multiply the hard stop limit by this when leaving singularity (see https://github.com/moveit/moveit2/pull/620)
 
 ## Topic names
 cartesian_command_in_topic: ~/delta_twist_cmds  # Topic for incoming Cartesian twist commands

--- a/moveit_ros/moveit_servo/package.xml
+++ b/moveit_ros/moveit_servo/package.xml
@@ -11,7 +11,7 @@
 
   <license>BSD-3-Clause</license>
 
-  <url type="website">https://ros-planning.github.io/moveit_tutorials</url>
+  <url type="website">https://moveit.github.io/moveit_tutorials</url>
 
   <author>Brian O'Neil</author>
   <author email="andyz@utexas.edu">Andy Zelenak</author>

--- a/moveit_ros/moveit_servo/src/collision_monitor.cpp
+++ b/moveit_ros/moveit_servo/src/collision_monitor.cpp
@@ -106,7 +106,7 @@ void CollisionMonitor::checkCollisions()
     if (servo_params_.check_collisions)
     {
       // Fetch latest robot state using planning scene instead of state monitor due to
-      // https://github.com/ros-planning/moveit2/issues/2748
+      // https://github.com/moveit/moveit2/issues/2748
       robot_state_ = planning_scene_monitor_->getPlanningScene()->getCurrentState();
       // This must be called before doing collision checking.
       robot_state_.updateCollisionBodyTransforms();

--- a/moveit_ros/moveit_servo/src/utils/common.cpp
+++ b/moveit_ros/moveit_servo/src/utils/common.cpp
@@ -343,7 +343,7 @@ std::pair<double, StatusCode> velocityScalingFactorForSingularity(const moveit::
   const bool moving_towards_singularity = vector_towards_singularity.dot(target_delta_x) > 0;
 
   // Compute upper condition variable threshold based on if we are moving towards or away from singularity.
-  // See https://github.com/ros-planning/moveit2/pull/620#issuecomment-1201418258 for visual explanation.
+  // See https://github.com/moveit/moveit2/pull/620#issuecomment-1201418258 for visual explanation.
   double upper_threshold;
   if (moving_towards_singularity)
   {

--- a/moveit_ros/occupancy_map_monitor/package.xml
+++ b/moveit_ros/occupancy_map_monitor/package.xml
@@ -11,8 +11,8 @@
   <license>BSD-3-Clause</license>
 
   <url type="website">http://moveit.ros.org</url>
-  <url type="bugtracker">https://github.com/ros-planning/moveit2/issues</url>
-  <url type="repository">https://github.com/ros-planning/moveit2</url>
+  <url type="bugtracker">https://github.com/moveit/moveit2/issues</url>
+  <url type="repository">https://github.com/moveit/moveit2</url>
 
   <author email="isucan@google.com">Ioan Sucan</author>
   <author email="jon.binney@gmail.com">Jon Binney</author>

--- a/moveit_ros/perception/package.xml
+++ b/moveit_ros/perception/package.xml
@@ -11,8 +11,8 @@
   <license>BSD-3-Clause</license>
 
   <url type="website">http://moveit.ros.org</url>
-  <url type="bugtracker">https://github.com/ros-planning/moveit2/issues</url>
-  <url type="repository">https://github.com/ros-planning/moveit2</url>
+  <url type="bugtracker">https://github.com/moveit/moveit2/issues</url>
+  <url type="repository">https://github.com/moveit/moveit2</url>
 
   <author email="isucan@google.com">Ioan Sucan</author>
   <author email="jon.binney@gmail.com">Jon Binney</author>

--- a/moveit_ros/planning/package.xml
+++ b/moveit_ros/planning/package.xml
@@ -12,8 +12,8 @@
   <license>BSD-3-Clause</license>
 
   <url type="website">http://moveit.ros.org</url>
-  <url type="bugtracker">https://github.com/ros-planning/moveit2/issues</url>
-  <url type="repository">https://github.com/ros-planning/moveit2</url>
+  <url type="bugtracker">https://github.com/moveit/moveit2/issues</url>
+  <url type="repository">https://github.com/moveit/moveit2</url>
 
   <author email="isucan@google.com">Ioan Sucan</author>
   <author email="robot.moveit@gmail.com">Sachin Chitta</author>

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -542,7 +542,7 @@ void PlanningSceneMonitor::getMonitoredTopics(std::vector<std::string>& topics) 
   if (collision_object_subscriber_)
   {
     // TODO (anasarrak) This has been changed to subscriber on Moveit, look at
-    // https://github.com/ros-planning/moveit/pull/1406/files/cb9488312c00e9c8949d89b363766f092330954d#diff-fb6e26ecc9a73d59dbdae3f3e08145e6
+    // https://github.com/moveit/moveit/pull/1406/files/cb9488312c00e9c8949d89b363766f092330954d#diff-fb6e26ecc9a73d59dbdae3f3e08145e6
     topics.push_back(collision_object_subscriber_->get_topic_name());
   }
   if (planning_scene_world_subscriber_)

--- a/moveit_ros/planning_interface/package.xml
+++ b/moveit_ros/planning_interface/package.xml
@@ -12,8 +12,8 @@
   <license>BSD-3-Clause</license>
 
   <url type="website">http://moveit.ros.org</url>
-  <url type="bugtracker">https://github.com/ros-planning/moveit2/issues</url>
-  <url type="repository">https://github.com/ros-planning/moveit2</url>
+  <url type="bugtracker">https://github.com/moveit/moveit2/issues</url>
+  <url type="repository">https://github.com/moveit/moveit2</url>
 
   <author email="isucan@google.com">Ioan Sucan</author>
 

--- a/moveit_ros/planning_interface/test/move_group_interface_cpp_test.cpp
+++ b/moveit_ros/planning_interface/test/move_group_interface_cpp_test.cpp
@@ -36,7 +36,7 @@
 /* Author: Tyler Weaver, Boston Cleek */
 
 /* These integration tests are based on the tutorials for using move_group:
- * https://ros-planning.github.io/moveit_tutorials/doc/move_group_interface/move_group_interface_tutorial.html
+ * https://moveit.github.io/moveit_tutorials/doc/move_group_interface/move_group_interface_tutorial.html
  */
 
 // C++

--- a/moveit_ros/planning_interface/test/move_group_pick_place_test.cpp
+++ b/moveit_ros/planning_interface/test/move_group_pick_place_test.cpp
@@ -36,7 +36,7 @@
 /* Author: Tyler Weaver */
 
 /* These integration tests are based on the tutorials for using move_group to do a pick and place:
- * https://ros-planning.github.io/moveit_tutorials/doc/pick_place/pick_place_tutorial.html
+ * https://moveit.github.io/moveit_tutorials/doc/pick_place/pick_place_tutorial.html
  */
 
 // C++

--- a/moveit_ros/planning_interface/test/subframes_test.cpp
+++ b/moveit_ros/planning_interface/test/subframes_test.cpp
@@ -36,7 +36,7 @@
 /* Author: Felix von Drigalski, Jacob Aas, Tyler Weaver, Boston Cleek */
 
 /* This integration test is based on the tutorial for using subframes
- * https://ros-planning.github.io/moveit_tutorials/doc/subframes/subframes_tutorial.html
+ * https://moveit.github.io/moveit_tutorials/doc/subframes/subframes_tutorial.html
  */
 
 // C++

--- a/moveit_ros/robot_interaction/package.xml
+++ b/moveit_ros/robot_interaction/package.xml
@@ -12,8 +12,8 @@
   <license>BSD-3-Clause</license>
 
   <url type="website">http://moveit.ros.org</url>
-  <url type="bugtracker">https://github.com/ros-planning/moveit2/issues</url>
-  <url type="repository">https://github.com/ros-planning/moveit2</url>
+  <url type="bugtracker">https://github.com/moveit/moveit2/issues</url>
+  <url type="repository">https://github.com/moveit/moveit2</url>
 
   <author email="isucan@google.com">Ioan Sucan</author>
 

--- a/moveit_ros/tests/package.xml
+++ b/moveit_ros/tests/package.xml
@@ -9,8 +9,8 @@
   <license>BSD-3-Clause</license>
 
   <url type="website">http://moveit.ros.org</url>
-  <url type="bugtracker">https://github.com/ros-planning/moveit2/issues</url>
-  <url type="repository">https://github.com/ros-planning/moveit2</url>
+  <url type="bugtracker">https://github.com/moveit/moveit2/issues</url>
+  <url type="repository">https://github.com/moveit/moveit2</url>
 
   <author email="sebastian.jahr@picknik.ai">Sebastian Jahr</author>
 

--- a/moveit_ros/visualization/package.xml
+++ b/moveit_ros/visualization/package.xml
@@ -12,8 +12,8 @@
   <license>BSD-3-Clause</license>
 
   <url type="website">http://moveit.ros.org</url>
-  <url type="bugtracker">https://github.com/ros-planning/moveit2/issues</url>
-  <url type="repository">https://github.com/ros-planning/moveit2</url>
+  <url type="bugtracker">https://github.com/moveit/moveit2/issues</url>
+  <url type="repository">https://github.com/moveit/moveit2</url>
 
   <author email="isucan@google.com">Ioan Sucan</author>
   <author email="dave@picknik.ai">Dave Coleman</author>

--- a/moveit_ros/warehouse/package.xml
+++ b/moveit_ros/warehouse/package.xml
@@ -11,8 +11,8 @@
   <license>BSD-3-Clause</license>
 
   <url type="website">http://moveit.ros.org</url>
-  <url type="bugtracker">https://github.com/ros-planning/moveit2/issues</url>
-  <url type="repository">https://github.com/ros-planning/moveit2</url>
+  <url type="bugtracker">https://github.com/moveit/moveit2/issues</url>
+  <url type="repository">https://github.com/moveit/moveit2</url>
 
   <author email="isucan@google.com">Ioan Sucan</author>
 

--- a/moveit_setup_assistant/moveit_setup_assistant/package.xml
+++ b/moveit_setup_assistant/moveit_setup_assistant/package.xml
@@ -13,8 +13,8 @@
   <license>BSD-3-Clause</license>
 
   <url type="website">http://moveit.ros.org</url>
-  <url type="bugtracker">https://github.com/ros-planning/moveit2/issues</url>
-  <url type="repository">https://github.com/ros-planning/moveit2</url>
+  <url type="bugtracker">https://github.com/moveit/moveit2/issues</url>
+  <url type="repository">https://github.com/moveit/moveit2</url>
 
   <author email="davidvlu@gmail.com">David V. Lu!!</author>
   <author email="dave@picknik.ai">Dave Coleman</author>
@@ -31,7 +31,7 @@
   <exec_depend>moveit_setup_controllers</exec_depend>
   <exec_depend>moveit_setup_core_plugins</exec_depend>
   <exec_depend>moveit_setup_app_plugins</exec_depend>
-  <!-- TODO: Enable once https://github.com/ros-planning/moveit2/issues/1262 is resolved -->
+  <!-- TODO: Enable once https://github.com/moveit/moveit2/issues/1262 is resolved -->
   <!-- <exec_depend>moveit_setup_simulation</exec_depend>  -->
 
   <test_depend>moveit_resources_panda_moveit_config</test_depend>

--- a/moveit_setup_assistant/moveit_setup_framework/templates/package.xml.template
+++ b/moveit_setup_assistant/moveit_setup_framework/templates/package.xml.template
@@ -11,8 +11,8 @@
   <license>BSD-3-Clause</license>
 
   <url type="website">http://moveit.ros.org/</url>
-  <url type="bugtracker">https://github.com/ros-planning/moveit2/issues</url>
-  <url type="repository">https://github.com/ros-planning/moveit2</url>
+  <url type="bugtracker">https://github.com/moveit/moveit2/issues</url>
+  <url type="repository">https://github.com/moveit/moveit2</url>
 
   <author email="[AUTHOR_EMAIL]">[AUTHOR_NAME]</author>
 


### PR DESCRIPTION
After having merged #2793, I noticed that the new docker images were not pushed to dockerhub yet.
The reason is that we have several guards checking for the old `ros-planning` organization.
Thus, this PR updates all occurrences of `ros-planning` to `moveit`.

There are a few more, related to SonarScan, which I'm not familiar with. Please decide yourself to update those references as well:
https://github.com/moveit/moveit2/blob/bee0a2985bdf5e5c9ba67c0e2e0d74c6a8840c63/sonar-project.properties#L1
https://github.com/moveit/moveit2/blob/bee0a2985bdf5e5c9ba67c0e2e0d74c6a8840c63/.github/workflows/ci.yaml#L89
https://github.com/moveit/moveit2/blob/bee0a2985bdf5e5c9ba67c0e2e0d74c6a8840c63/.github/workflows/sonar.yaml#L62