### PR TITLE
Cast of "max_velocity" and "max_acceleration" values to double (backport #2803)

### DIFF
--- a/moveit_setup_assistant/moveit_setup_framework/src/srdf_config.cpp
+++ b/moveit_setup_assistant/moveit_setup_framework/src/srdf_config.cpp
@@ -296,7 +296,7 @@ bool SRDFConfig::GeneratedJointLimits::writeYaml(YAML::Emitter& emitter)
 
     // Output property
     emitter << YAML::Key << "max_velocity";
-    emitter << YAML::Value << std::min(fabs(b.max_velocity_), fabs(b.min_velocity_));
+    emitter << YAML::Value << static_cast<double>(std::min(fabs(b.max_velocity_), fabs(b.min_velocity_)));
 
     // Output property
     emitter << YAML::Key << "has_acceleration_limits";
@@ -307,7 +307,7 @@ bool SRDFConfig::GeneratedJointLimits::writeYaml(YAML::Emitter& emitter)
 
     // Output property
     emitter << YAML::Key << "max_acceleration";
-    emitter << YAML::Value << std::min(fabs(b.max_acceleration_), fabs(b.min_acceleration_));
+    emitter << YAML::Value << static_cast<double>(std::min(fabs(b.max_acceleration_), fabs(b.min_acceleration_)));
 
     emitter << YAML::EndMap;
   }


### PR DESCRIPTION
### Description

Cherry pick #2803 to humble

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
