### PR TITLE
pilz_industrial_motion_planner: Use tf2::fromMsg instead of tf2::convert

### DIFF
--- a/moveit_planners/pilz_industrial_motion_planner/src/trajectory_functions.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/trajectory_functions.cpp
@@ -117,7 +117,7 @@ bool pilz_industrial_motion_planner::computePoseIK(const planning_scene::Plannin
                                                    const double timeout)
 {
   Eigen::Isometry3d pose_eigen;
-  tf2::convert<geometry_msgs::msg::Pose, Eigen::Isometry3d>(pose, pose_eigen);
+  tf2::fromMsg(pose, pose_eigen);
   return computePoseIK(scene, group_name, link_name, pose_eigen, frame_id, seed, solution, check_self_collision,
                        timeout);
 }
@@ -591,7 +591,7 @@ bool pilz_industrial_motion_planner::isStateColliding(const planning_scene::Plan
 void normalizeQuaternion(geometry_msgs::msg::Quaternion& quat)
 {
   tf2::Quaternion q;
-  tf2::convert<geometry_msgs::msg::Quaternion, tf2::Quaternion>(quat, q);
+  tf2::fromMsg(quat, q);
   quat = tf2::toMsg(q.normalized());
 }
 


### PR DESCRIPTION
### Description

I was compiling pilz_industrial_motion_planner on Windows, and I was obtaining a strange template error:

~~~
D:/src/testpilz/ros-humble/output/bld/rattler-build_ros-humble-pilz-industrial-motion-planner_1736462231/h_env/Library/include/tf2\tf2/impl/convert.hpp(60,1): error C2668
: 'tf2::fromMsg': ambiguous call to overloaded function [C:\Users\straversaro\build\trajectory_generation_common.vcxproj]
~~~

<details>

<summary> 
Click to see the rest of the error.
</summary>

~~~
D:/src/testpilz/ros-humble/output/bld/rattler-build_ros-humble-pilz-industrial-motion-planner_1736462231/h_env/Library/include/tf2\tf2/impl/convert.hpp(60,1): error C2668
: 'tf2::fromMsg': ambiguous call to overloaded function [C:\Users\straversaro\build\trajectory_generation_common.vcxproj]
D:/src/testpilz/ros-humble/output/bld/rattler-build_ros-humble-pilz-industrial-motion-planner_1736462231/h_env/Library/include/tf2_eigen\tf2_eigen/tf2_eigen.hpp(661,6): m
essage : could be 'void Eigen::fromMsg(const geometry_msgs::msg::Pose &,Eigen::Isometry3d &)' [found using argument-dependent lookup] [C:\Users\straversaro\build\trajecto
ry_generation_common.vcxproj]
D:/src/testpilz/ros-humble/output/bld/rattler-build_ros-humble-pilz-industrial-motion-planner_1736462231/h_env/Library/include/tf2_eigen\tf2_eigen/tf2_eigen.hpp(484,6): m
essage : or       'void tf2::fromMsg(const geometry_msgs::msg::Pose &,Eigen::Isometry3d &)' [C:\Users\straversaro\build\trajectory_generation_common.vcxproj]
D:/src/testpilz/ros-humble/output/bld/rattler-build_ros-humble-pilz-industrial-motion-planner_1736462231/h_env/Library/include/tf2\tf2/convert.hpp(138,6): message : or
    'void tf2::fromMsg<geometry_msgs::msg::Pose_<std::allocator<void>>,Eigen::Isometry3d>(const A &,B &)' [C:\Users\straversaro\build\trajectory_generation_common.vcxproj
]
          with
          [
              A=geometry_msgs::msg::Pose_<std::allocator<void>>,
              B=Eigen::Isometry3d
          ]
D:/src/testpilz/ros-humble/output/bld/rattler-build_ros-humble-pilz-industrial-motion-planner_1736462231/h_env/Library/include/tf2\tf2/impl/convert.hpp(60,1): message : w
hile trying to match the argument list '(const A, B)' [C:\Users\straversaro\build\trajectory_generation_common.vcxproj]
          with
          [
              A=geometry_msgs::msg::Pose
          ]
          and
          [
              B=Eigen::Isometry3d
          ]
D:/src/testpilz/ros-humble/output/bld/rattler-build_ros-humble-pilz-industrial-motion-planner_1736462231/h_env/Library/include/tf2\tf2/convert.hpp(151): message : see ref
erence to function template instantiation 'void tf2::impl::Converter<true,false>::convert<A,B>(const A &,B &)' being compiled [C:\Users\straversaro\build\trajectory_gener
ation_common.vcxproj]
          with
          [
              A=geometry_msgs::msg::Pose,
              B=Eigen::Isometry3d
          ]
D:/src/testpilz/ros-humble/output/bld/rattler-build_ros-humble-pilz-industrial-motion-planner_1736462231/h_env/Library/include/tf2\tf2/convert.hpp(151): message : see ref
erence to function template instantiation 'void tf2::impl::Converter<true,false>::convert<A,B>(const A &,B &)' being compiled [C:\Users\straversaro\build\trajectory_gener
ation_common.vcxproj]
          with
          [
              A=geometry_msgs::msg::Pose,
              B=Eigen::Isometry3d
          ]
D:\src\testpilz\ros-humble\output\bld\rattler-build_ros-humble-pilz-industrial-motion-planner_1736462231\work\ros-humble-pilz-industrial-motion-planner\src\work\src\traje
ctory_functions.cpp(111): message : see reference to function template instantiation 'void tf2::convert<geometry_msgs::msg::Pose,Eigen::Isometry3d>(const A &,B &)' being
compiled [C:\Users\straversaro\build\trajectory_generation_common.vcxproj]
          with
          [
              A=geometry_msgs::msg::Pose,
              B=Eigen::Isometry3d
          ]
~~~

</details>

This specific problems is probably actually a `geometry2` problem (see https://github.com/ros/geometry2/pull/444 for a fix on the ROS 1 repo, and https://github.com/ros2/geometry2/pull/369#issuecomment-774780748 that indicates that the issue is still present in the ROS 2 repo.

However, by checking the codebase I noticed that the `tf2::convert` templated function is only used here (see https://github.com/search?q=repo%3Amoveit%2Fmoveit2+convert%3C&type=code), while `tf2::fromMsg` is much more used (see https://github.com/search?q=repo%3Amoveit%2Fmoveit2+fromMsg&type=code), so I think that for consistency it make sense to use `tf2::fromMsg` also in pilz_industrial_motion_planner .


### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
