### PR TITLE
Update the "format" workflow version of ubuntu

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -14,7 +14,7 @@ on:
 jobs:
   pre-commit:
     name: Format
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5


### PR DESCRIPTION
### Description

If you search the `.github` folder, you'll see that `ubuntu-latest` is used almost everywhere. And that makes good sense. Switch `ubuntu-22.04` to `ubuntu-latest` in this one last place.
