### PR TITLE
Replace obsolete header

### DIFF
--- a/moveit_ros/perception/pointcloud_octomap_updater/include/moveit/pointcloud_octomap_updater/pointcloud_octomap_updater.h
+++ b/moveit_ros/perception/pointcloud_octomap_updater/include/moveit/pointcloud_octomap_updater/pointcloud_octomap_updater.h
@@ -39,10 +39,10 @@
 #include <rclcpp/rclcpp.hpp>
 #include <tf2_ros/transform_listener.h>
 #include <tf2_ros/message_filter.h>
-#if RCLCPP_VERSION_GTE(28, 0, 0)  // Rolling
+#if RCLCPP_VERSION_GTE(28, 3, 3)  // Rolling
 #include <message_filters/subscriber.hpp>
 #else
-#include <message_filters/subscriber.h> // Older versions
+#include <message_filters/subscriber.h>
 #endif
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <moveit/occupancy_map_monitor/occupancy_map_updater.h>

--- a/moveit_ros/perception/pointcloud_octomap_updater/include/moveit/pointcloud_octomap_updater/pointcloud_octomap_updater.h
+++ b/moveit_ros/perception/pointcloud_octomap_updater/include/moveit/pointcloud_octomap_updater/pointcloud_octomap_updater.h
@@ -39,7 +39,11 @@
 #include <rclcpp/rclcpp.hpp>
 #include <tf2_ros/transform_listener.h>
 #include <tf2_ros/message_filter.h>
+#if RCLCPP_VERSION_GTE(28, 0, 0)  // Rolling
 #include <message_filters/subscriber.hpp>
+#else
+#include <message_filters/subscriber.h> // Older versions
+#endif
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <moveit/occupancy_map_monitor/occupancy_map_updater.h>
 #include <moveit/point_containment_filter/shape_mask.h>

--- a/moveit_ros/perception/pointcloud_octomap_updater/include/moveit/pointcloud_octomap_updater/pointcloud_octomap_updater.h
+++ b/moveit_ros/perception/pointcloud_octomap_updater/include/moveit/pointcloud_octomap_updater/pointcloud_octomap_updater.h
@@ -40,7 +40,7 @@
 #include <rclcpp/version.h>
 #include <tf2_ros/transform_listener.h>
 #include <tf2_ros/message_filter.h>
-#if RCLCPP_VERSION_GTE(28, 3, 0)  // Rolling
+#if RCLCPP_VERSION_GTE(28, 3, 3)  // Rolling
 #include <message_filters/subscriber.hpp>
 #else
 #include <message_filters/subscriber.h>

--- a/moveit_ros/perception/pointcloud_octomap_updater/include/moveit/pointcloud_octomap_updater/pointcloud_octomap_updater.h
+++ b/moveit_ros/perception/pointcloud_octomap_updater/include/moveit/pointcloud_octomap_updater/pointcloud_octomap_updater.h
@@ -39,7 +39,7 @@
 #include <rclcpp/rclcpp.hpp>
 #include <tf2_ros/transform_listener.h>
 #include <tf2_ros/message_filter.h>
-#include <message_filters/subscriber.h>
+#include <message_filters/subscriber.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <moveit/occupancy_map_monitor/occupancy_map_updater.h>
 #include <moveit/point_containment_filter/shape_mask.h>

--- a/moveit_ros/perception/pointcloud_octomap_updater/include/moveit/pointcloud_octomap_updater/pointcloud_octomap_updater.h
+++ b/moveit_ros/perception/pointcloud_octomap_updater/include/moveit/pointcloud_octomap_updater/pointcloud_octomap_updater.h
@@ -39,7 +39,7 @@
 #include <rclcpp/rclcpp.hpp>
 #include <tf2_ros/transform_listener.h>
 #include <tf2_ros/message_filter.h>
-#if RCLCPP_VERSION_GTE(28, 3, 3)  // Rolling
+#if RCLCPP_VERSION_GTE(28, 3, 0)  // Rolling
 #include <message_filters/subscriber.hpp>
 #else
 #include <message_filters/subscriber.h>

--- a/moveit_ros/perception/pointcloud_octomap_updater/include/moveit/pointcloud_octomap_updater/pointcloud_octomap_updater.h
+++ b/moveit_ros/perception/pointcloud_octomap_updater/include/moveit/pointcloud_octomap_updater/pointcloud_octomap_updater.h
@@ -37,6 +37,7 @@
 #pragma once
 
 #include <rclcpp/rclcpp.hpp>
+#include <rclcpp/version.h>
 #include <tf2_ros/transform_listener.h>
 #include <tf2_ros/message_filter.h>
 #if RCLCPP_VERSION_GTE(28, 3, 0)  // Rolling


### PR DESCRIPTION
### Description
Fix failing CI
```
  --- stderr: moveit_ros_perception
  In file included from /home/runner/work/moveit2/moveit2/.work/target_ws/src/moveit2/moveit_ros/perception/pointcloud_octomap_updater/include/moveit/pointcloud_octomap_updater/pointcloud_octomap_updater.h:42,
                   from /home/runner/work/moveit2/moveit2/.work/target_ws/src/moveit2/moveit_ros/perception/pointcloud_octomap_updater/src/pointcloud_octomap_updater.cpp:38:
  /opt/ros/rolling/include/message_filters/message_filters/subscriber.h:18:2: error: #warning This header is obsolete, please include message_filters/subscriber.hpp instead [-Werror=cpp]
     18 | #warning This header is obsolete, please include message_filters/subscriber.hpp instead
        |  ^~~~~~~
```

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
