### PR TITLE
fix: OctoMap and Filtered_Cloud Not Updating During Movement Execution

### DIFF
--- a/moveit_ros/perception/pointcloud_octomap_updater/include/moveit/pointcloud_octomap_updater/pointcloud_octomap_updater.hpp
+++ b/moveit_ros/perception/pointcloud_octomap_updater/include/moveit/pointcloud_octomap_updater/pointcloud_octomap_updater.hpp
@@ -37,6 +37,7 @@
 #pragma once
 
 #include <rclcpp/rclcpp.hpp>
+#include <rclcpp/callback_group.hpp>
 #include <rclcpp/version.h>
 #include <tf2_ros/transform_listener.h>
 #include <tf2_ros/message_filter.h>

--- a/moveit_ros/perception/pointcloud_octomap_updater/src/pointcloud_octomap_updater.cpp
+++ b/moveit_ros/perception/pointcloud_octomap_updater/src/pointcloud_octomap_updater.cpp
@@ -118,13 +118,14 @@ void PointCloudOctomapUpdater::start()
   rclcpp::SubscriptionOptions options;
   options.callback_group = node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
   /* subscribe to point cloud topic using tf filter*/
-  point_cloud_subscriber_ = new message_filters::Subscriber<sensor_msgs::msg::PointCloud2>(node_, point_cloud_topic_,
+  auto qos_profile =
 #if RCLCPP_VERSION_GTE(28, 3, 0)
-                                                                                           rclcpp::SensorDataQoS(),
+      rclcpp::SensorDataQoS();
 #else
-                                                                                           rmw_qos_profile_sensor_data,
+      rmw_qos_profile_sensor_data;
 #endif
-                                                                                           options);
+  point_cloud_subscriber_ =
+      new message_filters::Subscriber<sensor_msgs::msg::PointCloud2>(node_, point_cloud_topic_, qos_profile, options);
   if (tf_listener_ && tf_buffer_ && !monitor_->getMapFrame().empty())
   {
     point_cloud_filter_ = new tf2_ros::MessageFilter<sensor_msgs::msg::PointCloud2>(

--- a/moveit_ros/perception/pointcloud_octomap_updater/src/pointcloud_octomap_updater.cpp
+++ b/moveit_ros/perception/pointcloud_octomap_updater/src/pointcloud_octomap_updater.cpp
@@ -114,13 +114,17 @@ void PointCloudOctomapUpdater::start()
 
   if (point_cloud_subscriber_)
     return;
+
+  rclcpp::SubscriptionOptions options;
+  options.callback_group = node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
   /* subscribe to point cloud topic using tf filter*/
   point_cloud_subscriber_ = new message_filters::Subscriber<sensor_msgs::msg::PointCloud2>(node_, point_cloud_topic_,
 #if RCLCPP_VERSION_GTE(28, 3, 0)
-                                                                                           rclcpp::SensorDataQoS());
+                                                                                           rclcpp::SensorDataQoS(),
 #else
-                                                                                           rmw_qos_profile_sensor_data);
+                                                                                           rmw_qos_profile_sensor_data,
 #endif
+                                                                                           options);
   if (tf_listener_ && tf_buffer_ && !monitor_->getMapFrame().empty())
   {
     point_cloud_filter_ = new tf2_ros::MessageFilter<sensor_msgs::msg::PointCloud2>(


### PR DESCRIPTION
### Description

MutuallyExclusive callbackgroup has been added to `point_cloud_subscriber_` to allow updating octomap during robot motion. See https://github.com/moveit/moveit2/issues/2192

---
### Additional notes
-  I was not able to do the same fix to the `depth_image_octomap_updater` since `image_transport::create_camera_subscription` seems to not allow passing `SubscriptionOptions`.

- I noticed that there is a big computational time mismatch between the two approaches (depth/pointcloud). After digging in a bit i found that the main computational time difference comes from `lazy_free_space_updater` but unfortunately I have not time to fix it. I will use the pointcloud instead._ 

