### PR TITLE
Fix: misleading error logs in RobotState::setFromIKSubgroups()

### DIFF
--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -2039,8 +2039,8 @@ bool RobotState::setFromIKSubgroups(const JointModelGroup* jmg, const EigenSTL::
   {
     if (consistency_limits[i].size() != sub_groups[i]->getVariableCount())
     {
-      RCLCPP_ERROR(getLogger(), "Number of joints in consistency_limits[%zu] is %lu but it should be should be %u",
-                   i, consistency_limits[i].size(), sub_groups[i]->getVariableCount());
+      RCLCPP_ERROR(getLogger(), "Number of joints in consistency_limits[%zu] is %lu but it should be should be %u", i,
+                   consistency_limits[i].size(), sub_groups[i]->getVariableCount());
       return false;
     }
   }

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -2039,8 +2039,8 @@ bool RobotState::setFromIKSubgroups(const JointModelGroup* jmg, const EigenSTL::
   {
     if (consistency_limits[i].size() != sub_groups[i]->getVariableCount())
     {
-      RCLCPP_ERROR(getLogger(), "Number of joints in consistency_limits is %zu but it should be should be %u", i,
-                   sub_groups[i]->getVariableCount());
+      RCLCPP_ERROR(getLogger(), "Number of joints in consistency_limits[%zu] is %lu but it should be should be %u",
+                   i, consistency_limits[i].size(), sub_groups[i]->getVariableCount());
       return false;
     }
   }


### PR DESCRIPTION
### Description

misleading log message for  RobotState::setFromIKSubgroups() when checking consistency_limits size

before:

![screenshot-20250123-160345](https://github.com/user-attachments/assets/10f3a8a0-7627-4497-9237-09967d154b06)

fixed:

![fixed](https://github.com/user-attachments/assets/9d808f05-a63d-4d8e-987a-d268c186c921)
