### PR TITLE
Don't set reset observer callback & set CB after world_ is initialized

### DIFF
--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -212,12 +212,12 @@ PlanningScene::PlanningScene(const PlanningSceneConstPtr& parent) : parent_(pare
 
   setStateFeasibilityPredicate(parent->getStateFeasibilityPredicate());
   setMotionFeasibilityPredicate(parent->getMotionFeasibilityPredicate());
-  setCollisionObjectUpdateCallback(parent_->current_world_object_update_callback_);
 
   // maintain a separate world.  Copy on write ensures that most of the object
   // info is shared until it is modified.
   world_ = std::make_shared<collision_detection::World>(*parent_->world_);
   world_const_ = world_;
+  setCollisionObjectUpdateCallback(parent_->current_world_object_update_callback_);
 
   // record changes to the world
   world_diff_ = std::make_shared<collision_detection::WorldDiff>(world_);
@@ -1214,9 +1214,6 @@ void PlanningScene::decoupleParent()
         (object_types_.value())[it->first] = it->second;
     }
   }
-
-  setCollisionObjectUpdateCallback(nullptr);
-
   parent_.reset();
 }
 


### PR DESCRIPTION
### Description

Fix segfault caused by https://github.com/moveit/moveit2/pull/2858

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
