### PR TITLE
Explicit convert from std::filesystem::path to std::string for Windows compatibility

### DIFF
--- a/moveit_setup_assistant/moveit_setup_assistant/src/collisions_updater.cpp
+++ b/moveit_setup_assistant/moveit_setup_assistant/src/collisions_updater.cpp
@@ -100,7 +100,7 @@ int main(int argc, char* argv[])
     auto package_settings = config_data->get<moveit_setup::PackageSettingsConfig>("package_settings");
     try
     {
-      package_settings->loadExisting(config_pkg_path);
+      package_settings->loadExisting(config_pkg_path.string());
     }
     catch (const std::runtime_error& e)
     {
@@ -113,7 +113,7 @@ int main(int argc, char* argv[])
     RCLCPP_ERROR_STREAM(node->get_logger(), "Please provide config package or URDF and SRDF path");
     return 1;
   }
-  else if (rdf_loader::RDFLoader::isXacroFile(srdf_path) && output_path.empty())
+  else if (rdf_loader::RDFLoader::isXacroFile(srdf_path.string()) && output_path.empty())
   {
     RCLCPP_ERROR_STREAM(node->get_logger(), "Please provide a different output file for SRDF xacro input file");
     return 1;

--- a/moveit_setup_assistant/moveit_setup_assistant/src/setup_assistant_widget.cpp
+++ b/moveit_setup_assistant/moveit_setup_assistant/src/setup_assistant_widget.cpp
@@ -71,7 +71,7 @@ SetupAssistantWidget::SetupAssistantWidget(const rviz_common::ros_integration::R
 
   // Setting the window icon
   auto icon_path = getSharePath("moveit_ros_visualization") / "icons/classes/MotionPlanning.png";
-  setWindowIcon(QIcon(icon_path.c_str()));
+  setWindowIcon(QIcon(icon_path.string().c_str()));
 
   // Basic widget container -----------------------------------------
   QHBoxLayout* layout = new QHBoxLayout();

--- a/moveit_setup_assistant/moveit_setup_core_plugins/include/moveit_setup_core_plugins/configuration_files.hpp
+++ b/moveit_setup_assistant/moveit_setup_core_plugins/include/moveit_setup_core_plugins/configuration_files.hpp
@@ -80,7 +80,7 @@ public:
 
   bool shouldGenerate(const GeneratedFilePtr& file) const
   {
-    std::string rel_path = file->getRelativePath();
+    std::string rel_path = file->getRelativePath().string();
     auto it = should_generate_.find(rel_path);
     if (it == should_generate_.end())
     {

--- a/moveit_setup_assistant/moveit_setup_core_plugins/src/configuration_files_widget.cpp
+++ b/moveit_setup_assistant/moveit_setup_core_plugins/src/configuration_files_widget.cpp
@@ -294,7 +294,7 @@ void ConfigurationFilesWidget::changeCheckedState(QListWidgetItem* item)
   }
 
   // Enable/disable file
-  setup_step_.setShouldGenerate(gen_file->getRelativePath(), generate);
+  setup_step_.setShouldGenerate(gen_file->getRelativePath().string(), generate);
 }
 
 // ******************************************************************************************
@@ -303,7 +303,7 @@ void ConfigurationFilesWidget::changeCheckedState(QListWidgetItem* item)
 void ConfigurationFilesWidget::focusGiven()
 {
   // Pass the package path from start screen to configuration files screen
-  stack_path_->setPath(setup_step_.getPackagePath());
+  stack_path_->setPath(setup_step_.getPackagePath().string());
 
   setup_step_.loadFiles();
 
@@ -352,7 +352,7 @@ void ConfigurationFilesWidget::showGenFiles()
     auto gen_file = gen_files[i];
 
     // Create a formatted row
-    QListWidgetItem* item = new QListWidgetItem(QString(gen_file->getRelativePath().c_str()), action_list_, 0);
+    QListWidgetItem* item = new QListWidgetItem(QString(gen_file->getRelativePath().string().c_str()), action_list_, 0);
 
     // Checkbox
     item->setCheckState(setup_step_.shouldGenerate(gen_file) ? Qt::Checked : Qt::Unchecked);
@@ -480,7 +480,7 @@ bool ConfigurationFilesWidget::generatePackage()
       // Error occurred
       QMessageBox::critical(this, "Error Generating File",
                             QString("Failed to generate folder or file: '")
-                                .append(gen_file->getRelativePath().c_str())
+                                .append(gen_file->getRelativePath().string().c_str())
                                 .append("' at location:\n")
                                 .append(absolute_path.c_str()));
       return false;

--- a/moveit_setup_assistant/moveit_setup_core_plugins/src/start_screen.cpp
+++ b/moveit_setup_assistant/moveit_setup_core_plugins/src/start_screen.cpp
@@ -70,7 +70,7 @@ std::filesystem::path StartScreen::getPackagePath()
 
 void StartScreen::loadExisting(const std::filesystem::path& package_path)
 {
-  package_settings_->loadExisting(package_path);
+  package_settings_->loadExisting(package_path.string());
 }
 
 bool StartScreen::isXacroFile()

--- a/moveit_setup_assistant/moveit_setup_core_plugins/src/start_screen_widget.cpp
+++ b/moveit_setup_assistant/moveit_setup_core_plugins/src/start_screen_widget.cpp
@@ -205,7 +205,7 @@ void StartScreenWidget::focusGiven()
   std::filesystem::path pkg_path = setup_step_.getPackagePath();
   if (!pkg_path.empty())
   {
-    stack_path_->setPath(pkg_path);
+    stack_path_->setPath(pkg_path.string());
     select_mode_->btn_exist_->click();
     return;
   }
@@ -213,7 +213,7 @@ void StartScreenWidget::focusGiven()
   std::filesystem::path urdf_path = setup_step_.getURDFPath();
   if (!urdf_path.empty())
   {
-    urdf_file_->setPath(urdf_path);
+    urdf_file_->setPath(urdf_path.string());
     select_mode_->btn_new_->click();
   }
 }
@@ -324,7 +324,7 @@ bool StartScreenWidget::loadPackageSettings(bool show_warnings)
 
   try
   {
-    setup_step_.loadExisting(package_path_input);
+    setup_step_.loadExisting(package_path_input.string());
     return true;
   }
   catch (const std::runtime_error& e)

--- a/moveit_setup_assistant/moveit_setup_framework/include/moveit_setup_framework/data/srdf_config.hpp
+++ b/moveit_setup_assistant/moveit_setup_framework/include/moveit_setup_framework/data/srdf_config.hpp
@@ -263,7 +263,7 @@ public:
 
   bool write(const std::filesystem::path& path)
   {
-    return srdf_.writeSRDF(path);
+    return srdf_.writeSRDF(path.string());
   }
 
   std::filesystem::path getPath() const

--- a/moveit_setup_assistant/moveit_setup_framework/src/srdf_config.cpp
+++ b/moveit_setup_assistant/moveit_setup_framework/src/srdf_config.cpp
@@ -88,7 +88,7 @@ void SRDFConfig::loadSRDFFile(const std::filesystem::path& srdf_file_path, const
   loadURDFModel();
 
   std::string srdf_string;
-  if (!rdf_loader::RDFLoader::loadXmlFileToString(srdf_string, srdf_path_, xacro_args))
+  if (!rdf_loader::RDFLoader::loadXmlFileToString(srdf_string, srdf_path_.string(), xacro_args))
   {
     throw std::runtime_error("SRDF file not found: " + srdf_path_.string());
   }

--- a/moveit_setup_assistant/moveit_setup_framework/src/urdf_config.cpp
+++ b/moveit_setup_assistant/moveit_setup_framework/src/urdf_config.cpp
@@ -120,13 +120,13 @@ void URDFConfig::setPackageName()
 void URDFConfig::loadFromPackage(const std::filesystem::path& package_name, const std::filesystem::path& relative_path,
                                  const std::string& xacro_args)
 {
-  const std::filesystem::path package_path = getSharePath(package_name);
+  const std::filesystem::path package_path = getSharePath(package_name.string());
   if (package_path.empty())
   {
     throw std::runtime_error("URDF/COLLADA package not found: ''" + package_name.string());
   }
 
-  urdf_pkg_name_ = package_name;
+  urdf_pkg_name_ = package_name.string();
   urdf_pkg_relative_path_ = relative_path;
   xacro_args_ = xacro_args;
 
@@ -139,12 +139,12 @@ void URDFConfig::load()
   RCLCPP_DEBUG_STREAM(*logger_, "URDF Package Name: " << urdf_pkg_name_);
   RCLCPP_DEBUG_STREAM(*logger_, "URDF Package Path: " << urdf_pkg_relative_path_);
 
-  if (!rdf_loader::RDFLoader::loadXmlFileToString(urdf_string_, urdf_path_, xacro_args_vec_))
+  if (!rdf_loader::RDFLoader::loadXmlFileToString(urdf_string_, urdf_path_.string(), xacro_args_vec_))
   {
     throw std::runtime_error("URDF/COLLADA file not found: " + urdf_path_.string());
   }
 
-  if (urdf_string_.empty() && rdf_loader::RDFLoader::isXacroFile(urdf_path_))
+  if (urdf_string_.empty() && rdf_loader::RDFLoader::isXacroFile(urdf_path_.string()))
   {
     throw std::runtime_error("Running xacro failed.\nPlease check console for errors.");
   }
@@ -154,7 +154,7 @@ void URDFConfig::load()
   {
     throw std::runtime_error("URDF/COLLADA file is not a valid robot model.");
   }
-  urdf_from_xacro_ = rdf_loader::RDFLoader::isXacroFile(urdf_path_);
+  urdf_from_xacro_ = rdf_loader::RDFLoader::isXacroFile(urdf_path_.string());
 
   // Set parameter
   parent_node_->set_parameter(rclcpp::Parameter("robot_description", urdf_string_));
@@ -164,7 +164,7 @@ void URDFConfig::load()
 
 bool URDFConfig::isXacroFile() const
 {
-  return rdf_loader::RDFLoader::isXacroFile(urdf_path_);
+  return rdf_loader::RDFLoader::isXacroFile(urdf_path_.string());
 }
 
 bool URDFConfig::isConfigured() const
@@ -182,7 +182,7 @@ void URDFConfig::collectVariables(std::vector<TemplateVariable>& variables)
   std::string urdf_location;
   if (urdf_pkg_name_.empty())
   {
-    urdf_location = urdf_path_;
+    urdf_location = urdf_path_.string();
   }
   else
   {

--- a/moveit_setup_assistant/moveit_setup_framework/src/utilities.cpp
+++ b/moveit_setup_assistant/moveit_setup_framework/src/utilities.cpp
@@ -63,7 +63,7 @@ bool extractPackageNameFromPath(const std::filesystem::path& path, std::string& 
       // Default package name to folder name
       package_name = sub_path.filename().string();
       tinyxml2::XMLDocument package_xml_file;
-      auto is_open = package_xml_file.LoadFile((sub_path / "package.xml").c_str());
+      auto is_open = package_xml_file.LoadFile((sub_path / "package.xml").string().c_str());
       if (is_open == tinyxml2::XML_SUCCESS)
       {
         auto name_potential =


### PR DESCRIPTION
### Description

On Linux and macOS `std::filesystem::path` is implicitly convertible to `std::string`, while on Windows it is convertible to `std::wstring`, see https://en.cppreference.com/w/cpp/filesystem/path and https://stackoverflow.com/questions/57377349/implicit-conversion-between-stdfilesystempath-and-stdstring-should-it-hap . If we want to convert `std::filesystem::path` to `std::string` in a Windows-compatible way, it is then necessary to explicitly call the `.string()` method.

Fix part of https://github.com/moveit/moveit2/issues/2391 .

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
