### PR TITLE
Enhanced documentation for composeMultiArrayMessage function

### DIFF
--- a/moveit_ros/moveit_servo/src/utils/common.cpp
+++ b/moveit_ros/moveit_servo/src/utils/common.cpp
@@ -255,6 +255,22 @@ void updateSlidingWindow(KinematicState& next_joint_state, std::deque<KinematicS
   joint_cmd_rolling_window.push_back(next_joint_state);
 }
 
+/**
+ * @brief Composes a Float64MultiArray message for controllers requiring Float64MultiArray input.
+ * 
+ * This function converts the given joint state into a Float64MultiArray message.
+ * 
+ * @param servo_params Configuration parameters for the servo, including message type selection.
+ * @param joint_state The current joint state to be converted into the message.
+ * @return A Float64MultiArray message containing the joint state data.
+ * 
+ * Example:
+ * @code
+ * auto message = composeMultiArrayMessage(servo_params, joint_state);
+ * controller.publish(message);
+ * @endcode
+ */
+
 std_msgs::msg::Float64MultiArray composeMultiArrayMessage(const servo::Params& servo_params,
                                                           const KinematicState& joint_state)
 {


### PR DESCRIPTION
Description
I have enhanced the documentation for the composeMultiArrayMessage function in common.cpp within the moveit_servo module.

Added a detailed Doxygen-compatible comment block for the function to clarify its purpose, parameters, return value, and usage.
The changes address the issue related to the lack of documentation for handling controllers that accept std_msgs::msg::Float64MultiArray messages.
This update improves developer experience and aligns with MoveIt 2's goal of becoming an industry-standard robotics framework.

Related Issue: https://github.com/moveit/moveit2/issues/3243
