### PR TITLE
Add use_padding flag + deprecate checkCollisionUnpadded() functions

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -3,6 +3,8 @@
 API changes in MoveIt releases
 
 ## ROS Rolling
+- [11/2024] Added flags to control padding to CollisionRequest. This change deprecates PlanningScene::checkCollisionUnpadded(..) functions. Please use PlanningScene::checkCollision(..) with a req.pad_environment_collisions = false;
+
 - [12/2023] `trajectory_processing::Path` and `trajectory_processing::Trajectory` APIs have been updated to prevent misuse.
 The constructors have been replaced by builder methods so that errors can be communicated. Paths and trajectories now need to be created with `Path::Create()` and `Trajectory::Create()`. These methods now return an `std::optional` that needs to be checked for a valid value. `Trajectory` no longer has the `isValid()` method. If it's invalid, `Trajectory::Create()` will return `std::nullopt`. Finally, `Path` now takes the list of input waypoints as `std::vector`, instead of `std::list`.
 - [12/2023] LMA kinematics plugin is removed to remove the maintenance work because better alternatives exist like KDL or TracIK

--- a/moveit_core/CHANGELOG.rst
+++ b/moveit_core/CHANGELOG.rst
@@ -1,6 +1,10 @@
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Changelog for package moveit_core
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+2.12.0 (202X-XX-XX)
+-------------------
+* Add flags to control padding to CollisionRequest and deprecate PlanningScene::checkCollisionUnpadded(..) functions
+
 
 2.11.0 (2024-09-16)
 -------------------

--- a/moveit_core/CHANGELOG.rst
+++ b/moveit_core/CHANGELOG.rst
@@ -1,10 +1,6 @@
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Changelog for package moveit_core
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-2.12.0 (202X-XX-XX)
--------------------
-* Add flags to control padding to CollisionRequest and deprecate PlanningScene::checkCollisionUnpadded(..) functions
-
 
 2.11.0 (2024-09-16)
 -------------------

--- a/moveit_core/collision_detection/include/moveit/collision_detection/collision_common.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/collision_common.h
@@ -151,10 +151,10 @@ struct CollisionRequest
   std::string group_name = "";
 
   /** \brief If true, use padded collision environment */
-  bool use_padded_collision_environment = true;
+  bool pad_environment_collisions = true;
 
   /** \brief If true, do self collision check with padded robot links */
-  bool use_padded_self_collision = false;
+  bool pad_self_collisions = false;
 
   /** \brief If true, compute proximity distance */
   bool distance = false;

--- a/moveit_core/collision_detection/include/moveit/collision_detection/collision_common.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/collision_common.h
@@ -150,6 +150,12 @@ struct CollisionRequest
    * are included. */
   std::string group_name = "";
 
+  /** \brief If true, use padded collision environment */
+  bool use_padded_collision_environment = true;
+
+  /** \brief If true, do self collision check with padded robot links */
+  bool use_padded_self_collision = false;
+
   /** \brief If true, compute proximity distance */
   bool distance = false;
 

--- a/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
+++ b/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
@@ -347,19 +347,12 @@ public:
   void checkCollision(const collision_detection::CollisionRequest& req, collision_detection::CollisionResult& res);
 
   /** \brief Check whether the current state is in collision. The current state is expected to be updated. */
