### PR TITLE
Unknown compiler options for clang shouldn't be show-stoppers

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,8 +31,10 @@ jobs:
           - IMAGE: jazzy-ci
             ROS_DISTRO: jazzy
     env:
+      # TODO(andyz): When this clang-tidy issue is fixed, remove -Wno-unknown-warning-option
+      # https://stackoverflow.com/a/41673702
       CXXFLAGS: >-
-        -Wall -Wextra -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls
+        -Wall -Wextra -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls -Wno-unknown-warning-option
       CLANG_TIDY_ARGS: --fix --fix-errors --format-style=file
       DOCKER_IMAGE: moveit/moveit2:${{ matrix.env.IMAGE }}
       UPSTREAM_WORKSPACE: >


### PR DESCRIPTION
### Description

This is a workaround for a CI error that has been cropping up once in awhile recently:

>    Error while processing /home/runner/work/moveit2/moveit2/.work/target_ws/src/moveit2/moveit_ros/moveit_servo/src/utils/common.cpp.
  error: unknown warning option '-Wno-maybe-uninitialized'; did you mean '-Wno-uninitialized'? [clang-diagnostic-unknown-warning-option]
  
 From https://github.com/moveit/moveit2/actions/runs/10335417126/job/28609933300 for one example
  
 I don't think there's actually a potentially uninitialized variable there, at least not a new one in this PR. I think what happened is, `clang-tidy` was cached previously for this `cpp` file. That PR happened to touch that `cpp` file, which caused `clang-tidy` to re-run for it. And something about `clang-tidy` has changed since the last time it ran.