### PR TITLE
Fix bad logic in Servo twist speed scaling

### DIFF
--- a/moveit_ros/moveit_servo/src/utils/command.cpp
+++ b/moveit_ros/moveit_servo/src/utils/command.cpp
@@ -169,25 +169,6 @@ JointDeltaResult jointDeltaFromTwist(const TwistCommand& command, const moveit::
       cartesian_position_delta.head<3>() *= servo_params.scale.linear;
       cartesian_position_delta.tail<3>() *= servo_params.scale.rotational;
     }
-    else if (servo_params.command_in_type == "speed_units")
-    {
-      if (servo_params.scale.linear > 0.0)
-      {
-        const auto linear_speed_scale = command.velocities.head<3>().norm() / servo_params.scale.linear;
-        if (linear_speed_scale > 1.0)
-        {
-          cartesian_position_delta.head<3>() /= linear_speed_scale;
-        }
-      }
-      if (servo_params.scale.rotational > 0.0)
-      {
-        const auto angular_speed_scale = command.velocities.tail<3>().norm() / servo_params.scale.rotational;
-        if (angular_speed_scale > 1.0)
-        {
-          cartesian_position_delta.tail<3>() /= angular_speed_scale;
-        }
-      }
-    }
 
     // Compute the required change in joint angles.
     const auto delta_result =


### PR DESCRIPTION
### Description

I mistakenly added some logic to the twist mode of MoveIt Servo in https://github.com/moveit/moveit2/pull/3007 that did not need to be there.

When the speed commands are in real speed units, we should not touch their scaling value as documented!

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
