### PR TITLE
fix missing gz_plugin_vendor

### DIFF
--- a/moveit2_humble.repos
+++ b/moveit2_humble.repos
@@ -3,3 +3,7 @@ repositories:
     type: git
     url: https://github.com/PickNikRobotics/generate_parameter_library.git
     version: 0.3.7
+  gz_plugin_vendor
+    type: git
+    url: https://github.com/gazebo-release/gz_plugin_vendor.git
+    vendor: jazzy


### PR DESCRIPTION
fix missing gz_plugin_vendor  into humble distro

### Description

Please explain the changes you made, including a reference to the related issue if applicable

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
