### PR TITLE
[Humble] Replace more ros-planning with moveit2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,19 +17,17 @@ jobs:
       fail-fast: false
       matrix:
         env:
-          - IMAGE: rolling-ci
-            CCOV: false # Disabled: https://github.com/moveit/moveit2/issues/2866
-            ROS_DISTRO: rolling
-          - IMAGE: rolling-ci
-            ROS_DISTRO: rolling
-            IKFAST_TEST: true
-            CLANG_TIDY: pedantic
+          - IMAGE: humble-ci
+            CCOV: true
+            ROS_DISTRO: humble
           - IMAGE: humble-ci
             ROS_DISTRO: humble
-          - IMAGE: humble-ci-testing
-            ROS_DISTRO: humble
-          - IMAGE: jazzy-ci
-            ROS_DISTRO: jazzy
+            IKFAST_TEST: true
+            CLANG_TIDY: pedantic
+            # Silent gmock/gtest warnings by picking more recent googletest version
+            AFTER_BUILD_UPSTREAM_WORKSPACE: |
+              git clone --depth 1 --quiet --branch 1.11.9000 https://github.com/ament/googletest "${BASEDIR}/upstream_ws/src/googletest"
+              builder_run_build "/opt/ros/${ROS_DISTRO}" "${BASEDIR}/upstream_ws" --packages-select gtest_vendor gmock_vendor
     env:
       CXXFLAGS: >-
         -Wall -Wextra -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -86,9 +86,9 @@ jobs:
           df -h
       - uses: actions/checkout@v4
       - uses: testspace-com/setup-testspace@v1
-        if: github.repository == 'ros-planning/moveit2'
+        if: github.repository == 'moveit/moveit2'
         with:
-          domain: ros-planning
+          domain: moveit
       - name: Get latest release date for rosdistro
         id: rosdistro_release_date
         uses: JafarAbdi/latest-rosdistro-release-date-action@main
@@ -140,7 +140,7 @@ jobs:
         uses: ros-industrial/industrial_ci@master
         env: ${{ matrix.env }}
       - name: Push result to Testspace
-        if: always() && (github.repository == 'ros-planning/moveit2')
+        if: always() && (github.repository == 'moveit/moveit2')
         run: |
           testspace "[ ${{ matrix.env.IMAGE }} ]${{ env.BASEDIR }}/target_ws/**/test_results/**/*.xml"
       - name: Upload test artifacts (on failure)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,7 @@ name: CI
 on:
   workflow_dispatch:
   pull_request:
+  merge_group:
   push:
     branches:
       - humble
@@ -16,17 +17,19 @@ jobs:
       fail-fast: false
       matrix:
         env:
-          - IMAGE: humble-ci
-            CCOV: true
-            ROS_DISTRO: humble
-          - IMAGE: humble-ci
-            ROS_DISTRO: humble
+          - IMAGE: rolling-ci
+            CCOV: false # Disabled: https://github.com/moveit/moveit2/issues/2866
+            ROS_DISTRO: rolling
+          - IMAGE: rolling-ci
+            ROS_DISTRO: rolling
             IKFAST_TEST: true
             CLANG_TIDY: pedantic
-            # Silent gmock/gtest warnings by picking more recent googletest version
-            AFTER_BUILD_UPSTREAM_WORKSPACE: |
-              git clone --depth 1 --quiet --branch 1.11.9000 https://github.com/ament/googletest "${BASEDIR}/upstream_ws/src/googletest"
-              builder_run_build "/opt/ros/${ROS_DISTRO}" "${BASEDIR}/upstream_ws" --packages-select gtest_vendor gmock_vendor
+          - IMAGE: humble-ci
+            ROS_DISTRO: humble
+          - IMAGE: humble-ci-testing
+            ROS_DISTRO: humble
+          - IMAGE: jazzy-ci
+            ROS_DISTRO: jazzy
     env:
       CXXFLAGS: >-
         -Wall -Wextra -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls
@@ -37,9 +40,6 @@ jobs:
         $(f="moveit2_$(sed 's/-.*$//' <<< "${{ matrix.env.IMAGE }}").repos"; test -r $f && echo $f)
       # Pull any updates to the upstream workspace (after restoring it from cache)
       AFTER_SETUP_UPSTREAM_WORKSPACE: vcs pull $BASEDIR/upstream_ws/src
