### PR TITLE
Fix: Conditionally install launch directory in generated MoveIt config package

### DIFF
--- a/moveit_setup_assistant/moveit_setup_framework/templates/CMakeLists.txt
+++ b/moveit_setup_assistant/moveit_setup_framework/templates/CMakeLists.txt
@@ -5,9 +5,12 @@ find_package(ament_cmake REQUIRED)
 
 ament_package()
 
-install(
-  DIRECTORY launch
-  DESTINATION share/${PROJECT_NAME}
-  PATTERN "setup_assistant.launch" EXCLUDE)
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/launch")
+  install(
+    DIRECTORY launch
+    DESTINATION share/${PROJECT_NAME}
+    PATTERN "setup_assistant.launch" EXCLUDE)
+endif()
+
 install(DIRECTORY config DESTINATION share/${PROJECT_NAME})
 install(FILES .setup_assistant DESTINATION share/${PROJECT_NAME})


### PR DESCRIPTION
### Overview

This pull request addresses issue #3189 where the `CMakeLists.txt` file always attempts to install the `launch` directory, even if it does not exist. This can cause the installation process to fail when no launch files are created in the setup assistant.

### Changes Made

1. **CMakeLists.txt**:
   - Added a condition to check if the `launch` directory exists before attempting to install it. This ensures that the installation process does not fail when the `launch` directory is not present.

```cmake
  // filepath: /ros2_humble/src/moveit2/moveit_setup_assistant/moveit_setup_framework/templates/CMakeLists.txt
  // ...existing code...
  if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/launch")
    install(
      DIRECTORY launch
      DESTINATION share/${PROJECT_NAME}
      PATTERN "setup_assistant.launch" EXCLUDE)
  endif()
  // ...existing code...