### PR TITLE
Remove ACM entries when removing collision objects

### DIFF
--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -1466,7 +1466,6 @@ void PlanningScene::removeAllCollisionObjects()
       world_->removeObject(object_id);
       removeObjectColor(object_id);
       removeObjectType(object_id);
-      // TODO: How about octomap?
       getAllowedCollisionMatrixNonConst().removeEntry(object_id);
     }
   }

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -374,6 +374,7 @@ void PlanningScene::pushDiffs(const PlanningScenePtr& scene)
         scene->world_->removeObject(it.first);
         scene->removeObjectColor(it.first);
         scene->removeObjectType(it.first);
+        scene->getAllowedCollisionMatrixNonConst().removeEntry(it.first);
       }
       else
       {
@@ -1465,6 +1466,8 @@ void PlanningScene::removeAllCollisionObjects()
       world_->removeObject(object_id);
       removeObjectColor(object_id);
       removeObjectType(object_id);
+      // TODO: How about octomap?
+      getAllowedCollisionMatrixNonConst().removeEntry(object_id);
     }
   }
 }
@@ -1939,6 +1942,7 @@ bool PlanningScene::processCollisionObjectRemove(const moveit_msgs::msg::Collisi
 
     removeObjectColor(object.id);
     removeObjectType(object.id);
+    getAllowedCollisionMatrixNonConst().removeEntry(object.id);
   }
   return true;
 }

--- a/moveit_core/planning_scene/test/test_planning_scene.cpp
+++ b/moveit_core/planning_scene/test/test_planning_scene.cpp
@@ -590,7 +590,7 @@ TEST(PlanningScene, RobotStateDiffBug)
   }
 }
 
-TEST(PlanningScene, ACMBug)
+TEST(PlanningScene, UpdateACMAfterObjectRemoval)
 {
   auto robot_model = moveit::core::loadTestingRobotModel("panda");
   auto ps = std::make_shared<planning_scene::PlanningScene>(robot_model);


### PR DESCRIPTION
### Description

When removing collision objects from a planning scene, we need to also remove their corresponding entries from the allowed collision matrix. Previously, these entries would remain in the ACM even after the object was removed, which could cause inconsistencies if an object with the same name was added later.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
