### PR TITLE
Switch to system version of octomap.

### DIFF
--- a/moveit_core/package.xml
+++ b/moveit_core/package.xml
@@ -41,13 +41,7 @@
   <depend>libfcl-dev</depend>
   <depend>moveit_common</depend>
   <depend>moveit_msgs</depend>
-  <!--
-  Temporarily disable octomap dependency because of
-  version conflict. We use liboctomap-dev provided
-  by libfcl-dev.
-  See https://github.com/moveit/moveit2/issues/2862
-  <depend>octomap</depend>
-  -->
+  <depend>liboctomap-dev</depend>
   <depend>octomap_msgs</depend>
   <depend>osqp_vendor</depend>
   <depend>pluginlib</depend>

--- a/moveit_ros/occupancy_map_monitor/package.xml
+++ b/moveit_ros/occupancy_map_monitor/package.xml
@@ -26,13 +26,7 @@
   <depend>rclcpp</depend>
   <depend>moveit_core</depend>
   <depend>moveit_msgs</depend>
-  <!--
-  Temporarily disable octomap dependency because of
-  version conflict. We use liboctomap-dev provided
-  by moveit_core->libfcl-dev.
-  See https://github.com/moveit/moveit2/issues/2862
-  <depend>octomap</depend>
-  -->
+  <depend>liboctomap-dev</depend>
   <depend version_gte="1.11.2">pluginlib</depend>
   <depend>tf2_ros</depend>
   <depend>geometric_shapes</depend>


### PR DESCRIPTION
### Description

This is so that we have a consistent ABI between these packages and anything else in the system that depends on octomap.  We'll eventually be removing the ROS-provided version of octomap to make sure we don't have these problems in the future.

This should solve the issue in https://github.com/ros/rosdistro/issues/41622 , and was enabled by the merging of https://github.com/ros/rosdistro/pull/41623

### Checklist
- [N/A] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [N/A] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [N/A] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [N/A] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [N/A] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"