### PR TITLE
Remove Humble and Iron from tutorial Docker CI job

### DIFF
--- a/.github/workflows/tutorial_docker.yaml
+++ b/.github/workflows/tutorial_docker.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ROS_DISTRO: [rolling, humble, iron, jazzy]
+        ROS_DISTRO: [rolling, jazzy]
     runs-on: ubuntu-latest
     permissions:
       packages: write


### PR DESCRIPTION
### Description

These jobs have been failing as optional for a while, and the `main` branch of `moveit2` just will not work with these older tutorial versions. So I opt for removing them here.

If anything, the tutorial job should be added into the `humble` branch to test that specific pipeline -- doing in https://github.com/moveit/moveit2/pull/3082.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
