### PR TITLE
[Servo] Support single-element joint limit margins vector and fix joint halting logic for multi-DOF Joints

### DIFF
--- a/moveit_ros/moveit_servo/config/panda_simulated_config.yaml
+++ b/moveit_ros/moveit_servo/config/panda_simulated_config.yaml
@@ -44,8 +44,9 @@ move_group_name: panda_arm  # Often 'manipulator' or 'arm'
 lower_singularity_threshold: 10.0  # Start decelerating when the condition number hits this (close to singularity)
 hard_stop_singularity_threshold: 30.0  # Stop when the condition number hits this
 leaving_singularity_threshold_multiplier: 2.0  # Multiply the hard stop limit by this when leaving singularity (see https://github.com/moveit/moveit2/pull/620)
-# Added as a buffer to joint limits [radians or meters]. If moving quickly, make this larger.
+# Added as a buffer to joint variable position bounds [in that joint variable's respective units].
 # Can be of size 1, which applies the margin to all joints, or the same size as the number of degrees of freedom of the active joint group.
+# If moving quickly, make these values larger.
 joint_limit_margins: [0.12]
 
 ## Topic names

--- a/moveit_ros/moveit_servo/config/panda_simulated_config.yaml
+++ b/moveit_ros/moveit_servo/config/panda_simulated_config.yaml
@@ -38,13 +38,15 @@ is_primary_planning_scene_monitor: true
 check_octomap_collisions: false  # Check collision against the octomap (if a 3D sensor plugin is available)
 
 ## MoveIt properties
-move_group_name:  panda_arm  # Often 'manipulator' or 'arm'
+move_group_name: panda_arm  # Often 'manipulator' or 'arm'
 
 ## Configure handling of singularities and joint limits
-lower_singularity_threshold:  10.0  # Start decelerating when the condition number hits this (close to singularity)
+lower_singularity_threshold: 10.0  # Start decelerating when the condition number hits this (close to singularity)
 hard_stop_singularity_threshold: 30.0  # Stop when the condition number hits this
-joint_limit_margins: [0.12, 0.12, 0.12, 0.12, 0.12, 0.12, 0.12]  # added as a buffer to joint limits [radians or meters]. If moving quickly, make this larger.
 leaving_singularity_threshold_multiplier: 2.0  # Multiply the hard stop limit by this when leaving singularity (see https://github.com/moveit/moveit2/pull/620)
+# Added as a buffer to joint limits [radians or meters]. If moving quickly, make this larger.
+# Can be of size 1, which applies the margin to all joints, or the same size as the number of degrees of freedom of the active joint group.
+joint_limit_margins: [0.12]
 
 ## Topic names
 cartesian_command_in_topic: ~/delta_twist_cmds  # Topic for incoming Cartesian twist commands

