### PR TITLE
Enhancement/moveit ros1 ports

### DIFF
--- a/moveit_planners/pilz_industrial_motion_planner/src/command_list_manager.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/command_list_manager.cpp
@@ -182,7 +182,8 @@ void CommandListManager::setStartState(const MotionResponseCont& motion_plan_res
   RobotState_OptRef rob_state_op{ getPreviousEndState(motion_plan_responses, group_name) };
   if (rob_state_op)
   {
-    moveit::core::robotStateToRobotStateMsg(rob_state_op.value(), start_state);
+    moveit::core::robotStateToRobotStateMsg(rob_state_op.value(), start_state, false);
+    start_state.is_diff = true;
   }
 }
 

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -135,6 +135,7 @@ public:
       throw std::runtime_error(error);
     }
 
+    setStartStateToCurrentState();
     joint_model_group_ = getRobotModel()->getJointModelGroup(opt.group_name);
 
     joint_state_target_ = std::make_shared<moveit::core::RobotState>(getRobotModel());
@@ -406,28 +407,30 @@ public:
     return *joint_state_target_;
   }
 
+  void setStartState(const moveit_msgs::msg::RobotState& start_state)
+  {
+    considered_start_state_ = start_state;
+  }
+
   void setStartState(const moveit::core::RobotState& start_state)
   {
-    considered_start_state_ = std::make_shared<moveit::core::RobotState>(start_state);
+    considered_start_state_ = moveit_msgs::msg::RobotState();
+    moveit::core::robotStateToRobotStateMsg(start_state, considered_start_state_, true);
   }
 
   void setStartStateToCurrentState()
   {
-    considered_start_state_.reset();
+    // set message to empty diff
+    considered_start_state_ = moveit_msgs::msg::RobotState();
+    considered_start_state_.is_diff = true;
   }
 
   moveit::core::RobotStatePtr getStartState()
   {
-    if (considered_start_state_)
-    {
-      return considered_start_state_;
-    }
-    else
-    {
-      moveit::core::RobotStatePtr s;
-      getCurrentState(s);
-      return s;
-    }
+    moveit::core::RobotStatePtr s;
+    getCurrentState(s);
+    moveit::core::robotStateMsgToRobotState(considered_start_state_, *s, true);
+    return s;
   }
 
   bool setJointValueTarget(const geometry_msgs::msg::Pose& eef_pose, const std::string& end_effector_link,
@@ -1006,18 +1009,6 @@ public:
     return allowed_planning_time_;
   }
 
-  void constructRobotState(moveit_msgs::msg::RobotState& state) const
-  {
-    if (considered_start_state_)
-    {
-      moveit::core::robotStateToRobotStateMsg(*considered_start_state_, state);
-    }
-    else
-    {
-      state.is_diff = true;
-    }
-  }
-
   void constructMotionPlanRequest(moveit_msgs::msg::MotionPlanRequest& request) const
   {
     request.group_name = opt_.group_name;
@@ -1028,8 +1019,7 @@ public:
     request.pipeline_id = planning_pipeline_id_;
     request.planner_id = planner_id_;
     request.workspace_parameters = workspace_parameters_;
-
-    constructRobotState(request.start_state);
+    request.start_state = considered_start_state_;
 
     if (active_target_ == JOINT)
     {
@@ -1217,7 +1207,7 @@ private:
   std::shared_ptr<rclcpp_action::Client<moveit_msgs::action::ExecuteTrajectory>> execute_action_client_;
 
   // general planning params
-  moveit::core::RobotStatePtr considered_start_state_;
+  moveit_msgs::msg::RobotState considered_start_state_;
   moveit_msgs::msg::WorkspaceParameters workspace_parameters_;
   double allowed_planning_time_;
   std::string planning_pipeline_id_;
@@ -1484,18 +1474,7 @@ void MoveGroupInterface::stop()
 
 void MoveGroupInterface::setStartState(const moveit_msgs::msg::RobotState& start_state)
 {
-  moveit::core::RobotStatePtr rs;
-  if (start_state.is_diff)
-  {
-    impl_->getCurrentState(rs);
-  }
-  else
-  {
-    rs = std::make_shared<moveit::core::RobotState>(getRobotModel());
-    rs->setToDefaultValues();  // initialize robot state values for conversion
-  }
-  moveit::core::robotStateMsgToRobotState(start_state, *rs);
-  setStartState(*rs);
+  impl_->setStartState(start_state);
 }
 
 void MoveGroupInterface::setStartState(const moveit::core::RobotState& start_state)

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -865,8 +865,7 @@ public:
     auto req = std::make_shared<moveit_msgs::srv::GetCartesianPath::Request>();
     moveit_msgs::srv::GetCartesianPath::Response::SharedPtr response;
 
-    constructRobotState(req->start_state);
-
+    req->start_state = considered_start_state_;
     req->group_name = opt_.group_name;
     req->header.frame_id = getPoseReferenceFrame();
     req->header.stamp = getClock()->now();
@@ -1007,6 +1006,11 @@ public:
   double getPlanningTime() const
   {
     return allowed_planning_time_;
+  }
+
+  void constructRobotState(moveit_msgs::msg::RobotState& state) const
+  {
+    state = considered_start_state_;
   }
 
   void constructMotionPlanRequest(moveit_msgs::msg::MotionPlanRequest& request) const


### PR DESCRIPTION
### Description

This PR ports the following ROS1 PRs to moveit2:
- https://github.com/moveit/moveit/pull/3590
- https://github.com/moveit/moveit/pull/3592

More in-depth descriptions can be found on those pull requests, however, for summary:

- Modifies `MoveGroupInterace` to use a `moveit_msgs::msgs::RobotSate` as the `considered_start_state_`
   - This prevents unnecessary conversions to and from message types when planning
   - This allows start states to be set using `RobotState` diffs to avoid passing around large messages
   - Public methods are modified to continue returning `robot_state::RobotStatePtr` to avoid breaking changes

- Disables updating of attached collision objects when updating states during a pilz sequence motion
  - This prevents unnecessary copying of attached collision objects, which do not change throughout a sequence plan
  - This fixes a bug where the poses of attached collision objects accumulate error throughout a sequence plan

I've more-or-less copied the changes from those PRs in verbatim, so if there are differences in moveit2 that need to be taken into account, let me know and I'll make them.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/) (No changes to user-facing functionality)
- [x] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes (preserves existing API)
- [x] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html) (Modifies implementation details. Should preserve existing test behaviour)
- [x] Include a screenshot if changing a GUI (No GUI changes)
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
