### PR TITLE
Fix key duplication in moveit_setup_assistant for moveit_controllers.yaml for typeFollowJointTrajectory

### DIFF
--- a/moveit_setup_assistant/moveit_setup_controllers/src/moveit_controllers_config.cpp
+++ b/moveit_setup_assistant/moveit_setup_controllers/src/moveit_controllers_config.cpp
@@ -187,11 +187,6 @@ bool MoveItControllersConfig::GeneratedControllersConfig::writeYaml(YAML::Emitte
         emitter << YAML::BeginMap;
         {
           emitter << YAML::Key << "type" << YAML::Value << controller.type_;
-          if (controller.type_ == "FollowJointTrajectory")
-          {
-            emitter << YAML::Key << "action_ns" << YAML::Value << "follow_joint_trajectory";
-            emitter << YAML::Key << "default" << YAML::Value << "true";
-          }
 
           // Write joints
           emitter << YAML::Key << "joints";


### PR DESCRIPTION
# Description

Moveit Setup Assistant generates duplicated keys action_ns, default for the type FollowJointTrajectory, e.g.

```
# MoveIt uses this configuration for controller management

moveit_controller_manager: moveit_simple_controller_manager/MoveItSimpleControllerManager

moveit_simple_controller_manager:
  controller_names:
    - steering_controller

  steering_controller:
    type: FollowJointTrajectory
    action_ns: follow_joint_trajectory
    default: true
    joints:
      - front_left_steer_joint
      - front_right_steer_joint
    action_ns: follow_joint_trajectory
    default: true
```

This PR deletes the redundant keys