### PR TITLE
rm unnessary time offset in pilz

### DIFF
--- a/moveit_planners/pilz_industrial_motion_planner/src/plan_components_builder.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/plan_components_builder.cpp
@@ -54,6 +54,11 @@ std::vector<robot_trajectory::RobotTrajectoryPtr> PlanComponentsBuilder::build()
 void PlanComponentsBuilder::appendWithStrictTimeIncrease(robot_trajectory::RobotTrajectory& result,
                                                          const robot_trajectory::RobotTrajectory& source)
 {
+  if (!source.getWayPointCount())
+  {
+    return;
+  }
+
   if (result.empty())
   {
     result.append(source, 0.0);
@@ -62,7 +67,14 @@ void PlanComponentsBuilder::appendWithStrictTimeIncrease(robot_trajectory::Robot
   if (!pilz_industrial_motion_planner::isRobotStateEqual(result.getLastWayPoint(), source.getFirstWayPoint(),
                                                          result.getGroupName(), ROBOT_STATE_EQUALITY_EPSILON))
   {
-    result.append(source, source.getWayPointDurationFromStart(0));
+    if (source.getWayPointDurationFromPrevious(0) == 0)
+    {
+      result.append(source, source.getWayPointDurationFromStart(0));
+    }
+    else
+    {
+      result.append(source, 0.0);
+    }
     return;
   }
 


### PR DESCRIPTION
### Description

A workaround of #3161 

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
