### PR TITLE
Export the IKFast library correctly

### DIFF
--- a/moveit_kinematics/ikfast_kinematics_plugin/templates/CMakeLists.txt
+++ b/moveit_kinematics/ikfast_kinematics_plugin/templates/CMakeLists.txt
@@ -52,6 +52,7 @@ pluginlib_export_plugin_description_file(
   moveit_core _ROBOT_NAME___GROUP_NAME__moveit_ikfast_plugin_description.xml)
 
 ament_export_targets(${PROJECT_NAME}Targets HAS_LIBRARY_TARGET)
+ament_export_libraries(${IKFAST_LIBRARY_NAME})
 ament_export_dependencies(moveit_core)
 ament_export_dependencies(pluginlib)
 ament_export_dependencies(rclcpp)


### PR DESCRIPTION
### Description

This exports an IKFast plugin library correctly. I got a strong hint from the comment here:

https://github.com/moveit/moveit2/issues/2144#issuecomment-1547967425
