### PR TITLE
Fix flipped comments in `joint_model.h`

### DIFF
--- a/moveit_core/robot_model/include/moveit/robot_model/joint_model.h
+++ b/moveit_core/robot_model/include/moveit/robot_model/joint_model.h
@@ -514,10 +514,10 @@ protected:
   /** \brief The joint this one mimics (nullptr for joints that do not mimic) */
   const JointModel* mimic_;
 
-  /** \brief The offset to the mimic joint */
+  /** \brief The multiplier to the mimic joint */
   double mimic_factor_;
 
-  /** \brief The multiplier to the mimic joint */
+  /** \brief The offset to the mimic joint */
   double mimic_offset_;
 
   /** \brief The set of joints that should get a value copied to them when this joint changes */


### PR DESCRIPTION
### Description

I was reading a file and noticed the comments were backwards. Tiny change.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