-      # Uninstall binaries that are duplicated in the .repos file
-      # TODO(andyz): remove this once a sync containing 35b93c8 happens
-      AFTER_SETUP_UPSTREAM_WORKSPACE_EMBED: sudo apt remove ros-${{ matrix.env.ROS_DISTRO }}-moveit-msgs -y
       AFTER_SETUP_DOWNSTREAM_WORKSPACE: vcs pull $BASEDIR/downstream_ws/src
       # Clear the ccache stats before and log the stats after the build
       AFTER_SETUP_CCACHE: ccache --zero-stats --max-size=10.0G
@@ -52,7 +52,7 @@ jobs:
         -DCMAKE_SHARED_LINKER_FLAGS=-fuse-ld=lld
         -DCMAKE_MODULE_LINKER_FLAGS=-fuse-ld=lld
         -DCMAKE_BUILD_TYPE=${{ matrix.env.CCOV && 'Debug' || 'Release'}}
-        -DCMAKE_CXX_FLAGS="-Werror $CXXFLAGS${{ matrix.env.CCOV && ' --coverage -O2 -fno-omit-frame-pointer'}}"
+        -DCMAKE_CXX_FLAGS="-Werror $CXXFLAGS${{ matrix.env.CCOV && ' --coverage -O2 -fno-omit-frame-pointer' || ''}}"
       UPSTREAM_CMAKE_ARGS: "-DCMAKE_CXX_FLAGS=''"
       DOWNSTREAM_CMAKE_ARGS: -DCMAKE_CXX_FLAGS="-Wall -Wextra"
       CCACHE_DIR: ${{ github.workspace }}/.ccache
@@ -63,6 +63,7 @@ jobs:
         (cd $TARGET_REPO_PATH; clang-tidy --list-checks)
         # Disable clang-tidy for ikfast plugins as we cannot fix the generated code
         find $BASEDIR/target_ws/build -iwholename "*_ikfast_plugin/compile_commands.json" -exec rm {} \;
+        find $BASEDIR/target_ws/build -iwholename "*_ikfast_manipulator_plugin/compile_commands.json" -exec rm {} \;
       CC: ${{ matrix.env.CLANG_TIDY && 'clang' }}
       CXX: ${{ matrix.env.CLANG_TIDY && 'clang++' }}
       ADDITIONAL_DEBS: lld
@@ -73,7 +74,7 @@ jobs:
       - name: "Free up disk space"
         if: matrix.env.CCOV
         run: |
-          sudo apt-get -qq purge build-essential "ghc*"
+          sudo apt-get -qq purge "ghc*"
           sudo apt-get clean
           # cleanup docker images not used by us
           docker system prune -af
@@ -85,12 +86,12 @@ jobs:
           sudo rm -rf /usr/local
           df -h
       - uses: actions/checkout@v4
-      # NOTE: Testspace is temporarily disabled and needs to be installed for the MoveIt org
-      # See: https://github.com/moveit/moveit2/issues/2852
-      # - uses: testspace-com/setup-testspace@v1
-      #   if: github.repository == 'moveit/moveit2'
-      #   with:
-      #     domain: moveit
+# NOTE: Testspace is temporarily disabled and needs to be installed for the MoveIt org
+# See: https://github.com/moveit/moveit2/issues/2852
+#       - uses: testspace-com/setup-testspace@v1
+#         if: github.repository == 'moveit/moveit2'
+#         with:
+#           domain: moveit
       - name: Get latest release date for rosdistro
         id: rosdistro_release_date
         uses: JafarAbdi/latest-rosdistro-release-date-action@main
@@ -102,26 +103,28 @@ jobs:
         with:
           file: moveit2.repos
       - name: Cache upstream workspace
-        uses: pat-s/always-upload-cache@v3.0.11
+        uses: rhaschke/cache@main
         with:
           path: ${{ env.BASEDIR }}/upstream_ws
           key: ${{ env.CACHE_PREFIX }}-${{ github.run_id }}
           restore-keys: ${{ env.CACHE_PREFIX }}
         env:
+          GHA_CACHE_SAVE: always
           CACHE_PREFIX: ${{ steps.rosdistro_release_date.outputs.date }}-upstream_ws-${{ steps.repos_edit_timestamp.outputs.timestamp }}-${{ matrix.env.IMAGE }}-${{ hashFiles('moveit2*.repos', '.github/workflows/ci.yaml') }}
       # The target directory cache doesn't include the source directory because
       # that comes from the checkout.  See "prepare target_ws for cache" task below
       - name: Cache target workspace
         if: "!matrix.env.CCOV"
