### PR TITLE
Parallelize the Collision Checking at CHOMP using OpenMP

### DIFF
--- a/moveit_planners/chomp/chomp_motion_planner/CMakeLists.txt
+++ b/moveit_planners/chomp/chomp_motion_planner/CMakeLists.txt
@@ -25,6 +25,12 @@ set_target_properties(chomp_motion_planner
                       PROPERTIES VERSION "${chomp_motion_planner_VERSION}")
 ament_target_dependencies(chomp_motion_planner ${THIS_PACKAGE_INCLUDE_DEPENDS})
 
+find_package(OpenMP REQUIRED)
+if(OPENMP_FOUND)
+    target_link_libraries(chomp_motion_planner PUBLIC OpenMP::OpenMP_CXX)
+endif()
+
+
 install(
   TARGETS chomp_motion_planner
   EXPORT chomp_motion_plannerTargets

--- a/moveit_planners/chomp/chomp_motion_planner/CMakeLists.txt
+++ b/moveit_planners/chomp/chomp_motion_planner/CMakeLists.txt
@@ -14,6 +14,11 @@ find_package(trajectory_msgs REQUIRED)
 
 set(THIS_PACKAGE_INCLUDE_DEPENDS moveit_core rclcpp rsl trajectory_msgs
                                  visualization_msgs)
+# Check if OpenMP is available, and add it to dependencies if so
+find_package(OpenMP)
+if(OpenMP_FOUND)
+  list(APPEND THIS_PACKAGE_INCLUDE_DEPENDS OpenMP)
+endif()
 
 include_directories(include)
 
@@ -25,10 +30,7 @@ set_target_properties(chomp_motion_planner
                       PROPERTIES VERSION "${chomp_motion_planner_VERSION}")
 ament_target_dependencies(chomp_motion_planner ${THIS_PACKAGE_INCLUDE_DEPENDS})
 
-find_package(OpenMP REQUIRED)
-if(OPENMP_FOUND)
-    target_link_libraries(chomp_motion_planner PUBLIC OpenMP::OpenMP_CXX)
-endif()
+target_compile_options(chomp_motion_planner PRIVATE -fopenmp)
 
 
 install(

--- a/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_cost.h
+++ b/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_cost.h
@@ -79,7 +79,10 @@ template <typename Derived>
 void ChompCost::getDerivative(const Eigen::MatrixXd::ColXpr& joint_trajectory,
                               Eigen::MatrixBase<Derived>& derivative) const
 {
-  derivative = (quad_cost_full_ * (2.0 * joint_trajectory));
+  if (quad_cost_full_.size() == 0) {
+    throw std::runtime_error("Error: Quadratic cost matrix is not initialized.");
+  }
+  derivative = 2.0 * (quad_cost_full_.lazyProduct(joint_trajectory));
 }
 
 inline const Eigen::MatrixXd& ChompCost::getQuadraticCostInverse() const
@@ -94,7 +97,10 @@ inline const Eigen::MatrixXd& ChompCost::getQuadraticCost() const
 
 inline double ChompCost::getCost(const Eigen::MatrixXd::ColXpr& joint_trajectory) const
 {
-  return joint_trajectory.dot(quad_cost_full_ * joint_trajectory);
+  if (quad_cost_full_.size() == 0) {
+    throw std::runtime_error("Error: Quadratic cost matrix is not initialized.");
+  }
+  return joint_trajectory.dot(quad_cost_full_.lazyProduct(joint_trajectory));
 }
 
 }  // namespace chomp

--- a/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_optimizer.h
+++ b/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_optimizer.h
@@ -48,6 +48,8 @@
 #include <Eigen/StdVector>
 #include <vector>
 
+#include <omp.h>
+
 namespace chomp
 {
 class ChompOptimizer

--- a/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_trajectory.h
+++ b/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_trajectory.h
@@ -224,12 +224,6 @@ inline double ChompTrajectory::operator()(size_t traj_point, size_t joint) const
 
 inline Eigen::MatrixXd::RowXpr ChompTrajectory::getTrajectoryPoint(int traj_point)
 {
-  // Checks to ensure indices are within bounds before accessing or modifying the trajectory matrix.
-  if (point < 0 || point >= num_points_) {
-    std::cerr << "Error: Point index out of range." << std::endl;
-    // Return a default value on error
-    return Eigen::VectorXd::Zero(num_joints_); 
-  }
   return trajectory_.row(point);
 }
 

--- a/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_trajectory.h
+++ b/moveit_planners/chomp/chomp_motion_planner/include/chomp_motion_planner/chomp_trajectory.h
@@ -224,7 +224,13 @@ inline double ChompTrajectory::operator()(size_t traj_point, size_t joint) const
 
 inline Eigen::MatrixXd::RowXpr ChompTrajectory::getTrajectoryPoint(int traj_point)
 {
-  return trajectory_.row(traj_point);
+  // Checks to ensure indices are within bounds before accessing or modifying the trajectory matrix.
+  if (point < 0 || point >= num_points_) {
+    std::cerr << "Error: Point index out of range." << std::endl;
+    // Return a default value on error
+    return Eigen::VectorXd::Zero(num_joints_); 
+  }
+  return trajectory_.row(point);
 }
 
 inline Eigen::MatrixXd::ColXpr ChompTrajectory::getJointTrajectory(int joint)

--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_optimizer.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_optimizer.cpp
@@ -560,6 +560,11 @@ void ChompOptimizer::calculateCollisionIncrements()
   Eigen::Vector3d curvature_vector;
   Eigen::Vector3d cartesian_gradient;
 
+
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_real_distribution<> dis(0.0, 1.0);
+  
   collision_increments_.setZero(num_vars_free_, num_joints_);
 
   int start_point = 0;
@@ -568,7 +573,14 @@ void ChompOptimizer::calculateCollisionIncrements()
   // In stochastic descent, simply use a random point in the trajectory, rather than all the trajectory points.
   if (parameters_->use_stochastic_descent_)
   {
+<<<<<<< HEAD
     start_point = static_cast<int>(rsl::uniform_real(0., 1.) * (free_vars_end_ - free_vars_start_) + free_vars_start_);
+=======
+    
+    start_point = static_cast<int>(dis(gen) * (free_vars_end_ - free_vars_start_) + free_vars_start_);
+
+    
+>>>>>>> 39881a592 (Added OpenMP to improve the collision checking.)
     start_point = std::clamp(start_point, free_vars_start_, free_vars_end_);
     end_point = start_point;
   }
@@ -615,6 +627,7 @@ void ChompOptimizer::calculateCollisionIncrements()
     }
   }
 }
+
 
 void ChompOptimizer::calculatePseudoInverse()
 {


### PR DESCRIPTION
### Description

I have added OpenMP to the CMakelist to be found. If it exist, it will be used to parallelize the collision checking in CHOMP. It is used to increase the speed of calculateCollisionIncrements. I have tested this in Humble, I do not see any reason it should not work in other dist. too.


### Checklist
- [x ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
