### PR TITLE
Fix Pilz blending times... the right way

### DIFF
--- a/moveit_planners/pilz_industrial_motion_planner/src/command_list_manager.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/command_list_manager.cpp
@@ -113,25 +113,7 @@ RobotTrajCont CommandListManager::solve(const planning_scene::PlanningSceneConst
                               (i > 0 ? radii.at(i - 1) : 0.));
   }
 
-  const auto res_vec = plan_comp_builder_.build();
-
-  // De-duplicate trajectory points with the same time value.
-  // This is necessary since some controllers do not allow times that are not monotonically increasing.
-  // TODO: Ideally, we would not need this code if the trajectory segments were created without
-  // duplicate time points in the first place. Leaving this note to revisit this with a more principled fix.
-  for (const auto& traj : res_vec)
-  {
-    for (size_t i = 0; i < traj->size() - 1; ++i)
-    {
-      if (traj->getWayPointDurationFromStart(i) == traj->getWayPointDurationFromStart(i + 1))
-      {
-        RCLCPP_WARN(getLogger(), "Removed duplicate point at time=%f", traj->getWayPointDurationFromStart(i));
-        traj->removeWayPoint(i + 1);
-      }
-    }
-  }
-
-  return res_vec;
+  return plan_comp_builder_.build();
 }
 
 bool CommandListManager::checkRadiiForOverlap(const robot_trajectory::RobotTrajectory& traj_A, const double radii_A,

--- a/moveit_planners/pilz_industrial_motion_planner/src/plan_components_builder.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/plan_components_builder.cpp
@@ -60,7 +60,8 @@ void PlanComponentsBuilder::appendWithStrictTimeIncrease(robot_trajectory::Robot
     return;
   }
   if (!pilz_industrial_motion_planner::isRobotStateEqual(result.getLastWayPoint(), source.getFirstWayPoint(),
-                                                         result.getGroupName(), ROBOT_STATE_EQUALITY_EPSILON)) {
+                                                         result.getGroupName(), ROBOT_STATE_EQUALITY_EPSILON))
+  {
     result.append(source, source.getWayPointDurationFromStart(0));
     return;
   }