-  void checkCollision(const collision_detection::CollisionRequest& req, collision_detection::CollisionResult& res) const
-  {
-    checkCollision(req, res, getCurrentState());
-  }
+  void checkCollision(const collision_detection::CollisionRequest& req, collision_detection::CollisionResult& res) const;
 
   /** \brief Check whether a specified state (\e robot_state) is in collision. This variant of the function takes
       a non-const \e robot_state and calls updateCollisionBodyTransforms() on it. */
   void checkCollision(const collision_detection::CollisionRequest& req, collision_detection::CollisionResult& res,
-                      moveit::core::RobotState& robot_state) const
-  {
-    robot_state.updateCollisionBodyTransforms();
-    checkCollision(req, res, static_cast<const moveit::core::RobotState&>(robot_state));
-  }
+                      moveit::core::RobotState& robot_state) const;
 
   /** \brief Check whether a specified state (\e robot_state) is in collision. The collision transforms of \e
    * robot_state are
@@ -372,114 +365,80 @@ public:
       a non-const \e robot_state and updates its link transforms if needed. */
   void checkCollision(const collision_detection::CollisionRequest& req, collision_detection::CollisionResult& res,
                       moveit::core::RobotState& robot_state,
-                      const collision_detection::AllowedCollisionMatrix& acm) const
-  {
-    robot_state.updateCollisionBodyTransforms();
-    checkCollision(req, res, static_cast<const moveit::core::RobotState&>(robot_state), acm);
-  }
+                      const collision_detection::AllowedCollisionMatrix& acm) const;
 
   /** \brief Check whether a specified state (\e robot_state) is in collision, with respect to a given
       allowed collision matrix (\e acm). */
   void checkCollision(const collision_detection::CollisionRequest& req, collision_detection::CollisionResult& res,
                       const moveit::core::RobotState& robot_state,
-                      const collision_detection::AllowedCollisionMatrix& acm) const;
+                      const collision_detection::AllowedCollisionMatrix& acm, bool validate_transforms = true) const;
 
   /** \brief Check whether the current state is in collision,
       but use a collision_detection::CollisionRobot instance that has no padding.
       Since the function is non-const, the current state transforms are also updated if needed. */
-  void checkCollisionUnpadded(const collision_detection::CollisionRequest& req,
-                              collision_detection::CollisionResult& res);
+  [[deprecated("Use new CollisionRequest flags to enable/ disable padding instead.")]] void
+  checkCollisionUnpadded(const collision_detection::CollisionRequest& req, collision_detection::CollisionResult& res);
 
   /** \brief Check whether the current state is in collision,
       but use a collision_detection::CollisionRobot instance that has no padding.  */
-  void checkCollisionUnpadded(const collision_detection::CollisionRequest& req,
-                              collision_detection::CollisionResult& res) const
-  {
-    checkCollisionUnpadded(req, res, getCurrentState(), getAllowedCollisionMatrix());
-  }
+  [[deprecated("Use new CollisionRequest flags to enable/ disable padding instead.")]] void
+  checkCollisionUnpadded(const collision_detection::CollisionRequest& req,
+                         collision_detection::CollisionResult& res) const;
 
   /** \brief Check whether a specified state (\e robot_state) is in collision,
       but use a collision_detection::CollisionRobot instance that has no padding.  */
-  void checkCollisionUnpadded(const collision_detection::CollisionRequest& req,
-                              collision_detection::CollisionResult& res,
-                              const moveit::core::RobotState& robot_state) const
-  {
-    checkCollisionUnpadded(req, res, robot_state, getAllowedCollisionMatrix());
-  }
+  [[deprecated("Use new CollisionRequest flags to enable/ disable padding instead.")]] void
+  checkCollisionUnpadded(const collision_detection::CollisionRequest& req, collision_detection::CollisionResult& res,
+                         const moveit::core::RobotState& robot_state) const;
 
   /** \brief Check whether a specified state (\e robot_state) is in collision,
       but use a collision_detection::CollisionRobot instance that has no padding.
       Update the link transforms of \e robot_state if needed. */
-  void checkCollisionUnpadded(const collision_detection::CollisionRequest& req,
-                              collision_detection::CollisionResult& res, moveit::core::RobotState& robot_state) const
-  {
-    robot_state.updateCollisionBodyTransforms();
-    checkCollisionUnpadded(req, res, static_cast<const moveit::core::RobotState&>(robot_state),
-                           getAllowedCollisionMatrix());
-  }
+  [[deprecated("Use new CollisionRequest flags to enable/ disable padding instead.")]] void
+  checkCollisionUnpadded(const collision_detection::CollisionRequest& req, collision_detection::CollisionResult& res,
+                         moveit::core::RobotState& robot_state) const;
 
   /** \brief Check whether a specified state (\e robot_state) is in collision, with respect to a given
       allowed collision matrix (\e acm), but use a collision_detection::CollisionRobot instance that has no padding.
       This variant of the function takes a non-const \e robot_state and calls updates the link transforms if needed. */
