### PR TITLE
Switch to get for Dict lookup to prevent KeyError

### DIFF
--- a/moveit_configs_utils/moveit_configs_utils/launches.py
+++ b/moveit_configs_utils/moveit_configs_utils/launches.py
@@ -249,7 +249,7 @@ def generate_move_group_launch(moveit_config):
         parameters=move_group_params,
         extra_debug_args=["--debug"],
         # Set the display variable, in case OpenGL code is used internally
-        additional_env={"DISPLAY": os.environ["DISPLAY"]},
+        additional_env={"DISPLAY": os.environ.get("DISPLAY", "")},
     )
     return ld
 


### PR DESCRIPTION
### Description

If you run the default generated configs for MoveIt on a headless system where `DISPLAY` isn't defined in the environment, this code crashes with a `KeyError`. Switch to use `dict.get(DISPLAY, "")` which returns `""` instead of
throwing.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
