### PR TITLE
Don't destroy objects on attach

### DIFF
--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -371,10 +371,16 @@ void PlanningScene::pushDiffs(const PlanningScenePtr& scene)
     {
       if (it.second == collision_detection::World::DESTROY)
       {
-        scene->world_->removeObject(it.first);
-        scene->removeObjectColor(it.first);
-        scene->removeObjectType(it.first);
-        scene->getAllowedCollisionMatrixNonConst().removeEntry(it.first);
+        moveit_msgs::msg::AttachedCollisionObject aco;
+        scene->getAttachedCollisionObjectMsg(aco, it.first);
+        // if object became attached, it should not be recorded as DESTROY here
+        if (aco.object.operation == moveit_msgs::msg::CollisionObject::REMOVE)
+        {
+          scene->world_->removeObject(it.first);
+          scene->removeObjectColor(it.first);
+          scene->removeObjectType(it.first);
+          scene->getAllowedCollisionMatrixNonConst().removeEntry(it.first);
+        }
       }
       else
       {

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -371,14 +371,12 @@ void PlanningScene::pushDiffs(const PlanningScenePtr& scene)
     {
       if (it.second == collision_detection::World::DESTROY)
       {
-        moveit_msgs::msg::AttachedCollisionObject aco;
-        scene->getAttachedCollisionObjectMsg(aco, it.first);
-        // if object became attached, it should not be recorded as DESTROY here
-        if (aco.object.operation == moveit_msgs::msg::CollisionObject::REMOVE)
+        scene->world_->removeObject(it.first);
+        scene->removeObjectColor(it.first);
+        scene->removeObjectType(it.first);
+        // if object is attached, it should not should not be removed from the ACM
+        if (!getCurrentState().hasAttachedBody(it.first))
         {
-          scene->world_->removeObject(it.first);
-          scene->removeObjectColor(it.first);
-          scene->removeObjectType(it.first);
           scene->getAllowedCollisionMatrixNonConst().removeEntry(it.first);
         }
       }

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -374,8 +374,8 @@ void PlanningScene::pushDiffs(const PlanningScenePtr& scene)
         scene->world_->removeObject(it.first);
         scene->removeObjectColor(it.first);
         scene->removeObjectType(it.first);
-        // if object is attached, it should not should not be removed from the ACM
-        if (!getCurrentState().hasAttachedBody(it.first))
+        // if object is attached, it should not be removed from the ACM
+        if (!scene->getCurrentState().hasAttachedBody(it.first))
         {
           scene->getAllowedCollisionMatrixNonConst().removeEntry(it.first);
         }

--- a/moveit_core/planning_scene/test/test_planning_scene.cpp
+++ b/moveit_core/planning_scene/test/test_planning_scene.cpp
@@ -607,6 +607,20 @@ TEST(PlanningScene, UpdateACMAfterObjectRemoval)
     EXPECT_EQ(getCollisionObjectsNames(*ps), (std::set<std::string>{ object_name }));
   };
 
+  // Helper function to attach the object to the robot
+  auto attach_object = [&] {
+    const auto ps1 = createPlanningSceneDiff(*ps, object_name, moveit_msgs::msg::CollisionObject::ADD, true);
+    ps->usePlanningSceneMsg(ps1);
+    EXPECT_EQ(getAttachedCollisionObjectsNames(*ps), (std::set<std::string>{ object_name }));
+  };
+
+  // Helper function to detach the object from the robot
+  auto detach_object = [&] {
+    const auto ps1 = createPlanningSceneDiff(*ps, object_name, moveit_msgs::msg::CollisionObject::REMOVE, true);
+    ps->usePlanningSceneMsg(ps1);
+    EXPECT_EQ(getAttachedCollisionObjectsNames(*ps), (std::set<std::string>{}));
+  };
+
   // Modify the allowed collision matrix and make sure it is updated
   auto modify_acm = [&] {
     collision_detection::AllowedCollisionMatrix& acm = ps->getAllowedCollisionMatrixNonConst();
@@ -626,6 +640,11 @@ TEST(PlanningScene, UpdateACMAfterObjectRemoval)
   add_object();
   EXPECT_TRUE(check_collision());
   modify_acm();
+  EXPECT_FALSE(check_collision());
+  // Attach and detach the object from the robot to make sure that collision are still allowed
+  attach_object();
+  EXPECT_FALSE(check_collision());
+  detach_object();
   EXPECT_FALSE(check_collision());
   {
     const auto ps1 = createPlanningSceneDiff(*ps, object_name, moveit_msgs::msg::CollisionObject::REMOVE);

--- a/moveit_ros/planning/plan_execution/src/plan_execution.cpp
+++ b/moveit_ros/planning/plan_execution/src/plan_execution.cpp
@@ -519,7 +519,6 @@ void plan_execution::PlanExecution::planningSceneUpdatedCallback(
   if (update_type & (planning_scene_monitor::PlanningSceneMonitor::UPDATE_GEOMETRY |
                      planning_scene_monitor::PlanningSceneMonitor::UPDATE_TRANSFORMS))
   {
-    RCLCPP_WARN(logger_, "planningSceneUpdatedCallback update_type: %d", update_type);
     new_scene_update_ = true;
   }
 }
@@ -527,7 +526,6 @@ void plan_execution::PlanExecution::planningSceneUpdatedCallback(
 void plan_execution::PlanExecution::doneWithTrajectoryExecution(
     const moveit_controller_manager::ExecutionStatus& /*status*/)
 {
-  RCLCPP_WARN(logger_, "doneWithTrajectoryExecution");
   execution_complete_ = true;
 }
 
@@ -541,7 +539,7 @@ void plan_execution::PlanExecution::successfulTrajectorySegmentExecution(const E
   }
 
   // if any side-effects are associated to the trajectory part that just completed, execute them
-  RCLCPP_WARN(logger_, "Completed '%s'", plan.plan_components[index].description.c_str());
+  RCLCPP_DEBUG(logger_, "Completed '%s'", plan.plan_components[index].description.c_str());
   if (plan.plan_components[index].effect_on_success)
   {
     if (!plan.plan_components[index].effect_on_success(&plan))

--- a/moveit_ros/planning/plan_execution/src/plan_execution.cpp
+++ b/moveit_ros/planning/plan_execution/src/plan_execution.cpp
@@ -518,9 +518,7 @@ void plan_execution::PlanExecution::planningSceneUpdatedCallback(
 {
   if (update_type & (planning_scene_monitor::PlanningSceneMonitor::UPDATE_GEOMETRY |
                      planning_scene_monitor::PlanningSceneMonitor::UPDATE_TRANSFORMS))
-  {
     new_scene_update_ = true;
-  }
 }
 
 void plan_execution::PlanExecution::doneWithTrajectoryExecution(


### PR DESCRIPTION
### Description

When an object is added to the scene and immediately attached to the gripper it gets marked as [collision_detection::World::DESTROY](https://github.com/moveit/moveit2/blob/main/moveit_core/planning_scene/src/planning_scene.cpp#L372) in the `world_diff_`. When this happens the [ACM is modified](https://github.com/moveit/moveit2/blob/main/moveit_core/planning_scene/src/planning_scene.cpp#L377) and the attached object is not allowed to touch anything. 99% of the time this does not cause issues when executing a trajectory because the [scene diff](https://github.com/moveit/moveit2/blob/main/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp#L502) is not applied until after the trajectory starts, but is still updating the ACM incorrectly. Sometimes the scene diff is applied before starting the trajectory and it fails after the arm starts moving because of [this check here](https://github.com/moveit/moveit2/blob/main/moveit_ros/planning/plan_execution/src/plan_execution.cpp#L443). This PR adds some logic to see if the object is being `ADD`ed as an attached collision object so that it is not `DESTROY`ed causing the ACM to incorrectly update.