-  void checkCollisionUnpadded(const collision_detection::CollisionRequest& req,
-                              collision_detection::CollisionResult& res, moveit::core::RobotState& robot_state,
-                              const collision_detection::AllowedCollisionMatrix& acm) const
-  {
-    robot_state.updateCollisionBodyTransforms();
-    checkCollisionUnpadded(req, res, static_cast<const moveit::core::RobotState&>(robot_state), acm);
-  }
+  [[deprecated("Use new CollisionRequest flags to enable/ disable padding instead.")]] void
+  checkCollisionUnpadded(const collision_detection::CollisionRequest& req, collision_detection::CollisionResult& res,
+                         moveit::core::RobotState& robot_state,
+                         const collision_detection::AllowedCollisionMatrix& acm) const;
 
   /** \brief Check whether a specified state (\e robot_state) is in collision, with respect to a given
       allowed collision matrix (\e acm), but use a collision_detection::CollisionRobot instance that has no padding.  */
-  void checkCollisionUnpadded(const collision_detection::CollisionRequest& req,
-                              collision_detection::CollisionResult& res, const moveit::core::RobotState& robot_state,
-                              const collision_detection::AllowedCollisionMatrix& acm) const;
+  [[deprecated("Use new CollisionRequest flags to enable/ disable padding instead.")]] void
+  checkCollisionUnpadded(const collision_detection::CollisionRequest& req, collision_detection::CollisionResult& res,
+                         const moveit::core::RobotState& robot_state,
+                         const collision_detection::AllowedCollisionMatrix& acm) const;
 
   /** \brief Check whether the current state is in self collision */
   void checkSelfCollision(const collision_detection::CollisionRequest& req, collision_detection::CollisionResult& res);
 
   /** \brief Check whether the current state is in self collision */
   void checkSelfCollision(const collision_detection::CollisionRequest& req,
-                          collision_detection::CollisionResult& res) const
-  {
-    checkSelfCollision(req, res, getCurrentState());
-  }
+                          collision_detection::CollisionResult& res) const;
 
   /** \brief Check whether a specified state (\e robot_state) is in self collision */
   void checkSelfCollision(const collision_detection::CollisionRequest& req, collision_detection::CollisionResult& res,
-                          moveit::core::RobotState& robot_state) const
-  {
-    robot_state.updateCollisionBodyTransforms();
-    checkSelfCollision(req, res, static_cast<const moveit::core::RobotState&>(robot_state), getAllowedCollisionMatrix());
-  }
+                          moveit::core::RobotState& robot_state) const;
 
   /** \brief Check whether a specified state (\e robot_state) is in self collision */
   void checkSelfCollision(const collision_detection::CollisionRequest& req, collision_detection::CollisionResult& res,
-                          const moveit::core::RobotState& robot_state) const
-  {
-    // do self-collision checking with the unpadded version of the robot
-    getCollisionEnvUnpadded()->checkSelfCollision(req, res, robot_state, getAllowedCollisionMatrix());
-  }
+                          const moveit::core::RobotState& robot_state) const;
 
   /** \brief Check whether a specified state (\e robot_state) is in self collision, with respect to a given
       allowed collision matrix (\e acm). The link transforms of \e robot_state are updated if needed. */
   void checkSelfCollision(const collision_detection::CollisionRequest& req, collision_detection::CollisionResult& res,
                           moveit::core::RobotState& robot_state,
-                          const collision_detection::AllowedCollisionMatrix& acm) const
-  {
-    robot_state.updateCollisionBodyTransforms();
-    checkSelfCollision(req, res, static_cast<const moveit::core::RobotState&>(robot_state), acm);
-  }
+                          const collision_detection::AllowedCollisionMatrix& acm) const;
 
   /** \brief Check whether a specified state (\e robot_state) is in self collision, with respect to a given
       allowed collision matrix (\e acm) */
   void checkSelfCollision(const collision_detection::CollisionRequest& req, collision_detection::CollisionResult& res,
                           const moveit::core::RobotState& robot_state,
-                          const collision_detection::AllowedCollisionMatrix& acm) const
-  {
-    // do self-collision checking with the unpadded version of the robot
-    getCollisionEnvUnpadded()->checkSelfCollision(req, res, robot_state, acm);
-  }
+                          const collision_detection::AllowedCollisionMatrix& acm) const;
 
   /** \brief Get the names of the links that are involved in collisions for the current state */
   void getCollidingLinks(std::vector<std::string>& links);