--- a/moveit_planners/pilz_industrial_motion_planner/src/plan_components_builder.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/plan_components_builder.cpp
@@ -54,11 +54,14 @@ std::vector<robot_trajectory::RobotTrajectoryPtr> PlanComponentsBuilder::build()
 void PlanComponentsBuilder::appendWithStrictTimeIncrease(robot_trajectory::RobotTrajectory& result,
                                                          const robot_trajectory::RobotTrajectory& source)
 {
-  if (result.empty() ||
-      !pilz_industrial_motion_planner::isRobotStateEqual(result.getLastWayPoint(), source.getFirstWayPoint(),
-                                                         result.getGroupName(), ROBOT_STATE_EQUALITY_EPSILON))
+  if (result.empty())
   {
     result.append(source, 0.0);
+    return;
+  }
+  if (!pilz_industrial_motion_planner::isRobotStateEqual(result.getLastWayPoint(), source.getFirstWayPoint(),
+                                                         result.getGroupName(), ROBOT_STATE_EQUALITY_EPSILON)) {
+    result.append(source, source.getWayPointDurationFromStart(0));
     return;
   }
 
@@ -94,7 +97,14 @@ void PlanComponentsBuilder::blend(const planning_scene::PlanningSceneConstPtr& p
 
   // Append the new trajectory elements
   appendWithStrictTimeIncrease(*(traj_cont_.back()), *blend_response.first_trajectory);
-  traj_cont_.back()->append(*blend_response.blend_trajectory, 0.0);
+  for (size_t i = 0; i < traj_cont_.back()->getWayPointCount(); ++i) {
+    std::cout << "PRE-BLEND TRAJ CONT IDX " << i << ", dt = " << traj_cont_.back()->getWayPointDurationFromStart(i) << std::endl;
+  }
+  // traj_cont_.back()->append(*blend_response.blend_trajectory, 0.0);
+  appendWithStrictTimeIncrease(*(traj_cont_.back()), *blend_response.blend_trajectory);
+  for (size_t i = 0; i < traj_cont_.back()->getWayPointCount(); ++i) {
+    std::cout << "POST-BLEND TRAJ CONT IDX " << i << ", dt = " << traj_cont_.back()->getWayPointDurationFromStart(i) << std::endl;
+  }
   // Store the last new trajectory element for future processing
   traj_tail_ = blend_response.second_trajectory;  // first for next blending segment
 }

--- a/moveit_planners/pilz_industrial_motion_planner/src/plan_components_builder.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/plan_components_builder.cpp
@@ -97,14 +97,8 @@ void PlanComponentsBuilder::blend(const planning_scene::PlanningSceneConstPtr& p
 
   // Append the new trajectory elements
   appendWithStrictTimeIncrease(*(traj_cont_.back()), *blend_response.first_trajectory);
-  for (size_t i = 0; i < traj_cont_.back()->getWayPointCount(); ++i) {
-    std::cout << "PRE-BLEND TRAJ CONT IDX " << i << ", dt = " << traj_cont_.back()->getWayPointDurationFromStart(i) << std::endl;
-  }
-  // traj_cont_.back()->append(*blend_response.blend_trajectory, 0.0);
   appendWithStrictTimeIncrease(*(traj_cont_.back()), *blend_response.blend_trajectory);
-  for (size_t i = 0; i < traj_cont_.back()->getWayPointCount(); ++i) {
-    std::cout << "POST-BLEND TRAJ CONT IDX " << i << ", dt = " << traj_cont_.back()->getWayPointDurationFromStart(i) << std::endl;
-  }
+
   // Store the last new trajectory element for future processing
   traj_tail_ = blend_response.second_trajectory;  // first for next blending segment
 }

--- a/moveit_planners/pilz_industrial_motion_planner/src/trajectory_blender_transition_window.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/trajectory_blender_transition_window.cpp
@@ -70,7 +70,7 @@ bool pilz_industrial_motion_planner::TrajectoryBlenderTransitionWindow::blend(
   std::size_t second_intersection_index;
   if (!searchIntersectionPoints(req, first_intersection_index, second_intersection_index))
   {
-    RCLCPP_ERROR(getLogger(), "Blend radius to large.");
+    RCLCPP_ERROR(getLogger(), "Blend radius too large.");
     res.error_code.val = moveit_msgs::msg::MoveItErrorCodes::INVALID_MOTION_PLAN;
     return false;
   }
@@ -127,6 +127,7 @@ bool pilz_industrial_motion_planner::TrajectoryBlenderTransitionWindow::blend(
 
   // append the blend trajectory
   res.blend_trajectory->setRobotTrajectoryMsg(req.first_trajectory->getFirstWayPoint(), blend_joint_trajectory);
+
   // copy the points [second_intersection_index, len] from the second trajectory
   for (size_t i = second_intersection_index + 1; i < req.second_trajectory->getWayPointCount(); ++i)
   {


### PR DESCRIPTION
### Description

Found the issue!

Turns out that Pilz's `appendWithStrictTimeIncrease()` function had a single if-statement that encompassed two conditions:
1. If trajectory is empty
2. If the end state of one segment is not equal to the start state of the second segment

In both cases, the whole trajectory segment was appended with a `dt=0`.

The problem is that in case 1, it's appropriate to add a `dt=0` (as the trajectory is empty, the first point should be at `t=0`). In case 2, we needed to apply a non-zero sample time offset dictated by the actual `dt` of that trajectory's first waypoint.

Closes https://github.com/moveit/moveit2/issues/2945

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [x] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [x] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [x] Include a screenshot if changing a GUI
- [x] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
