### PR TITLE
Copy planning scene predicates in the copy constructor

### DIFF
--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -212,6 +212,7 @@ PlanningScene::PlanningScene(const PlanningSceneConstPtr& parent) : parent_(pare
 
   setStateFeasibilityPredicate(parent->getStateFeasibilityPredicate());
   setMotionFeasibilityPredicate(parent->getMotionFeasibilityPredicate());
+  setCollisionObjectUpdateCallback(parent_->current_world_object_update_callback_);
 
   // maintain a separate world.  Copy on write ensures that most of the object
   // info is shared until it is modified.
@@ -1206,6 +1207,8 @@ void PlanningScene::decoupleParent()
         (object_types_.value())[it->first] = it->second;
     }
   }
+
+  setCollisionObjectUpdateCallback(nullptr);
 
   parent_.reset();
 }

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -210,6 +210,9 @@ PlanningScene::PlanningScene(const PlanningSceneConstPtr& parent) : parent_(pare
 
   robot_model_ = parent_->robot_model_;
 
+  setStateFeasibilityPredicate(parent->getStateFeasibilityPredicate());
+  setMotionFeasibilityPredicate(parent->getMotionFeasibilityPredicate());
+
   // maintain a separate world.  Copy on write ensures that most of the object
   // info is shared until it is modified.
   world_ = std::make_shared<collision_detection::World>(*parent_->world_);


### PR DESCRIPTION
### Description

The child planning scene should behave as its parent, so the state- and motion- feasibility predicates should be copied as well.

The copy of the collision update callback is treated in a separate commit because I'm not quite sure how to do it properly. I guess that the cloned planning scene should not call the collision update callback to avoid confusion.

Often in the planning scene implementation, the child planning scene uses members of its parent when it doesn't have its own but this is not the case for the predicates so I did copy them.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
