### PR TITLE
have moveit_planners depend on chomp

### DIFF
--- a/moveit_planners/moveit_planners/package.xml
+++ b/moveit_planners/moveit_planners/package.xml
@@ -20,9 +20,9 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <!--
-  <exec_depend>chomp_motion_planner</exec_depend>
   <exec_depend>moveit_planners_chomp</exec_depend>
   -->
+  <exec_depend>chomp_motion_planner</exec_depend>
   <exec_depend>moveit_planners_ompl</exec_depend>
   <exec_depend>moveit_planners_stomp</exec_depend>
   <exec_depend>pilz_industrial_motion_planner</exec_depend>

--- a/moveit_planners/moveit_planners/package.xml
+++ b/moveit_planners/moveit_planners/package.xml
@@ -19,9 +19,6 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <!--
-  <exec_depend>moveit_planners_chomp</exec_depend>
-  -->
   <exec_depend>chomp_motion_planner</exec_depend>
   <exec_depend>moveit_planners_ompl</exec_depend>
   <exec_depend>moveit_planners_stomp</exec_depend>


### PR DESCRIPTION
### Description

By default, the packages generated by moveit_setup_assistant now include a chomp configuration - but do not depend on chomp. the packages do depend on moveit_planners, so it makes sense to include chomp here.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers
