### PR TITLE
Fix deprecation warning

### DIFF
--- a/moveit_ros/perception/pointcloud_octomap_updater/src/pointcloud_octomap_updater.cpp
+++ b/moveit_ros/perception/pointcloud_octomap_updater/src/pointcloud_octomap_updater.cpp
@@ -96,7 +96,6 @@ void PointCloudOctomapUpdater::start()
   if (!ns_.empty())
     prefix = ns_ + "/";
 
-  rclcpp::QoS qos(rclcpp::QoSInitialization::from_rmw(rmw_qos_profile_sensor_data));
   if (!filtered_cloud_topic_.empty())
   {
     filtered_cloud_publisher_ =
@@ -107,7 +106,7 @@ void PointCloudOctomapUpdater::start()
     return;
   /* subscribe to point cloud topic using tf filter*/
   point_cloud_subscriber_ = new message_filters::Subscriber<sensor_msgs::msg::PointCloud2>(node_, point_cloud_topic_,
-                                                                                           rmw_qos_profile_sensor_data);
+                                                                                           rclcpp::SensorDataQoS());
   if (tf_listener_ && tf_buffer_ && !monitor_->getMapFrame().empty())
   {
     point_cloud_filter_ = new tf2_ros::MessageFilter<sensor_msgs::msg::PointCloud2>(

--- a/moveit_ros/perception/pointcloud_octomap_updater/src/pointcloud_octomap_updater.cpp
+++ b/moveit_ros/perception/pointcloud_octomap_updater/src/pointcloud_octomap_updater.cpp
@@ -44,6 +44,7 @@
 #include <tf2_ros/create_timer_interface.h>
 #include <tf2_ros/create_timer_ros.h>
 #include <moveit/utils/logger.hpp>
+#include <rclcpp/version.h>
 
 #include <memory>
 

--- a/moveit_ros/perception/pointcloud_octomap_updater/src/pointcloud_octomap_updater.cpp
+++ b/moveit_ros/perception/pointcloud_octomap_updater/src/pointcloud_octomap_updater.cpp
@@ -106,7 +106,11 @@ void PointCloudOctomapUpdater::start()
     return;
   /* subscribe to point cloud topic using tf filter*/
   point_cloud_subscriber_ = new message_filters::Subscriber<sensor_msgs::msg::PointCloud2>(node_, point_cloud_topic_,
+#if RCLCPP_VERSION_GTE(28, 3, 0)
                                                                                            rclcpp::SensorDataQoS());
+#else
+                                                                                           rmw_qos_profile_sensor_data);
+#endif
   if (tf_listener_ && tf_buffer_ && !monitor_->getMapFrame().empty())
   {
     point_cloud_filter_ = new tf2_ros::MessageFilter<sensor_msgs::msg::PointCloud2>(


### PR DESCRIPTION
Address the [newly failing rolling build](https://github.com/moveit/moveit2/actions/runs/10008006352/job/27663837261). They deprecated the use of `rmw_qos_profile_t` in favour of `rclcpp:QoS`.

Unfortunately, fixing the rolling build now invalidates the humble and jazzy builds.
Is there a compile-time version check available to handle this?