### PR TITLE
Make compatible with Windows

### DIFF
--- a/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/action_based_controller_handle.h
+++ b/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/action_based_controller_handle.h
@@ -145,7 +145,7 @@ public:
         do
         {
           status = result_future.wait_for(50ms);
-          if ((status == std::future_status::timeout) and ((node_->now() - start) > timeout))
+          if ((status == std::future_status::timeout) && ((node_->now() - start) > timeout))
           {
             RCLCPP_WARN(LOGGER, "waitForExecution timed out");
             return false;


### PR DESCRIPTION
Fails currently on Windows with:
```
error C2146: syntax error: missing ')' before identifier 'and' [%SRC_DIR%\build\moveit_simple_controller_manager.vcxproj]
```