### PR TITLE
Fixes pilz tests

### DIFF
--- a/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_trajectory_functions.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_trajectory_functions.cpp
@@ -415,9 +415,10 @@ TEST_F(TrajectoryFunctionsTestFlangeAndGripper, testIKRobotStateWithIdentityColl
   const moveit::core::LinkModel* tip_link = robot_model_->getLinkModel(tcp_link_);
   Eigen::Isometry3d tip_pose_in_base = state.getFrameTransform(tcp_link_);
 
-  // Attach an object with no subframes, and no transform
+  // Attach an object with ignored subframes, and no transform
   Eigen::Isometry3d object_pose_in_tip = Eigen::Isometry3d::Identity();
-  attachToLink(state, tip_link, "object", object_pose_in_tip, { {} });
+  moveit::core::FixedTransformsMap subframes({ { "ignored", Eigen::Isometry3d::Identity() } });
+  attachToLink(state, tip_link, "object", object_pose_in_tip, subframes);
 
   // The RobotState should be able to use an object pose to set the joints
   Eigen::Isometry3d object_pose_in_base = tip_pose_in_base * object_pose_in_tip;
@@ -440,12 +441,12 @@ TEST_F(TrajectoryFunctionsTestFlangeAndGripper, testIKRobotStateWithTransformedC
   const moveit::core::LinkModel* tip_link = robot_model_->getLinkModel(tcp_link_);
   Eigen::Isometry3d tip_pose_in_base = state.getFrameTransform(tcp_link_);
 
-  // Attach an object with no subframes, and a non-trivial transform
+  // Attach an object with ignored subframes, and a non-trivial transform
   Eigen::Isometry3d object_pose_in_tip;
   object_pose_in_tip = Eigen::Translation3d(1, 2, 3);
   object_pose_in_tip *= Eigen::AngleAxis(M_PI_2, Eigen::Vector3d::UnitX());
-
-  attachToLink(state, tip_link, "object", object_pose_in_tip, { {} });
+  moveit::core::FixedTransformsMap subframes({ { "ignored", Eigen::Isometry3d::Identity() } });
+  attachToLink(state, tip_link, "object", object_pose_in_tip, subframes);
 
   // The RobotState should be able to use an object pose to set the joints
   Eigen::Isometry3d object_pose_in_base = tip_pose_in_base * object_pose_in_tip;


### PR DESCRIPTION
### Description

This fixes an issue in some of the pilz tests introduced by #3077.

Instead of passing an empty map of subframes, we were passing a one-item map containing an empty pair, which was causing test errors.

This is fixed by adding some explicit subframes to every such test, with the ones that are unused named as such for clarity.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [x] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [x] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [x] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
