### PR TITLE
[MoveitPy] Added namespace to MoveitPy

### DIFF
--- a/moveit_py/src/moveit/moveit_ros/moveit_cpp/moveit_cpp.cpp
+++ b/moveit_py/src/moveit/moveit_ros/moveit_cpp/moveit_cpp.cpp
@@ -60,7 +60,7 @@ void initMoveitPy(py::module& m)
   The MoveItPy class is the main interface to the MoveIt Python API. It is a wrapper around the MoveIt C++ API.
 									     )")
 
-      .def(py::init([](const std::string& node_name, const std::vector<std::string>& launch_params_filepaths,
+      .def(py::init([](const std::string& node_name, const std::string& name_space, const std::vector<std::string>& launch_params_filepaths,
                        const py::object& config_dict, bool provide_planning_service) {
              // This section is used to load the appropriate node parameters before spinning a moveit_cpp instance
              // Priority is given to parameters supplied directly via a config_dict, followed by launch parameters
@@ -106,7 +106,7 @@ void initMoveitPy(py::module& m)
                  .arguments(launch_arguments);
 
              RCLCPP_INFO(getLogger(), "Initialize node and executor");
-             rclcpp::Node::SharedPtr node = rclcpp::Node::make_shared(node_name, "", node_options);
+             rclcpp::Node::SharedPtr node = rclcpp::Node::make_shared(node_name, name_space, node_options);
              std::shared_ptr<rclcpp::executors::SingleThreadedExecutor> executor =
                  std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
 
@@ -134,6 +134,7 @@ void initMoveitPy(py::module& m)
              return moveit_cpp_ptr;
            }),
            py::arg("node_name") = "moveit_py",
+           py::arg("name_space") = "",
            py::arg("launch_params_filepaths") =
                utils.attr("get_launch_params_filepaths")().cast<std::vector<std::string>>(),
            py::arg("config_dict") = py::none(), py::arg("provide_planning_service") = true,

--- a/moveit_py/src/moveit/moveit_ros/moveit_cpp/moveit_cpp.cpp
+++ b/moveit_py/src/moveit/moveit_ros/moveit_cpp/moveit_cpp.cpp
@@ -60,8 +60,9 @@ void initMoveitPy(py::module& m)
   The MoveItPy class is the main interface to the MoveIt Python API. It is a wrapper around the MoveIt C++ API.
 									     )")
 
-      .def(py::init([](const std::string& node_name, const std::string& name_space, const std::vector<std::string>& launch_params_filepaths,
-                       const py::object& config_dict, bool provide_planning_service) {
+      .def(py::init([](const std::string& node_name, const std::string& name_space,
+                       const std::vector<std::string>& launch_params_filepaths, const py::object& config_dict,
+                       bool provide_planning_service) {
              // This section is used to load the appropriate node parameters before spinning a moveit_cpp instance
              // Priority is given to parameters supplied directly via a config_dict, followed by launch parameters
              // and finally no supplied parameters.
@@ -133,8 +134,7 @@ void initMoveitPy(py::module& m)
 
              return moveit_cpp_ptr;
            }),
-           py::arg("node_name") = "moveit_py",
-           py::arg("name_space") = "",
+           py::arg("node_name") = "moveit_py", py::arg("name_space") = "",
            py::arg("launch_params_filepaths") =
                utils.attr("get_launch_params_filepaths")().cast<std::vector<std::string>>(),
            py::arg("config_dict") = py::none(), py::arg("provide_planning_service") = true,


### PR DESCRIPTION
### Description

To allow multiple MoveitPy instances which do not interfere with each other, i've added the namespace parameter. This way it is possible to have multiple, independent planning scene's, each in its own namespace.


If you add the namespace parameter to the launch file, you will also need to add it to the Python constructor.


### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
