### PR TITLE
CI: Allow non-interactive installation of rmw-connextdds

### DIFF
--- a/.docker/release/Dockerfile
+++ b/.docker/release/Dockerfile
@@ -5,6 +5,9 @@ ARG ROS_DISTRO=rolling
 FROM ros:${ROS_DISTRO}-ros-base
 LABEL maintainer Robert Haschke rhaschke@techfak.uni-bielefeld.de
 
+# Allow non-interactive installation of ros-*-rmw-connextdds
+ENV RTI_NC_LICENSE_ACCEPTED yes
+
 # Commands are combined in single RUN statement with "apt/lists" folder removal to reduce image size
 RUN apt-get update -q && \
     apt-get upgrade -q -y && \


### PR DESCRIPTION
Port #2790. Fixes https://github.com/moveit/moveit_task_constructor/actions/runs/11687907179/job/32547096849.