### PR TITLE
Allow passing pointers by value in clang-tidy settings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -64,5 +64,5 @@ CheckOptions:
     value:           UPPER_CASE
   # Allow passing pointers by value
   - key:             performance-unnecessary-value-param.AllowedTypes
-    value:           std::shared_ptr;std::unique_ptr
+    value:           ::std::shared_ptr;::std::unique_ptr
 ...

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -62,4 +62,7 @@ CheckOptions:
     value:           UPPER_CASE
   - key:             readability-identifier-naming.ClassConstantCase
     value:           UPPER_CASE
+  # Allow passing pointers by value
+  - key:             performance-unnecessary-value-param.AllowedTypes
+    value:           std::shared_ptr;std::unique_ptr
 ...


### PR DESCRIPTION
### Description

What the title says.

I'm torn on whether this should be allowed given the discussions in https://reviews.llvm.org/D52360 ... but I am leaning on this at least being allowed.

Curious what people who know C++ better than I do think.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
