### PR TITLE
Only display kinematics warning if no groups have an IK solver

### DIFF
--- a/moveit_ros/planning/robot_model_loader/src/robot_model_loader.cpp
+++ b/moveit_ros/planning/robot_model_loader/src/robot_model_loader.cpp
@@ -273,7 +273,7 @@ void RobotModelLoader::loadKinematicsSolvers(const kinematics_plugin_loader::Kin
     std::stringstream ss;
     std::copy(groups.begin(), groups.end(), std::ostream_iterator<std::string>(ss, " "));
     RCLCPP_DEBUG(logger_, "Loaded information about the following groups: '%s' ", ss.str().c_str());
-    if (groups.empty() && !model_->getJointModelGroups().empty())
+    if (groups.empty())
       RCLCPP_WARN(logger_, "No kinematics plugins defined. Fill and load kinematics.yaml!");
 
     std::map<std::string, moveit::core::SolverAllocatorFn> imap;


### PR DESCRIPTION
### Description

This warning appeared every time I launched MoveIt even though I had kinematics information assigned for each planning group.
```
[WARN] [1719602728.013530753] [waypoint_manager_node.moveit.ros.robot_model_loader]: No kinematics plugins defined. Fill and load kinematics.yaml!
```

I am removing the check to see if the robot model has JointModelGroups (the groups defined in the SRDF) as it does not pertain to the warning. 


### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
