### PR TITLE
Update ompl_interface with latest version of OMPL

### DIFF
--- a/moveit2.repos
+++ b/moveit2.repos
@@ -12,3 +12,7 @@ repositories:
     type: git
     url: https://github.com/moveit/moveit_resources.git
     version: ros2
+  ompl:
+    type: git
+    url: https://github.com/ompl/ompl.git
+    version: main

--- a/moveit_planners/ompl/CMakeLists.txt
+++ b/moveit_planners/ompl/CMakeLists.txt
@@ -27,7 +27,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)")
 endif()
 
 include_directories(ompl_interface/include)
-include_directories(SYSTEM ${Boost_INCLUDE_DIRS} ${OMPL_INCLUDE_DIRS})
+include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 
 add_subdirectory(ompl_interface)
 

--- a/moveit_planners/ompl/ompl_interface/CMakeLists.txt
+++ b/moveit_planners/ompl/ompl_interface/CMakeLists.txt
@@ -38,17 +38,17 @@ ament_target_dependencies(
   pluginlib
   tf2_eigen
   tf2_ros
-  OMPL
   Boost)
 set_target_properties(
   moveit_ompl_interface PROPERTIES COMPILE_FLAGS
                                    "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
 set_target_properties(moveit_ompl_interface PROPERTIES LINK_FLAGS
                                                        "${OpenMP_CXX_FLAGS}")
-
+target_link_libraries(moveit_ompl_interface ompl::ompl)
 add_executable(moveit_generate_state_database
                scripts/generate_state_database.cpp)
-target_link_libraries(moveit_generate_state_database moveit_ompl_interface)
+target_link_libraries(moveit_generate_state_database moveit_ompl_interface
+                      ompl::ompl)
 set_target_properties(moveit_generate_state_database
                       PROPERTIES LINK_FLAGS "${OpenMP_CXX_FLAGS}")
 set_target_properties(moveit_generate_state_database
@@ -64,9 +64,9 @@ ament_target_dependencies(
   rclcpp
   pluginlib
   tf2_ros
-  OMPL
   Boost)
-target_link_libraries(moveit_ompl_planner_plugin moveit_ompl_interface)
+target_link_libraries(moveit_ompl_planner_plugin moveit_ompl_interface
+                      ompl::ompl)
 
 install(TARGETS moveit_generate_state_database
         RUNTIME DESTINATION lib/${PROJECT_NAME})
@@ -77,24 +77,26 @@ if(BUILD_TESTING)
   find_package(Eigen3 REQUIRED)
 
   ament_add_gtest(test_state_space test/test_state_space.cpp)
-  ament_target_dependencies(test_state_space moveit_core OMPL Boost Eigen3)
-  target_link_libraries(test_state_space moveit_ompl_interface)
+  ament_target_dependencies(test_state_space moveit_core Boost Eigen3)
+  target_link_libraries(test_state_space moveit_ompl_interface ompl::ompl)
   set_target_properties(test_state_space PROPERTIES LINK_FLAGS
                                                     "${OpenMP_CXX_FLAGS}")
 
   ament_add_gtest(test_state_validity_checker
                   test/test_state_validity_checker.cpp)
-  ament_target_dependencies(test_state_validity_checker moveit_core OMPL Boost
+  ament_target_dependencies(test_state_validity_checker moveit_core Boost
                             Eigen3)
-  target_link_libraries(test_state_validity_checker moveit_ompl_interface)
+  target_link_libraries(test_state_validity_checker moveit_ompl_interface
+                        ompl::ompl)
   set_target_properties(test_state_validity_checker
                         PROPERTIES LINK_FLAGS "${OpenMP_CXX_FLAGS}")
 
   ament_add_gtest(test_planning_context_manager
                   test/test_planning_context_manager.cpp)
   ament_target_dependencies(test_planning_context_manager moveit_core tf2_eigen
-                            OMPL Boost Eigen3)
-  target_link_libraries(test_planning_context_manager moveit_ompl_interface)
+                            Boost Eigen3)
+  target_link_libraries(test_planning_context_manager moveit_ompl_interface
+                        ompl::ompl)
 
   # Disabling flaky test TODO (vatanaksoytezer): Uncomment once this is fixed
   # ament_add_gtest(test_ompl_constraints test/test_ompl_constraints.cpp)
@@ -104,26 +106,27 @@ if(BUILD_TESTING)
   ament_add_gtest(test_constrained_planning_state_space
                   test/test_constrained_planning_state_space.cpp)
   ament_target_dependencies(test_constrained_planning_state_space moveit_core
-                            OMPL Boost Eigen3)
+                            Boost Eigen3)
   target_link_libraries(test_constrained_planning_state_space
-                        moveit_ompl_interface)
+                        moveit_ompl_interface ompl::ompl)
   set_target_properties(test_constrained_planning_state_space
                         PROPERTIES LINK_FLAGS "${OpenMP_CXX_FLAGS}")
 
   ament_add_gtest(test_constrained_state_validity_checker
                   test/test_constrained_state_validity_checker.cpp)
   ament_target_dependencies(test_constrained_state_validity_checker moveit_core
-                            OMPL Boost Eigen3)
+                            Boost Eigen3)
   target_link_libraries(test_constrained_state_validity_checker
-                        moveit_ompl_interface)
+                        moveit_ompl_interface ompl::ompl)
   set_target_properties(test_constrained_state_validity_checker
                         PROPERTIES LINK_FLAGS "${OpenMP_CXX_FLAGS}")
 
   ament_add_gtest(test_threadsafe_state_storage
                   test/test_threadsafe_state_storage.cpp)
-  ament_target_dependencies(test_threadsafe_state_storage moveit_core OMPL
-                            Boost Eigen3)
-  target_link_libraries(test_threadsafe_state_storage moveit_ompl_interface)
+  ament_target_dependencies(test_threadsafe_state_storage moveit_core Boost
+                            Eigen3)
+  target_link_libraries(test_threadsafe_state_storage moveit_ompl_interface
+                        ompl::ompl)
   set_target_properties(test_threadsafe_state_storage
                         PROPERTIES LINK_FLAGS "${OpenMP_CXX_FLAGS}")
 


### PR DESCRIPTION
### Description

I'm working on debugging some issues and require building MoveIt2 and OMPL from source. This PR updates the package `moveit_planners_ompl` to work with the latest changes made in OMPL and it's more modern approach to exporting the library but will require building it from source until a new release is made (I am working on getting it released and will keep this PR updated with the status). 

I was also having issues with OMPL but that package was recently updated to properly work with Colcon. [Here is a link](https://github.com/ompl/ompl/issues/1175) to the issue.

Big thanks to @JafarAbdi for helping me debug some of these issues and getting this updated! :1st_place_medal: 

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