--- a/moveit_ros/moveit_servo/config/servo_parameters.yaml
+++ b/moveit_ros/moveit_servo/config/servo_parameters.yaml
@@ -326,7 +326,7 @@ servo:
 
   joint_limit_margins: {
     type: double_array,
-    default_value: [0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1],
+    default_value: [0.1],
     description: "Added as a buffer to joint limits [radians]. If moving quickly, make this larger. Can be of size 1, which applies the margin to all joints, or the same size as the number of degrees of freedom of the active joint group.",
     validation: {
       lower_element_bounds<>: 0.0

--- a/moveit_ros/moveit_servo/config/servo_parameters.yaml
+++ b/moveit_ros/moveit_servo/config/servo_parameters.yaml
@@ -327,7 +327,7 @@ servo:
   joint_limit_margins: {
     type: double_array,
     default_value: [0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1],
-    description: "Added as a buffer to joint limits [radians]. If moving quickly, make this larger.",
+    description: "Added as a buffer to joint limits [radians]. If moving quickly, make this larger. Can be of size 1, which applies the margin to all joints, or the same size as the number of degrees of freedom of the active joint group.",
     validation: {
       lower_element_bounds<>: 0.0
     }

--- a/moveit_ros/moveit_servo/config/servo_parameters.yaml
+++ b/moveit_ros/moveit_servo/config/servo_parameters.yaml
@@ -327,7 +327,7 @@ servo:
   joint_limit_margins: {
     type: double_array,
     default_value: [0.1],
-    description: "Added as a buffer to joint limits [radians]. If moving quickly, make this larger. Can be of size 1, which applies the margin to all joints, or the same size as the number of degrees of freedom of the active joint group.",
+    description: "Added as a buffer to joint variable position bounds [in that joint variable's respective units]. Can be of size 1, which applies the margin to all joints, or the same size as the number of degrees of freedom of the active joint group. If moving quickly, make these values larger.",
     validation: {
       lower_element_bounds<>: 0.0
     }
@@ -336,7 +336,7 @@ servo:
   override_velocity_scaling_factor: {
     type: double,
     default_value: 0.0,
-    description: "Scaling factor when servo overrides the velocity (eg: near singularities)",
+    description: "Scaling factor when servo overrides the velocity (e.g, near singularities)",
     validation: {
       bounds<>: [0.0, 1.0]
     }

--- a/moveit_ros/moveit_servo/config/test_config_panda.yaml
+++ b/moveit_ros/moveit_servo/config/test_config_panda.yaml
@@ -37,13 +37,15 @@ smoothing_filter_plugin_name: "online_signal_smoothing::ButterworthFilterPlugin"
 is_primary_planning_scene_monitor: true
 
 ## MoveIt properties
-move_group_name:  panda_arm  # Often 'manipulator' or 'arm'
+move_group_name: panda_arm  # Often 'manipulator' or 'arm'
 
 ## Configure handling of singularities and joint limits
-lower_singularity_threshold:  17.0  # Start decelerating when the condition number hits this (close to singularity)
+lower_singularity_threshold: 17.0  # Start decelerating when the condition number hits this (close to singularity)
 hard_stop_singularity_threshold: 30.0 # Stop when the condition number hits this
-joint_limit_margins: [0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1]  # added as a buffer to joint limits [radians or meters]. If moving quickly, make this larger.
 leaving_singularity_threshold_multiplier: 2.0 # Multiply the hard stop limit by this when leaving singularity (see https://github.com/moveit/moveit2/pull/620)
+# Added as a buffer to joint limits [radians or meters]. If moving quickly, make this larger.
+# Can be of size 1, which applies the margin to all joints, or the same size as the number of degrees of freedom of the active joint group.
+joint_limit_margins: [0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1]
 
 ## Topic names
 cartesian_command_in_topic: ~/delta_twist_cmds  # Topic for incoming Cartesian twist commands

--- a/moveit_ros/moveit_servo/config/test_config_panda.yaml
+++ b/moveit_ros/moveit_servo/config/test_config_panda.yaml
@@ -43,8 +43,9 @@ move_group_name: panda_arm  # Often 'manipulator' or 'arm'
 lower_singularity_threshold: 17.0  # Start decelerating when the condition number hits this (close to singularity)
 hard_stop_singularity_threshold: 30.0 # Stop when the condition number hits this
 leaving_singularity_threshold_multiplier: 2.0 # Multiply the hard stop limit by this when leaving singularity (see https://github.com/moveit/moveit2/pull/620)
-# Added as a buffer to joint limits [radians or meters]. If moving quickly, make this larger.
+# Added as a buffer to joint variable position bounds [in that joint variable's respective units].
 # Can be of size 1, which applies the margin to all joints, or the same size as the number of degrees of freedom of the active joint group.
+# If moving quickly, make these values larger.
 joint_limit_margins: [0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1]
 
 ## Topic names

--- a/moveit_ros/moveit_servo/include/moveit_servo/servo.hpp
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo.hpp
@@ -187,7 +187,7 @@ private:
    * @param servo_params The servo parameters
    * @return True if parameters are valid, else False
    */
-  bool validateParams(const servo::Params& servo_params) const;
+  bool validateParams(const servo::Params& servo_params);
 
   /**
    * \brief Updates the servo parameters and performs validations.
@@ -206,7 +206,7 @@ private:
    * @param target_state The target kinematic state.
    * @return The bounded kinematic state.
    */
-  KinematicState haltJoints(const std::vector<int>& joints_to_halt, const KinematicState& current_state,
+  KinematicState haltJoints(const std::vector<size_t>& joints_to_halt, const KinematicState& current_state,
                             const KinematicState& target_state) const;
 
   // Variables
@@ -230,6 +230,9 @@ private:
 
   // Map between joint subgroup names and corresponding joint name - move group indices map
   std::unordered_map<std::string, JointNameToMoveGroupIndexMap> joint_name_to_index_maps_;
+
+  // The current joint limit safety margins for each active joint position variable.
+  std::vector<double> joint_limit_margins_;
 };
 
 }  // namespace moveit_servo

--- a/moveit_ros/moveit_servo/include/moveit_servo/utils/common.hpp
+++ b/moveit_ros/moveit_servo/include/moveit_servo/utils/common.hpp
@@ -166,16 +166,16 @@ double jointLimitVelocityScalingFactor(const Eigen::VectorXd& velocities,
                                        const moveit::core::JointBoundsVector& joint_bounds, double scaling_override);
 
 /**
- * \brief Finds the joint indices that are exceeding allowable position limits in at least one variable.
+ * \brief Finds the joint variable indices correspond to joints exceeding allowable position limits.
  * @param positions The joint positions.
  * @param velocities The current commanded velocities.
  * @param joint_bounds The allowable limits for the robot joints.
  * @param margins Additional buffer on the actual joint limits.
- * @return The joint indices that violate the specified position limits.
+ * @return The joint variable indices that violate the specified position limits.
  */
-std::vector<size_t> jointsToHalt(const Eigen::VectorXd& positions, const Eigen::VectorXd& velocities,
-                                 const moveit::core::JointBoundsVector& joint_bounds,
-                                 const std::vector<double>& margins);
+std::vector<size_t> jointVariablesToHalt(const Eigen::VectorXd& positions, const Eigen::VectorXd& velocities,
+                                         const moveit::core::JointBoundsVector& joint_bounds,
+                                         const std::vector<double>& margins);
 
 /**
  * \brief Helper function for converting Eigen::Isometry3d to geometry_msgs/TransformStamped.

--- a/moveit_ros/moveit_servo/include/moveit_servo/utils/common.hpp
+++ b/moveit_ros/moveit_servo/include/moveit_servo/utils/common.hpp
@@ -166,7 +166,7 @@ double jointLimitVelocityScalingFactor(const Eigen::VectorXd& velocities,
                                        const moveit::core::JointBoundsVector& joint_bounds, double scaling_override);
 
 /**
- * \brief Finds the joint variable indices correspond to joints exceeding allowable position limits.
+ * \brief Finds the joint variable indices corresponding to joints exceeding allowable position limits.
  * @param positions The joint positions.
  * @param velocities The current commanded velocities.
  * @param joint_bounds The allowable limits for the robot joints.

--- a/moveit_ros/moveit_servo/include/moveit_servo/utils/common.hpp
+++ b/moveit_ros/moveit_servo/include/moveit_servo/utils/common.hpp
@@ -166,16 +166,16 @@ double jointLimitVelocityScalingFactor(const Eigen::VectorXd& velocities,
                                        const moveit::core::JointBoundsVector& joint_bounds, double scaling_override);
 
 /**
- * \brief Finds the joint variables that are exceeding allowable position limits.
+ * \brief Finds the joint indices that are exceeding allowable position limits in at least one variable.
  * @param positions The joint positions.
  * @param velocities The current commanded velocities.
  * @param joint_bounds The allowable limits for the robot joints.
  * @param margins Additional buffer on the actual joint limits.
- * @return The joint variables that are violating the specified position limits.
+ * @return The joint indices that violate the specified position limits.
  */
-std::vector<size_t> jointVariablesToHalt(const Eigen::VectorXd& positions, const Eigen::VectorXd& velocities,
-                                         const moveit::core::JointBoundsVector& joint_bounds,
-                                         const std::vector<double>& margins);
+std::vector<size_t> jointsToHalt(const Eigen::VectorXd& positions, const Eigen::VectorXd& velocities,
+                                 const moveit::core::JointBoundsVector& joint_bounds,
+                                 const std::vector<double>& margins);
 
 /**
  * \brief Helper function for converting Eigen::Isometry3d to geometry_msgs/TransformStamped.

--- a/moveit_ros/moveit_servo/include/moveit_servo/utils/common.hpp
+++ b/moveit_ros/moveit_servo/include/moveit_servo/utils/common.hpp
@@ -166,15 +166,16 @@ double jointLimitVelocityScalingFactor(const Eigen::VectorXd& velocities,
                                        const moveit::core::JointBoundsVector& joint_bounds, double scaling_override);
 
 /**
- * \brief Finds the joints that are exceeding allowable position limits.
+ * \brief Finds the joint variables that are exceeding allowable position limits.
  * @param positions The joint positions.
  * @param velocities The current commanded velocities.
  * @param joint_bounds The allowable limits for the robot joints.
  * @param margins Additional buffer on the actual joint limits.
- * @return The joints that are violating the specified position limits.
+ * @return The joint variables that are violating the specified position limits.
  */
-std::vector<int> jointsToHalt(const Eigen::VectorXd& positions, const Eigen::VectorXd& velocities,
-                              const moveit::core::JointBoundsVector& joint_bounds, const std::vector<double>& margins);
+std::vector<size_t> jointVariablesToHalt(const Eigen::VectorXd& positions, const Eigen::VectorXd& velocities,
+                                         const moveit::core::JointBoundsVector& joint_bounds,
+                                         const std::vector<double>& margins);
 
 /**
  * \brief Helper function for converting Eigen::Isometry3d to geometry_msgs/TransformStamped.

--- a/moveit_ros/moveit_servo/src/servo.cpp
+++ b/moveit_ros/moveit_servo/src/servo.cpp
@@ -334,14 +334,14 @@ void Servo::setCommandType(const CommandType& command_type)
   expected_command_type_ = command_type;
 }
 
-KinematicState Servo::haltJoints(const std::vector<size_t>& joint_variables_to_halt,
-                                 const KinematicState& current_state, const KinematicState& target_state) const
+KinematicState Servo::haltJoints(const std::vector<size_t>& joint_indices_to_halt, const KinematicState& current_state,
+                                 const KinematicState& target_state) const
 {
   KinematicState bounded_state(target_state.joint_names.size());
   bounded_state.joint_names = target_state.joint_names;
 
   std::stringstream halting_joint_names;
-  for (const auto idx : joint_variables_to_halt)
+  for (const auto idx : joint_indices_to_halt)
   {
     halting_joint_names << bounded_state.joint_names[idx] + " ";
   }
@@ -361,7 +361,7 @@ KinematicState Servo::haltJoints(const std::vector<size_t>& joint_variables_to_h
     // Halt only the joints that are out of bounds
     bounded_state.positions = target_state.positions;
     bounded_state.velocities = target_state.velocities;
-    for (const auto idx : joint_variables_to_halt)
+    for (const auto idx : joint_indices_to_halt)
     {
       bounded_state.positions[idx] = current_state.positions[idx];
       bounded_state.velocities[idx] = 0.0;
@@ -534,14 +534,14 @@ KinematicState Servo::getNextJointState(const moveit::core::RobotStatePtr& robot
     target_state.velocities = (target_state.positions - current_state.positions) / servo_params_.publish_period;
 
     // Check if any joints are going past joint position limits.
-    const std::vector<size_t> joint_variables_to_halt =
-        jointVariablesToHalt(target_state.positions, target_state.velocities, joint_bounds, joint_limit_margins_);
+    const std::vector<size_t> joint_indices_to_halt =
+        jointsToHalt(target_state.positions, target_state.velocities, joint_bounds, joint_limit_margins_);
 
     // Apply halting if any joints need to be halted.
-    if (!joint_variables_to_halt.empty())
+    if (!joint_indices_to_halt.empty())
     {
       servo_status_ = StatusCode::JOINT_BOUND;
-      target_state = haltJoints(joint_variables_to_halt, current_state, target_state);
+      target_state = haltJoints(joint_indices_to_halt, current_state, target_state);
     }
   }
 

--- a/moveit_ros/moveit_servo/src/servo.cpp
+++ b/moveit_ros/moveit_servo/src/servo.cpp
@@ -267,7 +267,7 @@ bool Servo::validateParams(const servo::Params& servo_params)
         logger_, "The parameter 'joint_limit_margins' must have either a single element or the same number of "
                  "elements as the degrees of freedom in the active joint group. The size of 'joint_limit_margins' is '"
                      << servo_params.joint_limit_margins.size() << "' but the number of degrees of freedom in group '"
-                     << servo_params.move_group_name << "' is '" << num_dofs << "'" << check_yaml_string);
+                     << servo_params.move_group_name << "' is '" << num_dofs << "'." << check_yaml_string);
     params_valid = false;
   }
 

--- a/moveit_ros/moveit_servo/src/servo.cpp
+++ b/moveit_ros/moveit_servo/src/servo.cpp
@@ -334,14 +334,14 @@ void Servo::setCommandType(const CommandType& command_type)
   expected_command_type_ = command_type;
 }
 
-KinematicState Servo::haltJoints(const std::vector<size_t>& joint_indices_to_halt, const KinematicState& current_state,
-                                 const KinematicState& target_state) const
+KinematicState Servo::haltJoints(const std::vector<size_t>& joint_variables_to_halt,
+                                 const KinematicState& current_state, const KinematicState& target_state) const
 {
   KinematicState bounded_state(target_state.joint_names.size());
   bounded_state.joint_names = target_state.joint_names;
 
   std::stringstream halting_joint_names;
-  for (const auto idx : joint_indices_to_halt)
+  for (const auto idx : joint_variables_to_halt)
   {
     halting_joint_names << bounded_state.joint_names[idx] + " ";
   }
@@ -361,7 +361,7 @@ KinematicState Servo::haltJoints(const std::vector<size_t>& joint_indices_to_hal
     // Halt only the joints that are out of bounds
     bounded_state.positions = target_state.positions;
     bounded_state.velocities = target_state.velocities;
-    for (const auto idx : joint_indices_to_halt)
+    for (const auto idx : joint_variables_to_halt)
     {
       bounded_state.positions[idx] = current_state.positions[idx];
       bounded_state.velocities[idx] = 0.0;
@@ -534,14 +534,14 @@ KinematicState Servo::getNextJointState(const moveit::core::RobotStatePtr& robot
     target_state.velocities = (target_state.positions - current_state.positions) / servo_params_.publish_period;
 
     // Check if any joints are going past joint position limits.
-    const std::vector<size_t> joint_indices_to_halt =
-        jointsToHalt(target_state.positions, target_state.velocities, joint_bounds, joint_limit_margins_);
+    const std::vector<size_t> joint_variables_to_halt =
+        jointVariablesToHalt(target_state.positions, target_state.velocities, joint_bounds, joint_limit_margins_);
 
     // Apply halting if any joints need to be halted.
-    if (!joint_indices_to_halt.empty())
+    if (!joint_variables_to_halt.empty())
     {
       servo_status_ = StatusCode::JOINT_BOUND;
-      target_state = haltJoints(joint_indices_to_halt, current_state, target_state);
+      target_state = haltJoints(joint_variables_to_halt, current_state, target_state);
     }
   }
 

--- a/moveit_ros/moveit_servo/src/utils/common.cpp
+++ b/moveit_ros/moveit_servo/src/utils/common.cpp
@@ -415,7 +415,6 @@ std::vector<size_t> jointVariablesToHalt(const Eigen::VectorXd& positions, const
   std::vector<size_t> variable_indices_to_halt;
 
   // Now get the scaling factor from joint velocity limits.
-  size_t joint_idx = 0;
   size_t variable_idx = 0;
   for (const auto& joint_bound : joint_bounds)
   {

--- a/moveit_ros/moveit_servo/src/utils/common.cpp
+++ b/moveit_ros/moveit_servo/src/utils/common.cpp
@@ -422,7 +422,7 @@ std::vector<size_t> jointVariablesToHalt(const Eigen::VectorXd& positions, const
     bool halt_joint = false;
     for (const auto& variable_bound : *joint_bound)
     {
-      // First, loop through all the variables to see if
+      // First, loop through all the joint variables to see if the entire joint should be halted.
       if (variable_bound.position_bounded_)
       {
         const bool approaching_negative_bound =

--- a/moveit_ros/moveit_servo/src/utils/common.cpp
+++ b/moveit_ros/moveit_servo/src/utils/common.cpp
@@ -446,8 +446,6 @@ std::vector<size_t> jointVariablesToHalt(const Eigen::VectorXd& positions, const
         }
       }
     }
-
-    ++joint_idx;
   }
   return variable_indices_to_halt;
 }


### PR DESCRIPTION
### Description

This PR allows the `joint_limit_margins` parameter of MoveIt Servo to be a single-element vector (and changes the defaults accordingly, so it works off-the-shelf with every robot).

It also fixes a not-yet-seen issue in which the joint halting logic would have failed if there were multi-DOF Joints. For those who were spammed by this PR, I was making sure this fix was correct, so please give it a look!

Closes https://github.com/moveit/moveit2/issues/2843.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [x] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [x] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [x] Include a screenshot if changing a GUI
- [x] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
