### PR TITLE
[Moveitpy] new planning scene message

### DIFF
--- a/moveit_py/src/moveit/moveit_ros/planning_scene_monitor/planning_scene_monitor.cpp
+++ b/moveit_py/src/moveit/moveit_ros/planning_scene_monitor/planning_scene_monitor.cpp
@@ -175,6 +175,16 @@ void initPlanningSceneMonitor(py::module& m)
                attached_collision_object_msg (moveit_msgs.msg.AttachedCollisionObject): The attached collision object to apply to the planning scene.
            )")
 
+      .def("new_planning_scene_message",
+           &planning_scene_monitor::PlanningSceneMonitor::newPlanningSceneMessage,
+           py::arg("scene"),
+           R"(
+           Called to update the planning scene with a new message.
+
+	      Args:
+               scene (moveit_msgs.msg.PlanningScene): The new planning scene message.
+           )")
+
       .def("read_only", &moveit_py::bind_planning_scene_monitor::readOnly,
            R"(
            Returns a read-only context manager for the planning scene.

--- a/moveit_py/src/moveit/moveit_ros/planning_scene_monitor/planning_scene_monitor.cpp
+++ b/moveit_py/src/moveit/moveit_ros/planning_scene_monitor/planning_scene_monitor.cpp
@@ -175,8 +175,7 @@ void initPlanningSceneMonitor(py::module& m)
                attached_collision_object_msg (moveit_msgs.msg.AttachedCollisionObject): The attached collision object to apply to the planning scene.
            )")
 
-      .def("new_planning_scene_message",
-           &planning_scene_monitor::PlanningSceneMonitor::newPlanningSceneMessage,
+      .def("new_planning_scene_message", &planning_scene_monitor::PlanningSceneMonitor::newPlanningSceneMessage,
            py::arg("scene"),
            R"(
            Called to update the planning scene with a new message.


### PR DESCRIPTION
### Description

Added the new_planning_scene_message function to the planning_scene_monitor in moveitpy.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
