### PR TITLE
Replaced gazebo_ros_control by gazebo_ros2_control

### DIFF
--- a/moveit_setup_assistant/moveit_setup_framework/templates/package.xml.template
+++ b/moveit_setup_assistant/moveit_setup_framework/templates/package.xml.template
@@ -29,7 +29,7 @@
   <!-- The next 2 packages are required for the gazebo simulation.
        We don't include them by default to prevent installing gazebo and all its dependencies. -->
   <!-- <exec_depend>joint_trajectory_controller</exec_depend> -->
-  <!-- <exec_depend>gazebo_ros_control</exec_depend> -->
+  <!-- <exec_depend>gazebo_ros2_control</exec_depend> -->
 [OTHER_DEPENDENCIES]
 
   <export>


### PR DESCRIPTION
### Description

When using the <exec-depend> tags generated in the package.xml for the use of Gazebo Classic, rosdep failed because it could not find the package `gazebo_ros_control`.

`ERROR: the following packages/stacks could not have their rosdep keys resolved
to system dependencies:
...: Cannot locate rosdep definition for [gazebo_ros_control]
`

I changed the template for the package.xml to include [gazebo_ros2_control](https://github.com/ros-controls/gazebo_ros2_control)

It could also be useful to include a second commented paragraph containing `gz_ros2_control` for Gazebo.


### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [x] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [x] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [x] Include a screenshot if changing a GUI
- [x] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers