### PR TITLE
Use ! in place of not keyword for Pilz and CHOMP planners

### DIFF
--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_planner.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_planner.cpp
@@ -281,7 +281,7 @@ void ChompPlanner::solve(const planning_scene::PlanningSceneConstPtr& planning_s
   res.processing_time[0] = std::chrono::duration<double>(std::chrono::system_clock::now() - start_time).count();
 
   // report planning failure if path has collisions
-  if (not optimizer->isCollisionFree())
+  if (!optimizer->isCollisionFree())
   {
     RCLCPP_ERROR(getLogger(), "Motion plan is invalid.");
     res.error_code.val = moveit_msgs::msg::MoveItErrorCodes::INVALID_MOTION_PLAN;

--- a/moveit_planners/pilz_industrial_motion_planner/include/joint_limits_copy/joint_limits_rosparam.hpp
+++ b/moveit_planners/pilz_industrial_motion_planner/include/joint_limits_copy/joint_limits_rosparam.hpp
@@ -32,7 +32,7 @@ namespace
 template <typename T>
 void declareParameterTemplate(const rclcpp::Node::SharedPtr& node, const std::string& name, T default_value)
 {
-  if (not node->has_parameter(name))
+  if (!node->has_parameter(name))
   {
     node->declare_parameter<T>(name, default_value);
   }


### PR DESCRIPTION
### Description

While compiling this package on Windows (see https://github.com/RoboStack/ros-humble/pull/241), the Windows compilation was failing as depending on the compilation options `not` may not be supported in MSVC depending on the compilation options. 

Anyhow, as everywhere else in the code `!` is used, I think it make sense to be consistent and use `!` also here.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [x] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
