### PR TITLE
Return if requested pause state is already active.

### DIFF
--- a/moveit_ros/moveit_servo/src/servo_node.cpp
+++ b/moveit_ros/moveit_servo/src/servo_node.cpp
@@ -147,6 +147,13 @@ ServoNode::ServoNode(const rclcpp::NodeOptions& options)
 void ServoNode::pauseServo(const std::shared_ptr<std_srvs::srv::SetBool::Request>& request,
                            const std::shared_ptr<std_srvs::srv::SetBool::Response>& response)
 {
+  if (servo_paused_ == request->data)
+  {
+    RCLCPP_INFO(node_->get_logger(), "Requested pause state is already active.");
+    response->success = true;
+    response->message = "Nothing changed since requested pause state was already active.";
+    return;
+  }
   servo_paused_ = request->data;
   response->success = (servo_paused_ == request->data);
   if (servo_paused_)


### PR DESCRIPTION
### Description

When using the servo_node from moveit_servo, the service call to /servo_node/pause_servo hangs for a while (sometimes even up to a minute on my machine) when requesting pause = false while the pause status was already false. This behavior can be experienced by running the demo:

`ros2 launch moveit_servo demo_ros_api.launch.py`

And calling the service:

`ros2 service call /servo_node/pause_servo std_srvs/srv/SetBool '{data: false}'`

After a while, the following error is logged:

`[moveit_servo_demo_container.moveit.ros.move_group.collision_monitor]: Collision monitor could not be started`

To avoid this behavior, I propose this change to first check whether the requested pause state is different compared to the current pause state. If not, the response will be returned with the message that nothing is changed since the requested pause stated was already active.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
