### PR TITLE
Add vel and acc scaling to computeCartesianPath in Humble

### DIFF
--- a/moveit_ros/move_group/src/default_capabilities/cartesian_path_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/cartesian_path_service_capability.cpp
@@ -177,7 +177,7 @@ bool MoveGroupCartesianPathService::computeService(
           // time trajectory
           // \todo optionally compute timing to move the eef with constant speed
           trajectory_processing::TimeOptimalTrajectoryGeneration time_param;
-          time_param.computeTimeStamps(rt, 1.0);
+          time_param.computeTimeStamps(rt, req->max_velocity_scaling_factor, req->max_acceleration_scaling_factor);
 
           rt.getRobotTrajectoryMsg(res->solution);
           RCLCPP_INFO(LOGGER, "Computed Cartesian path with %u points (followed %lf%% of requested trajectory)",

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -969,6 +969,8 @@ public:
     req->path_constraints = path_constraints;
     req->avoid_collisions = avoid_collisions;
     req->link_name = getEndEffectorLink();
+    req->max_velocity_scaling_factor = max_velocity_scaling_factor_;
+    req->max_acceleration_scaling_factor = max_acceleration_scaling_factor_;
 
     auto future_response = cartesian_path_service_->async_send_request(req);
     if (future_response.valid())


### PR DESCRIPTION
### Description

Hello, I'm back !

Made some more changes to properly integrate velocity and acceleration control to Cartesian Path Planning on the Humble branch of this repository.  Also opened a PR on <a href=https://github.com/moveit/moveit_msgs>moveit/moveit_msgs</a> to add these controls to the proper interface <a href="https://github.com/moveit/moveit_msgs/pull/184?notification_referrer_id=NT_kwDOCH6F6bUxMzEyMjgwMjkwOToxNDI1MDk1NDU#issuecomment-2483269402">#184</a>

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