--- a/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
+++ b/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
@@ -368,10 +368,10 @@ public:
                       const collision_detection::AllowedCollisionMatrix& acm) const;
 
   /** \brief Check whether a specified state (\e robot_state) is in collision, with respect to a given
-      allowed collision matrix (\e acm). If validate_transforms is set true, the given robot state is checked for dirty transforms. */
+      allowed collision matrix (\e acm). */
   void checkCollision(const collision_detection::CollisionRequest& req, collision_detection::CollisionResult& res,
                       const moveit::core::RobotState& robot_state,
-                      const collision_detection::AllowedCollisionMatrix& acm, bool validate_transforms = true) const;
+                      const collision_detection::AllowedCollisionMatrix& acm) const;
 
   /** \brief Check whether the current state is in collision,
       but use a collision_detection::CollisionRobot instance that has no padding.

--- a/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
+++ b/moveit_core/planning_scene/include/moveit/planning_scene/planning_scene.h
@@ -368,7 +368,7 @@ public:
                       const collision_detection::AllowedCollisionMatrix& acm) const;
 
   /** \brief Check whether a specified state (\e robot_state) is in collision, with respect to a given
-      allowed collision matrix (\e acm). */
+      allowed collision matrix (\e acm). If validate_transforms is set true, the given robot state is checked for dirty transforms. */
   void checkCollision(const collision_detection::CollisionRequest& req, collision_detection::CollisionResult& res,
                       const moveit::core::RobotState& robot_state,
                       const collision_detection::AllowedCollisionMatrix& acm, bool validate_transforms = true) const;

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -438,7 +438,7 @@ void PlanningScene::checkCollision(const collision_detection::CollisionRequest& 
                                    getCollisionEnvUnpadded()->checkRobotCollision(req, res, robot_state, acm);
 
   // Return early if a collision was found or the maximum number of allowed contacts is exceeded
-  if (res.collision || (req.contacts && res.contacts.size() >= req.max_contacts))
+  if (res.collision && (!req.contacts || res.contacts.size() >= req.max_contacts))
   {
     return;
   }

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -425,7 +425,7 @@ void PlanningScene::checkCollision(const collision_detection::CollisionRequest& 
   {
     robot_state.updateCollisionBodyTransforms();
   }
-  checkCollision(req, res, robot_state, acm);
+  checkCollision(req, res, static_cast<const moveit::core::RobotState&>(robot_state), acm);
 }
 
 void PlanningScene::checkCollision(const collision_detection::CollisionRequest& req,

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -431,14 +431,8 @@ void PlanningScene::checkCollision(const collision_detection::CollisionRequest& 
 void PlanningScene::checkCollision(const collision_detection::CollisionRequest& req,
                                    collision_detection::CollisionResult& res,
                                    const moveit::core::RobotState& robot_state,
-                                   const collision_detection::AllowedCollisionMatrix& acm,
-                                   bool validate_transforms) const
+                                   const collision_detection::AllowedCollisionMatrix& acm) const
 {
-  if (validate_transforms && robot_state.dirtyCollisionBodyTransforms())
-  {
-    RCLCPP_WARN(getLogger(), "Robot state has dirty collision body transforms. Please update the collision body "
-                             "transforms before checking collision.");
-  }
   // check collision with the world using the padded version
   req.pad_environment_collisions ? getCollisionEnv()->checkRobotCollision(req, res, robot_state, acm) :
                                    getCollisionEnvUnpadded()->checkRobotCollision(req, res, robot_state, acm);

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -437,7 +437,8 @@ void PlanningScene::checkCollision(const collision_detection::CollisionRequest& 
   req.pad_environment_collisions ? getCollisionEnv()->checkRobotCollision(req, res, robot_state, acm) :
                                    getCollisionEnvUnpadded()->checkRobotCollision(req, res, robot_state, acm);
 
-  // Return early if a collision was found or the maximum number of allowed contacts is exceeded
+  // Return early if a collision was found and the number of contacts found already exceed `req.max_contacts`, if
+  // `req.contacts` is enabled.
   if (res.collision && (!req.contacts || res.contacts.size() >= req.max_contacts))
   {
     return;

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -440,8 +440,8 @@ void PlanningScene::checkCollision(const collision_detection::CollisionRequest& 
                              "transforms before checking collision.");
   }
   // check collision with the world using the padded version
-  req.use_padded_collision_environment ? getCollisionEnv()->checkRobotCollision(req, res, robot_state, acm) :
-                                         getCollisionEnvUnpadded()->checkRobotCollision(req, res, robot_state, acm);
+  req.pad_environment_collisions ? getCollisionEnv()->checkRobotCollision(req, res, robot_state, acm) :
+                                   getCollisionEnvUnpadded()->checkRobotCollision(req, res, robot_state, acm);
 
   // Return early if a collision was found or the maximum number of allowed contacts is exceeded
   if (res.collision || (req.contacts && res.contacts.size() >= req.max_contacts))
@@ -450,15 +450,15 @@ void PlanningScene::checkCollision(const collision_detection::CollisionRequest& 
   }
 
   // do self-collision checking with the unpadded version of the robot
-  req.use_padded_self_collision ? getCollisionEnv()->checkSelfCollision(req, res, robot_state, acm) :
-                                  getCollisionEnvUnpadded()->checkSelfCollision(req, res, robot_state, acm);
+  req.pad_self_collisions ? getCollisionEnv()->checkSelfCollision(req, res, robot_state, acm) :
+                            getCollisionEnvUnpadded()->checkSelfCollision(req, res, robot_state, acm);
 }
 
 void PlanningScene::checkCollisionUnpadded(const collision_detection::CollisionRequest& req,
                                            collision_detection::CollisionResult& res)
 {
   collision_detection::CollisionRequest new_req = req;
-  new_req.use_padded_collision_environment = false;
+  new_req.pad_environment_collisions = false;
   checkCollision(req, res, getCurrentStateNonConst(), getAllowedCollisionMatrix());
 }
 
@@ -466,7 +466,7 @@ void PlanningScene::checkCollisionUnpadded(const collision_detection::CollisionR
                                            collision_detection::CollisionResult& res) const
 {
   collision_detection::CollisionRequest new_req = req;
-  new_req.use_padded_collision_environment = false;
+  new_req.pad_environment_collisions = false;
   checkCollision(new_req, res, getCurrentState(), getAllowedCollisionMatrix());
 }
 
@@ -475,7 +475,7 @@ void PlanningScene::checkCollisionUnpadded(const collision_detection::CollisionR
                                            const moveit::core::RobotState& robot_state) const
 {
   collision_detection::CollisionRequest new_req = req;
-  new_req.use_padded_collision_environment = false;
+  new_req.pad_environment_collisions = false;
   checkCollision(new_req, res, robot_state, getAllowedCollisionMatrix());
 }
 
@@ -484,7 +484,7 @@ void PlanningScene::checkCollisionUnpadded(const collision_detection::CollisionR
                                            moveit::core::RobotState& robot_state) const
 {
   collision_detection::CollisionRequest new_req = req;
-  new_req.use_padded_collision_environment = false;
+  new_req.pad_environment_collisions = false;
   checkCollision(new_req, res, static_cast<const moveit::core::RobotState&>(robot_state), getAllowedCollisionMatrix());
 }
 
@@ -495,7 +495,7 @@ void PlanningScene::checkCollisionUnpadded(const collision_detection::CollisionR
 {
   robot_state.updateCollisionBodyTransforms();
   collision_detection::CollisionRequest new_req = req;
-  new_req.use_padded_collision_environment = false;
+  new_req.pad_environment_collisions = false;
   checkCollision(new_req, res, static_cast<const moveit::core::RobotState&>(robot_state), acm);
 }
 
@@ -505,7 +505,7 @@ void PlanningScene::checkCollisionUnpadded(const collision_detection::CollisionR
                                            const collision_detection::AllowedCollisionMatrix& acm) const
 {
   collision_detection::CollisionRequest new_req = req;
-  new_req.use_padded_collision_environment = false;
+  new_req.pad_environment_collisions = false;
   checkCollision(req, res, robot_state, acm);
 }
 
@@ -515,7 +515,6 @@ void PlanningScene::checkSelfCollision(const collision_detection::CollisionReque
   checkSelfCollision(req, res, getCurrentStateNonConst());
 }
 
-/** \brief Check whether the current state is in self collision */
 void PlanningScene::checkSelfCollision(const collision_detection::CollisionRequest& req,
                                        collision_detection::CollisionResult& res) const
 {
@@ -556,8 +555,8 @@ void PlanningScene::checkSelfCollision(const collision_detection::CollisionReque
                                        const moveit::core::RobotState& robot_state,
                                        const collision_detection::AllowedCollisionMatrix& acm) const
 {
-  req.use_padded_self_collision ? getCollisionEnv()->checkSelfCollision(req, res, robot_state, acm) :
-                                  getCollisionEnvUnpadded()->checkSelfCollision(req, res, robot_state, acm);
+  req.pad_self_collisions ? getCollisionEnv()->checkSelfCollision(req, res, robot_state, acm) :
+                            getCollisionEnvUnpadded()->checkSelfCollision(req, res, robot_state, acm);
 }
 
 void PlanningScene::getCollidingPairs(collision_detection::CollisionResult::ContactMap& contacts)

--- a/moveit_py/src/moveit/moveit_core/planning_scene/planning_scene.cpp
+++ b/moveit_py/src/moveit/moveit_core/planning_scene/planning_scene.cpp
@@ -101,6 +101,9 @@ void initPlanningScene(py::module& m)
 {
   py::module planning_scene = m.def_submodule("planning_scene");
 
+// Remove once checkCollisionUnpadded is removed
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   py::class_<planning_scene::PlanningScene, std::shared_ptr<planning_scene::PlanningScene>>(planning_scene,
                                                                                             "PlanningScene",
                                                                                             R"(
@@ -360,8 +363,7 @@ void initPlanningScene(py::module& m)
 	   Returns:
                bool: true if state is in collision otherwise false.
            )")
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+      // DEPRECATED! Use check_collision instead
       .def("check_collision_unpadded",
            py::overload_cast<const collision_detection::CollisionRequest&, collision_detection::CollisionResult&>(
                &planning_scene::PlanningScene::checkCollisionUnpadded),
@@ -376,7 +378,7 @@ void initPlanningScene(py::module& m)
 	   Returns:
                bool: true if state is in collision otherwise false.
            )")
-
+      // DEPRECATED! Use check_collision instead
       .def("check_collision_unpadded",
            py::overload_cast<const collision_detection::CollisionRequest&, collision_detection::CollisionResult&,
                              moveit::core::RobotState&>(&planning_scene::PlanningScene::checkCollisionUnpadded,
@@ -393,7 +395,7 @@ void initPlanningScene(py::module& m)
 	   Returns:
                bool: true if state is in collision otherwise false.
            )")
-
+      // DEPRECATED! Use check_collision instead
       .def("check_collision_unpadded",
            py::overload_cast<const collision_detection::CollisionRequest&, collision_detection::CollisionResult&,
                              moveit::core::RobotState&, const collision_detection::AllowedCollisionMatrix&>(
@@ -411,7 +413,6 @@ void initPlanningScene(py::module& m)
 	   Returns:
                bool: true if state is in collision otherwise false.
            )")
-#pragma GCC diagnostic pop
       .def("check_self_collision",
            py::overload_cast<const collision_detection::CollisionRequest&, collision_detection::CollisionResult&>(
                &planning_scene::PlanningScene::checkSelfCollision),
@@ -482,6 +483,7 @@ void initPlanningScene(py::module& m)
      Returns:
                bool: true if load from file was successful otherwise false.
            )");
+#pragma GCC diagnostic pop  // TODO remove once checkCollisionUnpadded is removed
 }
 }  // namespace bind_planning_scene
 }  // namespace moveit_py

--- a/moveit_py/src/moveit/moveit_core/planning_scene/planning_scene.cpp
+++ b/moveit_py/src/moveit/moveit_core/planning_scene/planning_scene.cpp
@@ -360,7 +360,8 @@ void initPlanningScene(py::module& m)
 	   Returns:
                bool: true if state is in collision otherwise false.
            )")
-
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
       .def("check_collision_unpadded",
            py::overload_cast<const collision_detection::CollisionRequest&, collision_detection::CollisionResult&>(
                &planning_scene::PlanningScene::checkCollisionUnpadded),
@@ -410,7 +411,7 @@ void initPlanningScene(py::module& m)
 	   Returns:
                bool: true if state is in collision otherwise false.
            )")
-
+#pragma GCC diagnostic pop
       .def("check_self_collision",
            py::overload_cast<const collision_detection::CollisionRequest&, collision_detection::CollisionResult&>(
                &planning_scene::PlanningScene::checkSelfCollision),

--- a/moveit_ros/benchmarks/src/BenchmarkExecutor.cpp
+++ b/moveit_ros/benchmarks/src/BenchmarkExecutor.cpp
@@ -1010,7 +1010,7 @@ void BenchmarkExecutor::collectMetrics(PlannerRunData& metrics,
 
       // compute correctness and clearance
       collision_detection::CollisionRequest req;
-      req.use_padded_collision_environment = false;
+      req.pad_environment_collisions = false;
       for (std::size_t k = 0; k < p.getWayPointCount(); ++k)
       {
         collision_detection::CollisionResult res;

--- a/moveit_ros/benchmarks/src/BenchmarkExecutor.cpp
+++ b/moveit_ros/benchmarks/src/BenchmarkExecutor.cpp
@@ -1010,10 +1010,11 @@ void BenchmarkExecutor::collectMetrics(PlannerRunData& metrics,
 
       // compute correctness and clearance
       collision_detection::CollisionRequest req;
+      req.use_padded_collision_environment = false;
       for (std::size_t k = 0; k < p.getWayPointCount(); ++k)
       {
         collision_detection::CollisionResult res;
-        planning_scene_->checkCollisionUnpadded(req, res, p.getWayPoint(k));
+        planning_scene_->checkCollision(req, res, p.getWayPoint(k));
         if (res.collision)
           correct = false;
         if (!p.getWayPoint(k).satisfiesBounds())

--- a/moveit_ros/planning/plan_execution/src/plan_execution.cpp
+++ b/moveit_ros/planning/plan_execution/src/plan_execution.cpp
@@ -282,16 +282,17 @@ bool plan_execution::PlanExecution::isRemainingPathValid(const ExecutableMotionP
     std::size_t wpc = t.getWayPointCount();
     collision_detection::CollisionRequest req;
     req.group_name = t.getGroupName();
+    req.use_padded_collision_environment = false;
     for (std::size_t i = std::max(path_segment.second - 1, 0); i < wpc; ++i)
     {
       collision_detection::CollisionResult res;
       if (acm)
       {
-        plan.planning_scene->checkCollisionUnpadded(req, res, t.getWayPoint(i), *acm);
+        plan.planning_scene->checkCollision(req, res, t.getWayPoint(i), *acm);
       }
       else
       {
-        plan.planning_scene->checkCollisionUnpadded(req, res, t.getWayPoint(i));
+        plan.planning_scene->checkCollision(req, res, t.getWayPoint(i));
       }
 
       if (res.collision || !plan.planning_scene->isStateFeasible(t.getWayPoint(i), false))
@@ -306,11 +307,11 @@ bool plan_execution::PlanExecution::isRemainingPathValid(const ExecutableMotionP
         res.clear();
         if (acm)
         {
-          plan.planning_scene->checkCollisionUnpadded(req, res, t.getWayPoint(i), *acm);
+          plan.planning_scene->checkCollision(req, res, t.getWayPoint(i), *acm);
         }
         else
         {
-          plan.planning_scene->checkCollisionUnpadded(req, res, t.getWayPoint(i));
+          plan.planning_scene->checkCollision(req, res, t.getWayPoint(i));
         }
         return false;
       }

--- a/moveit_ros/planning/plan_execution/src/plan_execution.cpp
+++ b/moveit_ros/planning/plan_execution/src/plan_execution.cpp
@@ -282,7 +282,7 @@ bool plan_execution::PlanExecution::isRemainingPathValid(const ExecutableMotionP
     std::size_t wpc = t.getWayPointCount();
     collision_detection::CollisionRequest req;
     req.group_name = t.getGroupName();
-    req.use_padded_collision_environment = false;
+    req.pad_environment_collisions = false;
     for (std::size_t i = std::max(path_segment.second - 1, 0); i < wpc; ++i)
     {
       collision_detection::CollisionResult res;


### PR DESCRIPTION
### Description

I wanted to perform a padded self-collision check with a robot state and realized that this is not possible with the current API. So I decided to enable it + clean-up the checkCollision API of the planning scene a bit. This PR:
- Adds use_padded_collision_environment & use_padded_self_collision flags to choose the environment to be used for collision checks
- Clean up & update checkCollision(): Move all implementations into header make transform update more consistent
- Deprecate checkCollisionUnpadded() since they become redundant with the new flags
- Clean up & update checkSelfCollision(): Move all implementations into header make transform update more consistent

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
