### PR TITLE
Obtain time from node.

### DIFF
--- a/moveit_ros/moveit_servo/src/servo.cpp
+++ b/moveit_ros/moveit_servo/src/servo.cpp
@@ -648,8 +648,8 @@ KinematicState Servo::getCurrentRobotState(bool block_for_current_state) const
     bool have_current_state = false;
     while (rclcpp::ok() && !have_current_state)
     {
-      have_current_state = planning_scene_monitor_->getStateMonitor()->waitForCurrentState(
-          rclcpp::Clock(RCL_ROS_TIME).now(), ROBOT_STATE_WAIT_TIME /* s */);
+      have_current_state =
+          planning_scene_monitor_->getStateMonitor()->waitForCurrentState(node_->now(), ROBOT_STATE_WAIT_TIME /* s */);
       if (!have_current_state)
       {
         RCLCPP_WARN(logger_, "Waiting for the current state");


### PR DESCRIPTION
### Description

If I use the moveit_servo servo_node in combination with Gazebo simulation, the `moveit_ros.current_state_monitor` complains that it doesn't receive robot state with recent timestamp. I launch all nodes with the 'use_sim_time' set to True, however the current_state_monitor still seems to use wall time. A similar problem was explained in this issue, although not for moveit_servo:

https://github.com/moveit/moveit2/issues/2906

My solution is to change the code from `rclcpp::Clock(RCL_ROS_TIME).now()` to `node_->now()`, such that the time is obtained from the node, which is launched with 'use_sim_time' set to True, so that it gives the sim time. This fixes my problem for the moveit_servo node, but will probably not fix the problem in the issue I mentioned.

This is my first contribution. I would like to hear feedback about this suggested change!


### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
