### PR TITLE
Replace deprecated load_yaml with xacro.load_yaml in ros2_control.xacro template

### DIFF
--- a/moveit_ros/planning/moveit_cpp/include/moveit/moveit_cpp/moveit_cpp.h
+++ b/moveit_ros/planning/moveit_cpp/include/moveit/moveit_cpp/moveit_cpp.h
@@ -57,27 +57,28 @@ public:
   /// Specification of options to use when constructing the MoveItCpp class
   struct PlanningSceneMonitorOptions
   {
+    PlanningSceneMonitorOptions()
+      : joint_state_topic(planning_scene_monitor::PlanningSceneMonitor::DEFAULT_JOINT_STATES_TOPIC)
+      , attached_collision_object_topic(
+            planning_scene_monitor::PlanningSceneMonitor::DEFAULT_ATTACHED_COLLISION_OBJECT_TOPIC)
+      , monitored_planning_scene_topic(planning_scene_monitor::PlanningSceneMonitor::MONITORED_PLANNING_SCENE_TOPIC)
+      , publish_planning_scene_topic(planning_scene_monitor::PlanningSceneMonitor::DEFAULT_PLANNING_SCENE_TOPIC)
+    {
+    }
+
     void load(const rclcpp::Node::SharedPtr& node)
     {
       const std::string ns = "planning_scene_monitor_options";
       node->get_parameter_or(ns + ".name", name, std::string("planning_scene_monitor"));
       node->get_parameter_or(ns + ".robot_description", robot_description, std::string("robot_description"));
-      node->get_parameter_or(ns + ".joint_state_topic", joint_state_topic,
-                             planning_scene_monitor::PlanningSceneMonitor::DEFAULT_JOINT_STATES_TOPIC);
-      node->get_parameter_or(ns + ".attached_collision_object_topic", attached_collision_object_topic,
-                             planning_scene_monitor::PlanningSceneMonitor::DEFAULT_ATTACHED_COLLISION_OBJECT_TOPIC);
-      node->get_parameter_or(ns + ".monitored_planning_scene_topic", monitored_planning_scene_topic,
-                             planning_scene_monitor::PlanningSceneMonitor::MONITORED_PLANNING_SCENE_TOPIC);
-      node->get_parameter_or(ns + ".publish_planning_scene_topic", publish_planning_scene_topic,
-                             planning_scene_monitor::PlanningSceneMonitor::DEFAULT_PLANNING_SCENE_TOPIC);
       node->get_parameter_or(ns + ".wait_for_initial_state_timeout", wait_for_initial_state_timeout, 0.0);
     }
     std::string name;
     std::string robot_description;
-    std::string joint_state_topic;
-    std::string attached_collision_object_topic;
-    std::string monitored_planning_scene_topic;
-    std::string publish_planning_scene_topic;
+    const std::string joint_state_topic;
+    const std::string attached_collision_object_topic;
+    const std::string monitored_planning_scene_topic;
+    const std::string publish_planning_scene_topic;
     double wait_for_initial_state_timeout;
   };
 

--- a/moveit_setup_assistant/moveit_setup_controllers/templates/config/ros2_control.xacro
+++ b/moveit_setup_assistant/moveit_setup_controllers/templates/config/ros2_control.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
     <xacro:macro name="[ROBOT_NAME]_ros2_control" params="name initial_positions_file">
-        <xacro:property name="initial_positions" value="${load_yaml(initial_positions_file)['initial_positions']}"/>
+        <xacro:property name="initial_positions" value="${xacro.load_yaml(initial_positions_file)['initial_positions']}"/>
 
         <ros2_control name="${name}" type="system">
             <hardware>


### PR DESCRIPTION
### Description

Removes deprecation warning 
```
Using load_yaml() directly is deprecated. Use xacro.load_yaml() instead.
```

by updating the template for ros2_control.xacro