### PR TITLE
Fix planning_scene_monitor sync when passed empty robot state

### DIFF
--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -732,9 +732,11 @@ bool PlanningSceneMonitor::newPlanningSceneMessage(const moveit_msgs::msg::Plann
     if (!scene.is_diff && parent_scene_)
     {
       // if the scene does not contain a robot state then use the latest value from the current_state_monitor_
-      // so that we are not updating the scene with stale values for the robots state.
-      if (scene.robot_state.joint_state.name.empty())
+      // so that we are not updating the scene with stale values for the robot's state.
+      if (scene.robot_state.joint_state.name.empty() && current_state_monitor_->haveCompleteState())
+      {
         parent_scene_->setCurrentState(*current_state_monitor_->getCurrentState());
+      }
       // clear maintained (diff) scene_ and set the full new scene in parent_scene_ instead
       scene_->clearDiffs();
       result = parent_scene_->setPlanningSceneMsg(scene);

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -731,11 +731,20 @@ bool PlanningSceneMonitor::newPlanningSceneMessage(const moveit_msgs::msg::Plann
 
     if (!scene.is_diff && parent_scene_)
     {
-      // if the scene does not contain a robot state then use the latest value from the current_state_monitor_
-      // so that we are not updating the scene with stale values for the robot's state.
-      if (scene.robot_state.joint_state.name.empty() && current_state_monitor_->haveCompleteState())
+      // if the scene does not contain a robot state then use the latest known values for the robot state
+      // so that we are not updating the scene with stale values.
+      if (scene.robot_state.joint_state.name.empty())
       {
-        parent_scene_->setCurrentState(*current_state_monitor_->getCurrentState());
+        // if we have a valid current_state_monitor_ with complete state use the latest data otherwise try
+        // to use the maintained (diff) scene_ which may fall back to the parent_scene_ data and not update.
+        if (current_state_monitor_ && current_state_monitor_->haveCompleteState())
+        {
+          parent_scene_->setCurrentState(*current_state_monitor_->getCurrentState());
+        }
+        else
+        {
+          parent_scene_->setCurrentState(scene_->getCurrentState());
+        }
       }
       // clear maintained (diff) scene_ and set the full new scene in parent_scene_ instead
       scene_->clearDiffs();

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -731,6 +731,10 @@ bool PlanningSceneMonitor::newPlanningSceneMessage(const moveit_msgs::msg::Plann
 
     if (!scene.is_diff && parent_scene_)
     {
+      // if the scene does not contain a robot state then use the latest value from the current_state_monitor_
+      // so that we are not updating the scene with stale values for the robots state.
+      if (scene.robot_state.joint_state.name.empty())
+        parent_scene_->setCurrentState(*current_state_monitor_->getCurrentState());
       // clear maintained (diff) scene_ and set the full new scene in parent_scene_ instead
       scene_->clearDiffs();
       result = parent_scene_->setPlanningSceneMsg(scene);


### PR DESCRIPTION
### Description

Fixes issue #3174.

When motion planning and executing solutions with MTC I have stages where objects are attached/removed and deleted from the scene at the beginning or end of a task. I have been having issues with the planning scene not updating correctly and the final state of the robot in the planning scene having offsets compared to the final state of trajectory given.

When executing an MTC solution that contains changes to the planning scene they are sent to the `planning_scene_monitor_` with [no robot_state information](https://github.com/moveit/moveit_task_constructor/blob/master/capabilities/src/execute_task_solution_capability.cpp#L173-L176). When MoveIt receives this `newPlanningSceneMessage` that is not marked as a scene_diff (because things are being added or removed from the scene) the first thing is does is clear out the maintained diff `scene_`. The problem with this approach is that the `planning_scene_monitor_` is only updating it's `parent_scene_` at a 2Hz rate. Depending on when the trajectory finishes vs the last time the `parent_scene_` was updated it could contain stale robot state information and by calling [scene_->clearDiffs()](https://github.com/MarqRazz/moveit2/blob/main/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp#L735) we throw all of our updated robot state information away before we `setPlanningSceneMsg` with a message that does not contain robot_state so it uses the old values it had from the last sync.

To fix the issue this PR checks if the `newPlanningSceneMessage` contains a robot_state. If it does not it updates the `parent_scene_` with the latest information from the `current_state_monitor_` before calling `setPlanningSceneMsg(scene)` to ensure that the new scene is applied with the most up to date robot_state information.