### PR TITLE
Fix typo on Cached IK Kinematics Plugin doc

### DIFF
--- a/moveit_kinematics/cached_ik_kinematics_plugin/README.md
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/README.md
@@ -17,8 +17,8 @@ to this:
       kinematics_solver: cached_ik_kinematics_plugin/CachedKDLKinematicsPlugin
       # optional parameters for caching:
       max_cache_size: 10000
-      min_pose_distance: 1
-      min_joint_config_distance: 4
+      min_pose_distance: 1.0
+      min_joint_config_distance: 4.0
 
 The cache size can be controlled with an absolute cap (`max_cache_size`) or with a distance threshold on the end effector pose (`min_pose_distance`) or robot joint state (`min_joint_config_distance`). Normally, the cache files are saved to the current working directory (which is usually `${HOME}/.ros`, not the directory where you ran `roslaunch`), in a subdirectory for each robot. Possible values for `kinematics_solver` are:
 


### PR DESCRIPTION
### Description

At least on Humble, without explicit double formatting, errors are:

<details>
  <summary>stack trace</summary>
  
```bash
[move_group-4]   what():  parameter 'robot_description_kinematics.robot.min_joint_config_distance' has invalid type: expected [double] got [integer]
[move_group-4] Stack trace (most recent call last):
[move_group-4] #24   Object "", at 0xffffffffffffffff, in 
[move_group-4] #23   Object "/opt/ros/humble/lib/moveit_ros_move_group/move_group", at 0x561c4934c724, in 
[...]
[...]
[...]
[move_group-4] #22   Source "../csu/libc-start.c", line 392, in __libc_start_main_impl [0x7fda8016be3f]
[move_group-4] #21   Source "../sysdeps/nptl/libc_start_call_main.h", line 58, in __libc_start_call_main [0x7fda8016bd8f]
[move_group-4] #20   Object "/opt/ros/humble/lib/moveit_ros_move_group/move_group", at 0x561c4934b2c2, in 
[move_group-4] #19   Object "/opt/ros/humble/lib/libmoveit_cpp.so.2.5.5", at 0x7fda80ab2e94, in moveit_cpp::MoveItCpp::MoveItCpp(std::shared_ptr<rclcpp::Node> const&, moveit_cpp::MoveItCpp::Options const&)
[move_group-4] #18   Object "/opt/ros/humble/lib/libmoveit_cpp.so.2.5.5", at 0x7fda80ab084b, in moveit_cpp::MoveItCpp::loadPlanningSceneMonitor(moveit_cpp::MoveItCpp::PlanningSceneMonitorOptions const&)
[move_group-4] #17   Object "/opt/ros/humble/lib/libmoveit_planning_scene_monitor.so.2.5.5", at 0x7fda809d448a, in planning_scene_monitor::PlanningSceneMonitor::PlanningSceneMonitor(std::shared_ptr<rclcpp::Node> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)
[move_group-4] #16   Object "/opt/ros/humble/lib/libmoveit_planning_scene_monitor.so.2.5.5", at 0x7fda809d43da, in planning_scene_monitor::PlanningSceneMonitor::PlanningSceneMonitor(std::shared_ptr<rclcpp::Node> const&, std::shared_ptr<planning_scene::PlanningScene> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)
[move_group-4] #15   Object "/opt/ros/humble/lib/libmoveit_robot_model_loader.so.2.5.5", at 0x7fda7fcf4c3e, in robot_model_loader::RobotModelLoader::RobotModelLoader(std::shared_ptr<rclcpp::Node> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool)
[move_group-4] #14   Object "/opt/ros/humble/lib/libmoveit_robot_model_loader.so.2.5.5", at 0x7fda7fcf4687, in robot_model_loader::RobotModelLoader::configure(robot_model_loader::RobotModelLoader::Options const&)
[move_group-4] #13   Object "/opt/ros/humble/lib/libmoveit_robot_model_loader.so.2.5.5", at 0x7fda7fcf095e, in robot_model_loader::RobotModelLoader::loadKinematicsSolvers(std::shared_ptr<kinematics_plugin_loader::KinematicsPluginLoader> const&)
[move_group-4] #12   Object "/opt/ros/humble/lib/libmoveit_kinematics_plugin_loader.so.2.5.5", at 0x7fda7f9679f7, in 
[move_group-4] #11   Object "/opt/ros/humble/lib/libmoveit_kinematics_plugin_loader.so.2.5.5", at 0x7fda7f96441f, in 
[move_group-4] #10   Object "/opt/ros/humble/lib/libmoveit_kinematics_plugin_loader.so.2.5.5", at 0x7fda7f962df3, in 
[move_group-4] #9    Object "/opt/ros/humble/lib/libmoveit_cached_ik_kinematics_plugin.so.2.5.5", at 0x7fda780306ef, in 
[move_group-4] #8    Object "/opt/ros/humble/lib/libmoveit_cached_ik_kinematics_plugin.so.2.5.5", at 0x7fda7802edea, in 
[move_group-4] #7    Object "/opt/ros/humble/lib/libmoveit_cached_ik_kinematics_plugin.so.2.5.5", at 0x7fda7802b4bd, in 
[move_group-4] #6    Object "/usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.30", at 0x7fda804384d7, in __cxa_throw
[move_group-4] #5    Object "/usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.30", at 0x7fda80438276, in std::terminate()
[move_group-4] #4    Object "/usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.30", at 0x7fda8043820b, in 
[move_group-4] #3    Object "/usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.30", at 0x7fda8042cb9d, in 
[move_group-4] #2    Source "./stdlib/abort.c", line 79, in abort [0x7fda8016a7f2]
[move_group-4] #1    Source "../sysdeps/posix/raise.c", line 26, in raise [0x7fda80184475]
[move_group-4] #0  | Source "./nptl/pthread_kill.c", line 89, in __pthread_kill_internal
[move_group-4]     | Source "./nptl/pthread_kill.c", line 78, in __pthread_kill_implementation
[move_group-4]       Source "./nptl/pthread_kill.c", line 44, in __pthread_kill [0x7fda801d89fc]
```
</details>

---

Would be great to backport to previous MoveIt2 version since this typo could be cumbersome if you do not pay attention.

---

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
