### PR TITLE
Update controller_manager_plugin.cpp

### DIFF
--- a/moveit_plugins/moveit_ros_control_interface/src/controller_manager_plugin.cpp
+++ b/moveit_plugins/moveit_ros_control_interface/src/controller_manager_plugin.cpp
@@ -264,7 +264,7 @@ public:
   void initialize(const rclcpp::Node::SharedPtr& node) override
   {
     node_ = node;
-    if (!ns_.empty())
+    if (ns_.empty())
     {
       if (!node_->has_parameter("ros_control_namespace"))
       {
@@ -274,11 +274,6 @@ public:
       {
         node_->get_parameter<std::string>("ros_control_namespace", ns_);
       }
-    }
-    else if (node->has_parameter("ros_control_namespace"))
-    {
-      node_->get_parameter<std::string>("ros_control_namespace", ns_);
-      RCLCPP_INFO_STREAM(getLogger(), "Namespace for controller manager was specified, namespace: " << ns_);
     }
 
     list_controllers_service_ = node_->create_client<controller_manager_msgs::srv::ListControllers>(


### PR DESCRIPTION
Fixing the bug where the namespace is not properly applied when using Ros2ControlMultiManager

### Description

When using two ROS2 controls, the namespace is automatically detected, but the namespace is not properly applied when registering the action client.

For more details, please refer to https://github.com/moveit/moveit2/issues/3150