### PR TITLE
Remove source builds of `geometric_shapes` and `srdfdom`

### DIFF
--- a/moveit2.repos
+++ b/moveit2.repos
@@ -1,9 +1,5 @@
 repositories:
   # Keep moveit_* repos here because they are released with moveit
-  geometric_shapes:
-    type: git
-    url: https://github.com/moveit/geometric_shapes.git
-    version: ros2
   moveit_msgs:
     type: git
     url: https://github.com/moveit/moveit_msgs.git
@@ -11,8 +7,4 @@ repositories:
   moveit_resources:
     type: git
     url: https://github.com/moveit/moveit_resources.git
-    version: ros2
-  srdfdom:
-    type: git
-    url: https://github.com/moveit/srdfdom.git
     version: ros2


### PR DESCRIPTION
### Description

We had added these a few months back to circumvent some breakages, but this should no longer be needed.

Q: Should we backport this to Jazzy? Because if so, `srdfdom` there is at 2.0.5 and not 2.0.7, so I think we may need to first release to there.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
