### PR TITLE
[Humble] Add sleep in setup of flaky PSM test fixture

### DIFF
--- a/moveit_ros/planning/planning_scene_monitor/test/planning_scene_monitor_test.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/test/planning_scene_monitor_test.cpp
@@ -59,6 +59,9 @@ public:
     scene_ = planning_scene_monitor_->getPlanningScene();
     executor_->add_node(test_node_);
     executor_thread_ = std::thread([this]() { executor_->spin(); });
+
+    // Needed to avoid race conditions on high-load CPUs.
+    std::this_thread::sleep_for(std::chrono::seconds{ 1 });
   }
 
   void TearDown() override


### PR DESCRIPTION
### Description

This is the Humble version of https://github.com/moveit/moveit2/pull/3124, in which the test was never disabled and continued to be flaky.

See my log of successful retries: https://github.com/moveit/moveit2/actions/runs/11966024737?pr=3126

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
