### PR TITLE
[moveit_servo] avoid race condition when calling ~/pause_servo

### DIFF
--- a/moveit_ros/moveit_servo/include/moveit_servo/servo_node.hpp
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo_node.hpp
@@ -133,6 +133,9 @@ private:
   // Threads used by ServoNode
   std::thread servo_loop_thread_;
 
+  // Locks for threads safety
+  std::mutex lock_;
+
   // rolling window of joint commands
   std::deque<KinematicState> joint_cmd_rolling_window_;
 };

--- a/moveit_ros/moveit_servo/src/servo_node.cpp
+++ b/moveit_ros/moveit_servo/src/servo_node.cpp
@@ -151,6 +151,7 @@ void ServoNode::pauseServo(const std::shared_ptr<std_srvs::srv::SetBool::Request
   }
   else
   {
+    std::lock_guard<std::mutex> lock_guard(lock_);
     // Reset the smoothing plugin with the robot's current state in case the robot moved between pausing and unpausing.
     last_commanded_state_ = servo_->getCurrentRobotState(true /* block for current robot state */);
     servo_->resetSmoothing(last_commanded_state_);
@@ -320,6 +321,7 @@ void ServoNode::servoLoop()
       continue;
     }
 
+    std::lock_guard<std::mutex> lock_guard(lock_);
     const bool use_trajectory = servo_params_.command_out_type == "trajectory_msgs/JointTrajectory";
     const auto cur_time = node_->now();
 


### PR DESCRIPTION
### Description

`pauseServo` and `servoLoop` are running in two different threads, we should use a mutex to avoid race condition.


here is a core dump sample of race condition, when `pauseServo` and `servoLoop` both calling `joint_cmd_rolling_window_.clear()`
```text
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/aarch64-linux-gnu/libthread_db.so.1".
Core was generated by `/packages/moveit_servo/lib/moveit_servo/servo_node --ros-args -r'.
Program terminated with signal SIGSEGV, Segmentation fault.

#0  0x0000ffff9f32dbf4 in __GI___libc_free (mem=0xfff097f6d2fb) at ./malloc/malloc.c:3368
3368	./malloc/malloc.c: No such file or directory.
[Current thread is 1 (Thread 0xffff94aae8e0 (LWP 454))]
(gdb)
(gdb)
(gdb)
(gdb)
(gdb) bt
#0  0x0000ffff9f32dbf4 in __GI___libc_free (mem=0xfff097f6d2fb) at ./malloc/malloc.c:3368
#1  0x0000ffff9dcbc36c in __gnu_cxx::new_allocator<char>::deallocate (__t=<optimized out>, __p=<optimized out>, this=0xffff6800b800)
    at /usr/include/c++/11/ext/new_allocator.h:145
#2  std::allocator_traits<std::allocator<char> >::deallocate (__n=<optimized out>, __p=<optimized out>, __a=...) at /usr/include/c++/11/bits/alloc_traits.h:496
#3  std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_destroy (__size=<optimized out>, this=0xffff6800b800)
    at /usr/include/c++/11/bits/basic_string.h:245
#4  std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_dispose (this=0xffff6800b800) at /usr/include/c++/11/bits/basic_string.h:240
#5  std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::~basic_string (this=0xffff6800b800, __in_chrg=<optimized out>)
    at /usr/include/c++/11/bits/basic_string.h:672
#6  std::_Destroy<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > (__pointer=0xffff6800b800) at /usr/include/c++/11/bits/stl_construct.h:151
#7  std::_Destroy_aux<false>::__destroy<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*> (__last=<optimized out>, __first=0xffff6800b800)
    at /usr/include/c++/11/bits/stl_construct.h:163
#8  std::_Destroy<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*> (__last=<optimized out>, __first=<optimized out>)
    at /usr/include/c++/11/bits/stl_construct.h:196
