### PR TITLE
Use Gazebo Ionic in tutorial images

### DIFF
--- a/.docker/tutorial-source/Dockerfile
+++ b/.docker/tutorial-source/Dockerfile
@@ -4,7 +4,7 @@
 # Source build of the repos file from the tutorial site
 
 ARG ROS_DISTRO=rolling
-ARG GZ_VERSION=harmonic
+ARG GZ_VERSION=ionic
 
 FROM moveit/moveit2:${ROS_DISTRO}-ci
 LABEL maintainer Tyler Weaver tyler@picknik.ai


### PR DESCRIPTION
### Description

Seems like  Rolling has now shifted to using Gazebo Ionic... seeing if this fixes the build. (EDIT: it does.)

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