-        uses: pat-s/always-upload-cache@v3.0.11
+        uses: rhaschke/cache@main
         with:
           path: ${{ env.BASEDIR }}/target_ws
           key: ${{ env.CACHE_PREFIX }}-${{ github.run_id }}
           restore-keys: ${{ env.CACHE_PREFIX }}
         env:
+          GHA_CACHE_SAVE: always
           CACHE_PREFIX: target_ws${{ matrix.env.CCOV && '-ccov' || '' }}-${{ matrix.env.IMAGE }}-${{ hashFiles('**/CMakeLists.txt', '**/package.xml', '.github/workflows/ci.yaml') }}
       - name: Cache ccache
-        uses: pat-s/always-upload-cache@v3.0.11
+        uses: rhaschke/cache@main
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ${{ env.CACHE_PREFIX }}-${{ github.sha }}-${{ github.run_id }}
@@ -129,6 +132,7 @@ jobs:
             ${{ env.CACHE_PREFIX }}-${{ github.sha }}
             ${{ env.CACHE_PREFIX }}
         env:
+          GHA_CACHE_SAVE: always
           CACHE_PREFIX: ccache-${{ matrix.env.IMAGE }}${{ matrix.env.CCOV && '-ccov' || '' }}
       - name: Configure ccache
         run: |
@@ -141,14 +145,14 @@ jobs:
         name: Run industrial_ci
         uses: ros-industrial/industrial_ci@master
         env: ${{ matrix.env }}
-      # NOTE: Testspace is temporarily disabled and needs to be installed for the MoveIt org
-      # See: https://github.com/moveit/moveit2/issues/2852
-      # - name: Push result to Testspace
-      #   if: always() && (github.repository == 'moveit/moveit2')
-      #   run: |
-      #     testspace "[ ${{ matrix.env.IMAGE }} ]${{ env.BASEDIR }}/target_ws/**/test_results/**/*.xml"
+# NOTE: Testspace is temporarily disabled and needs to be installed for the MoveIt org
+# See: https://github.com/moveit/moveit2/issues/2852
+#      - name: Push result to Testspace
+#        if: always() && (github.repository == 'moveit/moveit2')
+#        run: |
+#          testspace "[ ${{ matrix.env.IMAGE }} ]${{ env.BASEDIR }}/target_ws/**/test_results/**/*.xml"
       - name: Upload test artifacts (on failure)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure() && (steps.ici.outputs.run_target_test || steps.ici.outputs.target_test_results)
         with:
           name: test-results-${{ matrix.env.IMAGE }}
@@ -161,7 +165,7 @@ jobs:
           workdir: ${{ env.BASEDIR }}/target_ws
           ignore: '"*/target_ws/build/*" "*/target_ws/install/*" "*/test/*"'
       - name: Upload codecov report
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         if: always() && matrix.env.CCOV && steps.ici.outputs.target_test_results == '0'
         with:
           files: ${{ env.BASEDIR }}/target_ws/coverage.info

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -85,10 +85,12 @@ jobs:
           sudo rm -rf /usr/local
           df -h
       - uses: actions/checkout@v4
-      - uses: testspace-com/setup-testspace@v1
-        if: github.repository == 'moveit/moveit2'
-        with:
-          domain: moveit
+      # NOTE: Testspace is temporarily disabled and needs to be installed for the MoveIt org
+      # See: https://github.com/moveit/moveit2/issues/2852
+      # - uses: testspace-com/setup-testspace@v1
+      #   if: github.repository == 'moveit/moveit2'
+      #   with:
+      #     domain: moveit
       - name: Get latest release date for rosdistro
         id: rosdistro_release_date
         uses: JafarAbdi/latest-rosdistro-release-date-action@main
@@ -139,10 +141,12 @@ jobs:
         name: Run industrial_ci
         uses: ros-industrial/industrial_ci@master
         env: ${{ matrix.env }}
-      - name: Push result to Testspace
-        if: always() && (github.repository == 'moveit/moveit2')
-        run: |
-          testspace "[ ${{ matrix.env.IMAGE }} ]${{ env.BASEDIR }}/target_ws/**/test_results/**/*.xml"
+      # NOTE: Testspace is temporarily disabled and needs to be installed for the MoveIt org
+      # See: https://github.com/moveit/moveit2/issues/2852
+      # - name: Push result to Testspace
+      #   if: always() && (github.repository == 'moveit/moveit2')
+      #   run: |
+      #     testspace "[ ${{ matrix.env.IMAGE }} ]${{ env.BASEDIR }}/target_ws/**/test_results/**/*.xml"
       - name: Upload test artifacts (on failure)
         uses: actions/upload-artifact@v3
         if: failure() && (steps.ici.outputs.run_target_test || steps.ici.outputs.target_test_results)

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -78,9 +78,9 @@ jobs:
       packages: write
       contents: read
     env:
-      GH_IMAGE: ghcr.io/ros-planning/moveit2:${{ matrix.ROS_DISTRO }}-${{ github.job }}
+      GH_IMAGE: ghcr.io/moveit/moveit2:${{ matrix.ROS_DISTRO }}-${{ github.job }}
       DH_IMAGE: moveit/moveit2:${{ matrix.ROS_DISTRO }}-${{ github.job }}
-      PUSH: ${{ (github.event_name != 'pull_request') && (github.repository == 'ros-planning/moveit2') }}
+      PUSH: ${{ (github.event_name != 'pull_request') && (github.repository == 'moveit/moveit2') }}
 
     steps:
       - uses: rhaschke/docker-run-action@v5
@@ -134,9 +134,9 @@ jobs:
       packages: write
       contents: read
     env:
-      GH_IMAGE: ghcr.io/ros-planning/moveit2:${{ matrix.ROS_DISTRO }}-${{ github.job }}
+      GH_IMAGE: ghcr.io/moveit/moveit2:${{ matrix.ROS_DISTRO }}-${{ github.job }}
       DH_IMAGE: moveit/moveit2:${{ matrix.ROS_DISTRO }}-${{ github.job }}
-      PUSH: ${{ (github.event_name != 'pull_request') && (github.repository == 'ros-planning/moveit2') }}
+      PUSH: ${{ (github.event_name != 'pull_request') && (github.repository == 'moveit/moveit2') }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -176,7 +176,7 @@ jobs:
       - source
     steps:
       - name: Delete Untagged Images
-        if: (github.event_name != 'pull_request') && (github.repository == 'ros-planning/moveit2')
+        if: (github.event_name != 'pull_request') && (github.repository == 'moveit/moveit2')
         uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.DELETE_PACKAGES_TOKEN }}
@@ -192,6 +192,6 @@ jobs:
                 }
             }
         env:
-          OWNER: ros-planning
+          OWNER: moveit
           PACKAGE_NAME: moveit2
           PER_PAGE: 100

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -25,9 +25,9 @@ jobs:
       packages: write
       contents: read
     env:
-      GH_IMAGE: ghcr.io/ros-planning/moveit2:${{ matrix.ROS_DISTRO }}-${{ github.job }}
+      GH_IMAGE: ghcr.io/moveit/moveit2:${{ matrix.ROS_DISTRO }}-${{ github.job }}
       DH_IMAGE: moveit/moveit2:${{ matrix.ROS_DISTRO }}-${{ github.job }}
-      PUSH: ${{ (github.event_name != 'pull_request') && (github.repository == 'ros-planning/moveit2') }}
+      PUSH: ${{ (github.event_name != 'pull_request') && (github.repository == 'moveit/moveit2') }}
 
     steps:
       - uses: rhaschke/docker-run-action@v5

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -158,13 +158,14 @@ jobs:
       - name: "Remove .dockerignore"
         run: rm .dockerignore  # enforce full source context
       - name: Build and Push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: .docker/${{ github.job }}/Dockerfile
           build-args: ROS_DISTRO=${{ matrix.ROS_DISTRO }}
           push: ${{ env.PUSH }}
-          no-cache: true
+          cache-from: type=registry,ref=${{ env.GH_IMAGE }}
+          cache-to: type=inline
           tags: |
             ${{ env.GH_IMAGE }}
             ${{ env.DH_IMAGE }}
@@ -177,7 +178,7 @@ jobs:
     steps:
       - name: Delete Untagged Images
         if: (github.event_name != 'pull_request') && (github.repository == 'moveit/moveit2')
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.DELETE_PACKAGES_TOKEN }}
           script: |


### PR DESCRIPTION
### Description

Missed a few more in https://github.com/moveit/moveit2/pull/3101... this is hard to do from a phone.

Also generally brought in all the relevant CI changes from `main`, for parity.

NOTE: This may fail until merged because this will finally upload the `humble-ci` image to Docker Hub. Took me forever to figure this out.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