#9  std::_Destroy<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > (__last=0xffff6800b8c0, __first=<optimized out>) at /usr/include/c++/11/bits/alloc_traits.h:848
#10 std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >::~vector (this=0xffff68012550, __in_chrg=<optimized out>) at /usr/include/c++/11/bits/stl_vector.h:680
#11 moveit_servo::KinematicState::~KinematicState (this=0xffff68012550, __in_chrg=<optimized out>) at /workspace/source/moveit_servo/include/moveit_servo/utils/datatypes.hpp:114
#12 std::_Destroy<moveit_servo::KinematicState> (__pointer=0xffff68012550) at /usr/include/c++/11/bits/stl_construct.h:151
#13 std::_Destroy_aux<false>::__destroy<moveit_servo::KinematicState*> (__last=<optimized out>, __first=0xffff68012550) at /usr/include/c++/11/bits/stl_construct.h:163
#14 std::_Destroy<moveit_servo::KinematicState*> (__last=<optimized out>, __first=<optimized out>) at /usr/include/c++/11/bits/stl_construct.h:196
#15 std::_Destroy<moveit_servo::KinematicState*, moveit_servo::KinematicState> (__last=0xffff68012730, __first=0xffff68012550) at /usr/include/c++/11/bits/alloc_traits.h:848
#16 std::deque<moveit_servo::KinematicState, std::allocator<moveit_servo::KinematicState> >::_M_destroy_data_aux (
  __first={joint_names = std::vector of length 6, capacity 6 = {"\000\000\000\000\000\000\360?\321\000\000\000\000\000\000\000\260\317\000h\377\377\000\000PT\000h\377\377\000\000j1\000\324\004/ɿ\224IC\301\350F\345\277И\001h\377\377\000\000\002\000\000\000\000\000\000\000j2\000W~W\252?\b\273B\217yz\325?\360\230\001h\377\377\000\000\002\000\000\000\000\000\000\000j3\000}x鶿\n:\236\200\314\361\355\277\020\231\001h\377\377\000\000\002\000\000\000\000\000\000\000j4\000\274\017\337\306?x}\337,A\200\342\277\060\231\001h\377\377\000\000\002\000\000\000\000\000\000\000j5\000\005\224.Ͽ\225\aH\004\262?\340\277P\231\001h\377\377\000\000\002\000\000\000\000\000\000\000j6\000\275N3ֿ"..., "j2", "j3", "j4", "j5", "j6"}, positions = {<Eigen::PlainObjectBase<Eigen::Matrix<double, -1, 1, 0, -1, 1> >> = {<Eigen::MatrixBase<Eigen::Matrix<double, -1, 1, 0, -1, 1> >> = {<Eigen::DenseBase<Eigen::Matrix<double, -1, 1, 0, -1, 1> >> = {<Eigen::DenseCoeffsBase<Eigen::Matrix<double, -1, 1, 0, -1, 1>, 3>> = {<Eigen::DenseCoeffsBase<Eigen::Matrix<double, -1, 1, 0, -1, 1>, 1>> = {<Eigen::DenseCoeffsBase<Eigen::Matrix<double, -1, 1, 0, -1, 1>, 0>> = {<Eigen::EigenBase<Eigen::Matrix<double, -1, 1, 0, -1, 1> >> = {<No data fields>}, <No data fields>}, <No data fields>}, <No data fields>}, <No data fields>}, <No data fields>}, m_storage = {m_data = 0xffff680154a0, m_rows = 6}}, <No data fields>}, velocities = {<Eigen::PlainObjectBase<Eigen::Matrix<double, -1, 1, 0, -1, 1> >> = {<Eigen::MatrixBase<Eigen::Matrix<double, -1, 1, 0, -1, 1> >> = {<Eigen::DenseBase<Eigen::Matrix<double, -1, 1, 0, -1, 1> >> = {<Eigen::DenseCoeffsBase<Eigen::Matrix<double, -1, 1, 0, -1, 1>, 3>> = {<Eigen::DenseCoeffsBase<Eigen::Matrix<double, -1, 1, 0, -1, 1>, 1>> = {<Eigen::DenseCoeffsBase<Eigen::Matrix<double, -1, 1, 0, -1, 1>, 0>> = {<Eigen::EigenBase<Eigen::Matrix<double, -1, 1, 0, -1, 1> >> = {<No data fields>}, <No data fields>}, <No data fields>}, <No data fields>}, <No data fields>}, <No data fields>}, m_storage = {m_data = 0xffff680154e0, m_rows = 6}}, <No data fields>}, accelerations = {<Eigen::PlainObjectBase<Eigen::Matrix<double, -1, 1, 0, -1, 1> >> = {<Eigen::MatrixBase<Eigen::Matrix<double, -1, 1, 0, -1, 1> >> = {<Eigen::DenseBase<Eigen::Matrix<double, -1, 1, 0, -1, 1> >> = {<Eigen::DenseCoeffsBase<Eigen::Matrix<double, -1, 1, 0, -1, 1>, 3>> = {<Eigen::DenseCoeffsBase<Eigen::Matrix<double, -1, 1, 0, -1, 1>, 1>> = {<Eigen::DenseCoeffsBase<Eigen::Matrix<double, -1, 1, 0, -1, 1>, 0>> = {<Eigen::EigenBase<Eigen::Matrix<double, -1, 1, 0, -1, 1> >> = {<No data fields>}, <No data fields>}, <No data fields>}, <No data fields>}, <No data fields>}, <No data fields>}, m_storage = {m_data = 0xffff68019e80, m_rows = 6}}, <No data fields>}, time_stamp = <incomplete type>},
    __last={joint_names = std::vector of length -2147464192, capacity 8793865868214 = {<error reading variable: Cannot access memory at address 0xffff6801a>, this=<optimized out>)
    at /usr/include/c++/11/bits/deque.tcc:864
#17 0x0000ffff9dcbf044 in std::deque<moveit_servo::KinematicState, std::allocator<moveit_servo::KinematicState> >::_M_destroy_data (this=0xaaaaea706828, __last=..., __first=...)
    at /usr/include/c++/11/bits/stl_deque.h:2049
#18 std::deque<moveit_servo::KinematicState, std::allocator<moveit_servo::KinematicState> >::_M_erase_at_end (__pos=..., this=0xaaaaea706828)
    at /usr/include/c++/11/bits/stl_deque.h:2066
#19 std::deque<moveit_servo::KinematicState, std::allocator<moveit_servo::KinematicState> >::clear (this=0xaaaaea706828) at /usr/include/c++/11/bits/stl_deque.h:1794
#20 moveit_servo::ServoNode::servoLoop (this=0xaaaaea706380) at /workspace/source/moveit_servo/src/servo_node.cpp:331
#21 0x0000ffff9f5531fc in ?? () from /lib/aarch64-linux-gnu/libstdc++.so.6
#22 0x0000ffff9f31d5c8 in start_thread (arg=0x0) at ./nptl/pthread_create.c:442
#23 0x0000ffff9f385edc in thread_start () at ../sysdeps/unix/sysv/linux/aarch64/clone.S:79
```




### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
