### PR TITLE
Fixes flaky RobotState test

### DIFF
--- a/moveit_core/robot_state/test/robot_state_test.cpp
+++ b/moveit_core/robot_state/test/robot_state_test.cpp
@@ -781,6 +781,8 @@ TEST_F(OneRobot, rigidlyConnectedParent)
   EXPECT_EQ(robot_model_->getRigidlyConnectedParentLinkModel(link_b), link_a);
 
   moveit::core::RobotState state(robot_model_);
+  state.setToDefaultValues();
+  state.updateLinkTransforms();
 
   EXPECT_EQ(state.getRigidlyConnectedParentLinkModel("link_b"), link_a);
 
@@ -789,6 +791,9 @@ TEST_F(OneRobot, rigidlyConnectedParent)
       link_b, "object", Eigen::Isometry3d::Identity(), std::vector<shapes::ShapeConstPtr>{},
       EigenSTL::vector_Isometry3d{}, std::set<std::string>{}, trajectory_msgs::msg::JointTrajectory{},
       moveit::core::FixedTransformsMap{ { "subframe", Eigen::Isometry3d::Identity() } }));
+
+  // This may be redundant
+  state.updateLinkTransforms();
 
   // RobotState's version should resolve these too
   EXPECT_EQ(link_a, state.getRigidlyConnectedParentLinkModel("object"));

--- a/moveit_core/robot_state/test/robot_state_test.cpp
+++ b/moveit_core/robot_state/test/robot_state_test.cpp
@@ -792,9 +792,6 @@ TEST_F(OneRobot, rigidlyConnectedParent)
       EigenSTL::vector_Isometry3d{}, std::set<std::string>{}, trajectory_msgs::msg::JointTrajectory{},
       moveit::core::FixedTransformsMap{ { "subframe", Eigen::Isometry3d::Identity() } }));
 
-  // This may be redundant
-  state.updateLinkTransforms();
-
   // RobotState's version should resolve these too
   EXPECT_EQ(link_a, state.getRigidlyConnectedParentLinkModel("object"));
   EXPECT_EQ(link_a, state.getRigidlyConnectedParentLinkModel("object/subframe"));


### PR DESCRIPTION
### Description

Fixes #3103 by ensuring that the `dirty_link_transforms_` member is cleared before querying the `RobotState`

See #3102 for more details on the cause. 

TLDR: 

Setting the build type to Release causes tests to silently fail, whereas Debug does not (some tests rely on assert calls, which are enabled / disabled based on the presence of the `NDBUG` macro variable, which is set by CMake depending on the build type). 

See the SonarScan pipeline call to ros-industrial/industrial_ci@master, which sets DCMAKE_BUILD_TYPE to Debug (and where the tests fail), and the same call in the rolling-ci pipeline (where the tests pass), which sets the same variable to Release.

I've also added a comment (and demonstration of the fix, at least for this test) locally.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [x] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [x] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [x] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
