### PR TITLE
Consider attached collision objects in the ComputeFK service

### DIFF
--- a/moveit_ros/move_group/src/default_capabilities/kinematics_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/kinematics_service_capability.cpp
@@ -223,10 +223,10 @@ bool MoveGroupKinematicsService::computeFKService(const std::shared_ptr<rmw_requ
   moveit::core::robotStateMsgToRobotState(req->robot_state, rs);
   for (std::size_t i = 0; i < req->fk_link_names.size(); ++i)
   {
-    if (rs.getRobotModel()->hasLinkModel(req->fk_link_names[i]))
+    if (rs.knowsFrameTransform(req->fk_link_names[i]))
     {
       res->pose_stamped.resize(res->pose_stamped.size() + 1);
-      res->pose_stamped.back().pose = tf2::toMsg(rs.getGlobalLinkTransform(req->fk_link_names[i]));
+      res->pose_stamped.back().pose = tf2::toMsg(rs.getFrameTransform(req->fk_link_names[i]));
       res->pose_stamped.back().header.frame_id = default_frame;
       res->pose_stamped.back().header.stamp = context_->moveit_cpp_->getNode()->get_clock()->now();
       if (do_transform)


### PR DESCRIPTION
### Description

Currently, the ComputeFK service only works for robot links. By using `getFrameTransform` we can also consider attached collision objects and their subframes.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
