### PR TITLE
Reverts default launch argument "capabilities" to not cause an error

### DIFF
--- a/moveit_configs_utils/moveit_configs_utils/launches.py
+++ b/moveit_configs_utils/moveit_configs_utils/launches.py
@@ -200,7 +200,7 @@ def generate_move_group_launch(moveit_config):
     ld.add_action(
         DeclareLaunchArgument(
             "capabilities",
-            default_value=moveit_config.move_group_capabilities["capabilities"],
+            default_value="",
         )
     )
     # inhibit these default MoveGroup capabilities (space separated)


### PR DESCRIPTION
Reverts capabilities default value to the empty string. Reverts #2696.

The issue is extensively documented:

- https://github.com/moveit/moveit2/issues/2734
- https://github.com/moveit/moveit2/pull/2696

### Description
Reverted the backport to the empty string, which it was before the merge that apparently broke things. Alternatively, 
```
default_value=moveit_config.move_group_capabilities
```
was suggested in these discussions. Both worked on my system.