### PR TITLE
Attached Collision Object Transparency

### DIFF
--- a/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
@@ -356,10 +356,10 @@ void PlanningSceneDisplay::changedSceneName()
 void PlanningSceneDisplay::renderPlanningScene()
 {
   QColor color = scene_color_property_->getColor();
-  Ogre::ColourValue env_color(color.redF(), color.greenF(), color.blueF());
+  Ogre::ColourValue env_color(color.redF(), color.greenF(), color.blueF(), scene_alpha_property_->getFloat());
   if (attached_body_color_property_)
     color = attached_body_color_property_->getColor();
-  Ogre::ColourValue attached_color(color.redF(), color.greenF(), color.blueF());
+  Ogre::ColourValue attached_color(color.redF(), color.greenF(), color.blueF(), color.alphaF());
 
   try
   {

--- a/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
@@ -359,7 +359,7 @@ void PlanningSceneDisplay::renderPlanningScene()
   Ogre::ColourValue env_color(color.redF(), color.greenF(), color.blueF(), scene_alpha_property_->getFloat());
   if (attached_body_color_property_)
     color = attached_body_color_property_->getColor();
-  Ogre::ColourValue attached_color(color.redF(), color.greenF(), color.blueF(), color.alphaF());
+  Ogre::ColourValue attached_color(color.redF(), color.greenF(), color.blueF(), robot_alpha_property_->getFloat());
 
   try
   {

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/planning_scene_render.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/planning_scene_render.cpp
@@ -91,7 +91,7 @@ void PlanningSceneRender::renderPlanningScene(const planning_scene::PlanningScen
     color.r = default_attached_color.r;
     color.g = default_attached_color.g;
     color.b = default_attached_color.b;
-    color.a = 1.0f;
+    color.a = default_attached_color.a;
     planning_scene::ObjectColorMap color_map;
     scene->getKnownObjectColors(color_map);
     scene_robot_->update(moveit::core::RobotStateConstPtr(rs), color, color_map);

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/robot_state_visualization.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/robot_state_visualization.cpp
@@ -145,7 +145,7 @@ void RobotStateVisualization::updateHelper(const moveit::core::RobotStateConstPt
       RCLCPP_ERROR_STREAM(getLogger(), "Link " << attached_body->getAttachedLinkName() << " not found in rviz::Robot");
       continue;
     }
-    Ogre::ColourValue rcolor(color.r, color.g, color.b);
+    Ogre::ColourValue rcolor(color.r, color.g, color.b, color.a);
     const EigenSTL::vector_Isometry3d& ab_t = attached_body->getShapePosesInLinkFrame();
     const std::vector<shapes::ShapeConstPtr>& ab_shapes = attached_body->getShapes();
     for (std::size_t j = 0; j < ab_shapes.size(); ++j)


### PR DESCRIPTION
### Description

This PR aims to resolve missing functionality from Moveit1 which allowed for attached collision objects to become transparent through the setting of an alpha value in `robot_state_visualization.cpp`. It also defaults the alpha value to match the Scene Robot Alpha value which was default behaviour for Moveit1.

If this could be backported to Humble it would be much appreciated

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
