### PR TITLE
Correctly load smoothing plugins in Servo integration tests

### DIFF
--- a/moveit_ros/moveit_servo/tests/launch/servo_cpp_integration.test.py
+++ b/moveit_ros/moveit_servo/tests/launch/servo_cpp_integration.test.py
@@ -22,8 +22,9 @@ def generate_test_description():
         .to_dict()
     }
 
-    # This filter parameter should be >1. Increase it for greater smoothing but slower motion.
-    low_pass_filter_coeff = {"butterworth_filter_coeff": 1.5}
+    # This sets the update rate and planning group name for the acceleration limiting filter.
+    acceleration_filter_update_period = {"update_period": 0.01}
+    planning_group_name = {"planning_group_name": "panda_arm"}
 
     # ros2_control using FakeSystem as hardware
     ros2_controllers_path = os.path.join(
@@ -91,7 +92,8 @@ def generate_test_description():
         ),
         parameters=[
             servo_params,
-            low_pass_filter_coeff,
+            acceleration_filter_update_period,
+            planning_group_name,
             moveit_config.robot_description,
             moveit_config.robot_description_semantic,
             moveit_config.robot_description_kinematics,

--- a/moveit_ros/moveit_servo/tests/launch/servo_ros_integration.test.py
+++ b/moveit_ros/moveit_servo/tests/launch/servo_ros_integration.test.py
@@ -29,8 +29,9 @@ def generate_test_description():
         .to_dict()
     }
 
-    # This filter parameter should be >1. Increase it for greater smoothing but slower motion.
-    low_pass_filter_coeff = {"butterworth_filter_coeff": 1.5}
+    # This sets the update rate and planning group name for the acceleration limiting filter.
+    acceleration_filter_update_period = {"update_period": 0.01}
+    planning_group_name = {"planning_group_name": "panda_arm"}
 
     # ros2_control using FakeSystem as hardware
     ros2_controllers_path = os.path.join(
@@ -82,7 +83,8 @@ def generate_test_description():
                 name="servo_node",
                 parameters=[
                     servo_params,
-                    low_pass_filter_coeff,
+                    acceleration_filter_update_period,
+                    planning_group_name,
                     moveit_config.robot_description,
                     moveit_config.robot_description_semantic,
                     moveit_config.robot_description_kinematics,
@@ -112,7 +114,8 @@ def generate_test_description():
         name="servo_node",
         parameters=[
             servo_params,
-            low_pass_filter_coeff,
+            acceleration_filter_update_period,
+            planning_group_name,
             moveit_config.robot_description,
             moveit_config.robot_description_semantic,
             moveit_config.robot_description_kinematics,

--- a/moveit_ros/moveit_servo/tests/test_ros_integration.cpp
+++ b/moveit_ros/moveit_servo/tests/test_ros_integration.cpp
@@ -74,7 +74,7 @@ TEST_F(ServoRosFixture, testJointJog)
 
   // Call input type service
   auto request = std::make_shared<moveit_msgs::srv::ServoCommandType::Request>();
-  request->command_type = 0;
+  request->command_type = moveit_msgs::srv::ServoCommandType::Request::JOINT_JOG;
   auto response = switch_input_client_->async_send_request(request);
   ASSERT_EQ(response.get()->success, true);
 
@@ -116,7 +116,7 @@ TEST_F(ServoRosFixture, testTwist)
       "/servo_node/delta_twist_cmds", rclcpp::SystemDefaultsQoS());
 
   auto request = std::make_shared<moveit_msgs::srv::ServoCommandType::Request>();
-  request->command_type = 1;
+  request->command_type = moveit_msgs::srv::ServoCommandType::Request::TWIST;
   auto response = switch_input_client_->async_send_request(request);
   ASSERT_EQ(response.get()->success, true);
 
@@ -155,7 +155,7 @@ TEST_F(ServoRosFixture, testPose)
       "/servo_node/pose_target_cmds", rclcpp::SystemDefaultsQoS());
 
   auto request = std::make_shared<moveit_msgs::srv::ServoCommandType::Request>();
-  request->command_type = 2;
+  request->command_type = moveit_msgs::srv::ServoCommandType::Request::POSE;
   auto response = switch_input_client_->async_send_request(request);
   ASSERT_EQ(response.get()->success, true);
 


### PR DESCRIPTION
### Description

I just realized in analyzing servo integration tests that they were pulling from the `panda_simulated_config.yaml` (which currently uses the Acceleration filter plugin), but still had the old parameters from the Butterworth filter plugin in the launch files.

As a consequence, the smoothing plugin was not loading correctly in these tests; see, e.g., [this CI run](https://github.com/moveit/moveit2/actions/runs/10342130968/job/28624714548#step:11:4130).

This happens specifically because the Acceleration filter parameters *do not* have defaults, so they are required. Butterworth, on the other hand, has a default parameter value for its one coefficient.

@AndyZe FYI if you are switching the default in `panda_simulated_config.yaml` to the new Ruckig plugin in your PR, you will need to make similar updates in the integration test launch files as well.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [x] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [x] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [x] Include a screenshot if changing a GUI
- [x] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
