### PR TITLE
Humble

### DIFF
--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_generator.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_generator.h
@@ -136,8 +136,16 @@ protected:
    * The trap profile returns uses the longer distance of translational and
    * rotational motion.
    */
-  std::unique_ptr<KDL::VelocityProfile> cartesianTrapVelocityProfile(const double& max_velocity_scaling_factor,
+    std::unique_ptr<KDL::VelocityProfile> cartesianTrapVelocityProfile(const double& max_velocity_scaling_factor,
                                                                      const double& max_acceleration_scaling_factor,
+                                                                     const std::unique_ptr<KDL::Path>& path) const;
+    /**
+   * @brief build cartesian velocity profile for the path
+   *
+   * Uses the path to get the cartesian length from start to goal.
+   * The rect profile returns a uniform velocity profile without considering the acceleration
+   */    
+   std::unique_ptr<KDL::VelocityProfile> cartesianRectVelocityProfile(const double& max_velocity_scaling_factor,
                                                                      const std::unique_ptr<KDL::Path>& path) const;
 
 private:

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_generator.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_generator.h
@@ -279,7 +279,7 @@ private:
 protected:
   const moveit::core::RobotModelConstPtr robot_model_;
   const pilz_industrial_motion_planner::LimitsContainer planner_limits_;
-  static constexpr double MIN_SCALING_FACTOR{ 0.0001 };
+  static constexpr double MIN_SCALING_FACTOR{ 0.0000001 };
   static constexpr double MAX_SCALING_FACTOR{ 1. };
   static constexpr double VELOCITY_TOLERANCE{ 1e-8 };
   const std::unique_ptr<rclcpp::Clock> clock_;

--- a/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_lin.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_lin.cpp
@@ -154,10 +154,12 @@ void TrajectoryGeneratorLIN::plan(const planning_scene::PlanningSceneConstPtr& s
   // create Cartesian path for lin
   std::unique_ptr<KDL::Path> path(setPathLIN(plan_info.start_pose, plan_info.goal_pose));
 
-  // create velocity profile
+  // create velocity profile using trap profile
+  //std::unique_ptr<KDL::VelocityProfile> vp(
+  //    cartesianTrapVelocityProfile(req.max_velocity_scaling_factor, req.max_acceleration_scaling_factor, path));
+  // create velocity profile using rect profile
   std::unique_ptr<KDL::VelocityProfile> vp(
-      cartesianTrapVelocityProfile(req.max_velocity_scaling_factor, req.max_acceleration_scaling_factor, path));
-
+        cartesianRectVelocityProfile(req.max_velocity_scaling_factor, path));
   // combine path and velocity profile into Cartesian trajectory
   // with the third parameter set to false, KDL::Trajectory_Segment does not
   // take
@@ -185,8 +187,9 @@ std::unique_ptr<KDL::Path> TrajectoryGeneratorLIN::setPathLIN(const Eigen::Affin
   KDL::Frame kdl_start_pose, kdl_goal_pose;
   tf2::transformEigenToKDL(start_pose, kdl_start_pose);
   tf2::transformEigenToKDL(goal_pose, kdl_goal_pose);
-  double eqradius = planner_limits_.getCartesianLimits().getMaxTranslationalVelocity() /
-                    planner_limits_.getCartesianLimits().getMaxRotationalVelocity();
+  //double eqradius = planner_limits_.getCartesianLimits().getMaxTranslationalVelocity() /
+  //                  planner_limits_.getCartesianLimits().getMaxRotationalVelocity();
+  double eqradius = 0.0;
   KDL::RotationalInterpolation* rot_interpo = new KDL::RotationalInterpolation_SingleAxis();
 
   return std::unique_ptr<KDL::Path>(


### PR DESCRIPTION
The solution for solving the deviation as described in  #2909.

 The issue is that the Pilz LIN planner deviates from target linear speed when rotation is involved in a move. The issue seems to arise from two factors within Pilz, both related to KDL::Path_line. 

1) While generating the path using KDL::Path_line a parameter called eqradius is used. The use of Eqradius prevents very fast angular motions but as a side effect the motion deviated from the specified linear speed. *
*solution** : set eqradius to zero if the motion should only consider the specified linear TCP speed

2) Even after setting eqradius to zero we observed a small deviation in the time take for motion, this was pin-pointed to the use of trapezoidal velocity profile. 
**solution** : By using a rectangular velocity profile this issue seems to be solved.

It would be nice if these changes can be used if the use-case requires that the time for motion has to be accurate. Now I have permanently changed the code but maybe we could force Pilz to use rectangular profile when acceleration limit is not specified as suggested by @sea-bass ?

