### PR TITLE
Reverts #2985, Ports moveit #3388 #3470 #3539

### DIFF
--- a/moveit_core/robot_model/include/moveit/robot_model/robot_model.hpp
+++ b/moveit_core/robot_model/include/moveit/robot_model/robot_model.hpp
@@ -256,6 +256,9 @@ public:
 
   /** \brief Get the latest link upwards the kinematic tree, which is only connected via fixed joints
    *
+   * If jmg is given, all links that are not active in this JMG are considered fixed.
+   * Otherwise only fixed joints are considered fixed.
+   *
    * This is useful, if the link should be warped to a specific pose using updateStateWithLinkAt().
    * As updateStateWithLinkAt() warps only the specified link and its descendants, you might not
    * achieve what you expect, if link is an abstract frame name. Considering the following example:
@@ -265,7 +268,8 @@ public:
    * what you went for. Instead, updateStateWithLinkAt(getRigidlyConnectedParentLinkModel(grasp_frame), ...)
    * will actually warp wrist (and all its descendants).
    */
-  static const moveit::core::LinkModel* getRigidlyConnectedParentLinkModel(const LinkModel* link);
+  static const moveit::core::LinkModel* getRigidlyConnectedParentLinkModel(const LinkModel* link,
+                                                                           const JointModelGroup* jmg = nullptr);
 
   /** \brief Get the array of links  */
   const std::vector<const LinkModel*>& getLinkModels() const

--- a/moveit_core/robot_model/include/moveit/robot_model/robot_model.hpp
+++ b/moveit_core/robot_model/include/moveit/robot_model/robot_model.hpp
@@ -269,7 +269,14 @@ public:
    * will actually warp wrist (and all its descendants).
    */
   static const moveit::core::LinkModel* getRigidlyConnectedParentLinkModel(const LinkModel* link,
+                                                                           Eigen::Isometry3d& transform,
                                                                            const JointModelGroup* jmg = nullptr);
+  static const moveit::core::LinkModel* getRigidlyConnectedParentLinkModel(const LinkModel* link,
+                                                                           const JointModelGroup* jmg = nullptr)
+  {
+    Eigen::Isometry3d unused;
+    return getRigidlyConnectedParentLinkModel(link, unused, jmg);
+  }
 
   /** \brief Get the array of links  */
   const std::vector<const LinkModel*>& getLinkModels() const

--- a/moveit_core/robot_model/include/moveit/robot_model/robot_model.hpp
+++ b/moveit_core/robot_model/include/moveit/robot_model/robot_model.hpp
@@ -268,11 +268,11 @@ public:
    * what you went for. Instead, updateStateWithLinkAt(getRigidlyConnectedParentLinkModel(grasp_frame), ...)
    * will actually warp wrist (and all its descendants).
    */
-  static const moveit::core::LinkModel* getRigidlyConnectedParentLinkModel(const LinkModel* link,
-                                                                           Eigen::Isometry3d& transform,
-                                                                           const JointModelGroup* jmg = nullptr);
-  static const moveit::core::LinkModel* getRigidlyConnectedParentLinkModel(const LinkModel* link,
-                                                                           const JointModelGroup* jmg = nullptr)
+  static const LinkModel* getRigidlyConnectedParentLinkModel(const LinkModel* link,
+                                                             Eigen::Isometry3d& transform,
+                                                             const JointModelGroup* jmg = nullptr);
+  static const LinkModel* getRigidlyConnectedParentLinkModel(const LinkModel* link,
+                                                             const JointModelGroup* jmg = nullptr)
   {
     Eigen::Isometry3d unused;
     return getRigidlyConnectedParentLinkModel(link, unused, jmg);

--- a/moveit_core/robot_model/include/moveit/robot_model/robot_model.hpp
+++ b/moveit_core/robot_model/include/moveit/robot_model/robot_model.hpp
@@ -268,7 +268,8 @@ public:
    * what you went for. Instead, updateStateWithLinkAt(getRigidlyConnectedParentLinkModel(grasp_frame), ...)
    * will actually warp wrist (and all its descendants).
    */
-  static const LinkModel* getRigidlyConnectedParentLinkModel(const LinkModel* link, const JointModelGroup* jmg = nullptr);
+  static const LinkModel* getRigidlyConnectedParentLinkModel(const LinkModel* link,
+                                                             const JointModelGroup* jmg = nullptr);
 
   /** \brief Get the array of links  */
   const std::vector<const LinkModel*>& getLinkModels() const

--- a/moveit_core/robot_model/include/moveit/robot_model/robot_model.hpp
+++ b/moveit_core/robot_model/include/moveit/robot_model/robot_model.hpp
@@ -268,11 +268,9 @@ public:
    * what you went for. Instead, updateStateWithLinkAt(getRigidlyConnectedParentLinkModel(grasp_frame), ...)
    * will actually warp wrist (and all its descendants).
    */
-  static const LinkModel* getRigidlyConnectedParentLinkModel(const LinkModel* link,
-                                                             Eigen::Isometry3d& transform,
+  static const LinkModel* getRigidlyConnectedParentLinkModel(const LinkModel* link, Eigen::Isometry3d& transform,
                                                              const JointModelGroup* jmg = nullptr);
-  static const LinkModel* getRigidlyConnectedParentLinkModel(const LinkModel* link,
-                                                             const JointModelGroup* jmg = nullptr)
+  static const LinkModel* getRigidlyConnectedParentLinkModel(const LinkModel* link, const JointModelGroup* jmg = nullptr)
   {
     Eigen::Isometry3d unused;
     return getRigidlyConnectedParentLinkModel(link, unused, jmg);

--- a/moveit_core/robot_model/include/moveit/robot_model/robot_model.hpp
+++ b/moveit_core/robot_model/include/moveit/robot_model/robot_model.hpp
@@ -268,13 +268,7 @@ public:
    * what you went for. Instead, updateStateWithLinkAt(getRigidlyConnectedParentLinkModel(grasp_frame), ...)
    * will actually warp wrist (and all its descendants).
    */
-  static const LinkModel* getRigidlyConnectedParentLinkModel(const LinkModel* link, Eigen::Isometry3d& transform,
-                                                             const JointModelGroup* jmg = nullptr);
-  static const LinkModel* getRigidlyConnectedParentLinkModel(const LinkModel* link, const JointModelGroup* jmg = nullptr)
-  {
-    Eigen::Isometry3d unused;
-    return getRigidlyConnectedParentLinkModel(link, unused, jmg);
-  }
+  static const LinkModel* getRigidlyConnectedParentLinkModel(const LinkModel* link, const JointModelGroup* jmg = nullptr);
 
   /** \brief Get the array of links  */
   const std::vector<const LinkModel*>& getLinkModels() const

--- a/moveit_core/robot_model/src/robot_model.cpp
+++ b/moveit_core/robot_model/src/robot_model.cpp
@@ -1380,8 +1380,8 @@ const LinkModel* RobotModel::getRigidlyConnectedParentLinkModel(const LinkModel*
     end = jmg->getJointModels().cend();
   }
 
-  auto is_fixed_or_not_in_jmg = [begin, end](const moveit::core::JointModel* joint) {
-    if (joint->getType() == moveit::core::JointModel::FIXED)
+  auto is_fixed_or_not_in_jmg = [begin, end](const JointModel* joint) {
+    if (joint->getType() == JointModel::FIXED)
       return true;
     if (begin != end &&                       // we do have a non-empty jmg
         std::find(begin, end, joint) == end)  // joint does not belong to jmg

--- a/moveit_core/robot_model/src/robot_model.cpp
+++ b/moveit_core/robot_model/src/robot_model.cpp
@@ -1364,13 +1364,12 @@ LinkModel* RobotModel::getLinkModel(const std::string& name, bool* has_link)
   return nullptr;
 }
 
-const LinkModel* RobotModel::getRigidlyConnectedParentLinkModel(const LinkModel* link, Eigen::Isometry3d& transform,
+const LinkModel* RobotModel::getRigidlyConnectedParentLinkModel(const LinkModel* link,
                                                                 const JointModelGroup* jmg)
 {
   if (!link)
     return link;
 
-  transform.setIdentity();
   const moveit::core::LinkModel* parent_link = link->getParentLinkModel();
   const moveit::core::JointModel* joint = link->getParentJointModel();
   decltype(jmg->getJointModels().cbegin()) begin{}, end{};
@@ -1380,6 +1379,8 @@ const LinkModel* RobotModel::getRigidlyConnectedParentLinkModel(const LinkModel*
     end = jmg->getJointModels().cend();
   }
 
+  // Returns whether `joint` is part of the rigidly connected chain.
+  // This is only false if the joint is both in `jmg` and not fixed.
   auto is_fixed_or_not_in_jmg = [begin, end](const JointModel* joint) {
     if (joint->getType() == JointModel::FIXED)
       return true;
@@ -1391,7 +1392,6 @@ const LinkModel* RobotModel::getRigidlyConnectedParentLinkModel(const LinkModel*
 
   while (parent_link && is_fixed_or_not_in_jmg(joint))
   {
-    transform = link->getJointOriginTransform() * transform;
     link = parent_link;
     joint = link->getParentJointModel();
     parent_link = joint->getParentLinkModel();

--- a/moveit_core/robot_model/src/robot_model.cpp
+++ b/moveit_core/robot_model/src/robot_model.cpp
@@ -1364,8 +1364,7 @@ LinkModel* RobotModel::getLinkModel(const std::string& name, bool* has_link)
   return nullptr;
 }
 
-const LinkModel* RobotModel::getRigidlyConnectedParentLinkModel(const LinkModel* link,
-                                                                const JointModelGroup* jmg)
+const LinkModel* RobotModel::getRigidlyConnectedParentLinkModel(const LinkModel* link, const JointModelGroup* jmg)
 {
   if (!link)
     return link;

--- a/moveit_core/robot_model/src/robot_model.cpp
+++ b/moveit_core/robot_model/src/robot_model.cpp
@@ -1364,14 +1364,29 @@ LinkModel* RobotModel::getLinkModel(const std::string& name, bool* has_link)
   return nullptr;
 }
 
-const LinkModel* RobotModel::getRigidlyConnectedParentLinkModel(const LinkModel* link)
+const LinkModel* RobotModel::getRigidlyConnectedParentLinkModel(const LinkModel* link, const JointModelGroup* jmg)
 {
   if (!link)
     return link;
   const moveit::core::LinkModel* parent_link = link->getParentLinkModel();
   const moveit::core::JointModel* joint = link->getParentJointModel();
+  decltype(jmg->getJointModels().cbegin()) begin{}, end{};
+  if (jmg)
+  {
+    begin = jmg->getJointModels().cbegin();
+    end = jmg->getJointModels().cend();
+  }
 
-  while (parent_link && joint->getType() == moveit::core::JointModel::FIXED)
+  auto is_fixed_or_not_in_jmg = [begin, end](const moveit::core::JointModel* joint) {
+    if (joint->getType() == moveit::core::JointModel::FIXED)
+      return true;
+    if (begin != end &&                       // we do have a non-empty jmg
+        std::find(begin, end, joint) == end)  // joint does not belong to jmg
+      return true;
+    return false;
+  };
+
+  while (parent_link && is_fixed_or_not_in_jmg(joint))
   {
     link = parent_link;
     joint = link->getParentJointModel();

--- a/moveit_core/robot_model/src/robot_model.cpp
+++ b/moveit_core/robot_model/src/robot_model.cpp
@@ -1364,10 +1364,13 @@ LinkModel* RobotModel::getLinkModel(const std::string& name, bool* has_link)
   return nullptr;
 }
 
-const LinkModel* RobotModel::getRigidlyConnectedParentLinkModel(const LinkModel* link, const JointModelGroup* jmg)
+const LinkModel* RobotModel::getRigidlyConnectedParentLinkModel(const LinkModel* link, Eigen::Isometry3d& transform,
+                                                                const JointModelGroup* jmg)
 {
   if (!link)
     return link;
+
+  transform.setIdentity();
   const moveit::core::LinkModel* parent_link = link->getParentLinkModel();
   const moveit::core::JointModel* joint = link->getParentJointModel();
   decltype(jmg->getJointModels().cbegin()) begin{}, end{};
@@ -1388,6 +1391,7 @@ const LinkModel* RobotModel::getRigidlyConnectedParentLinkModel(const LinkModel*
 
   while (parent_link && is_fixed_or_not_in_jmg(joint))
   {
+    transform = link->getJointOriginTransform() * transform;
     link = parent_link;
     joint = link->getParentJointModel();
     parent_link = joint->getParentLinkModel();

--- a/moveit_core/robot_state/CMakeLists.txt
+++ b/moveit_core/robot_state/CMakeLists.txt
@@ -21,8 +21,8 @@ if(BUILD_TESTING)
   find_package(benchmark REQUIRED)
   find_package(kdl_parser REQUIRED)
 
-  catkin_add_gtest(test_robot_state test/robot_state_test.cpp)
-  target_link_libraries(test_robot_state ${MOVEIT_LIB_NAME} moveit_test_utils gmock_main)
+  find_package(tf2_geometry_msgs REQUIRED)
+  find_package(resource_retriever REQUIRED)
 
   if(WIN32)
     # TODO add windows paths

--- a/moveit_core/robot_state/CMakeLists.txt
+++ b/moveit_core/robot_state/CMakeLists.txt
@@ -21,8 +21,8 @@ if(BUILD_TESTING)
   find_package(benchmark REQUIRED)
   find_package(kdl_parser REQUIRED)
 
-  find_package(tf2_geometry_msgs REQUIRED)
-  find_package(resource_retriever REQUIRED)
+  catkin_add_gtest(test_robot_state test/robot_state_test.cpp)
+  target_link_libraries(test_robot_state ${MOVEIT_LIB_NAME} moveit_test_utils gmock_main)
 
   if(WIN32)
     # TODO add windows paths

--- a/moveit_core/robot_state/CMakeLists.txt
+++ b/moveit_core/robot_state/CMakeLists.txt
@@ -31,7 +31,7 @@ if(BUILD_TESTING)
         "${CMAKE_CURRENT_BINARY_DIR};${CMAKE_CURRENT_BINARY_DIR}/../utils")
   endif()
 
-  ament_add_gtest(test_robot_state test/robot_state_test.cpp
+  ament_add_gmock(test_robot_state test/robot_state_test.cpp
                   APPEND_LIBRARY_DIRS "${APPEND_LIBRARY_DIRS}")
 
   target_link_libraries(test_robot_state moveit_test_utils moveit_utils

--- a/moveit_core/robot_state/include/moveit/robot_state/attached_body.hpp
+++ b/moveit_core/robot_state/include/moveit/robot_state/attached_body.hpp
@@ -167,13 +167,6 @@ public:
    * The returned transform is guaranteed to be a valid isometry. */
   const Eigen::Isometry3d& getSubframeTransform(const std::string& frame_name, bool* found = nullptr) const;
 
-  /** \brief Get the fixed transform to a named subframe on this body (relative to the robot link)
-   *
-   * The frame_name needs to have the object's name prepended (e.g. "screwdriver/tip" returns true if the object's
-   * name is "screwdriver"). Returns an identity transform if frame_name is unknown (and set found to false).
-   * The returned transform is guaranteed to be a valid isometry. */
-  const Eigen::Isometry3d& getSubframeTransformInLinkFrame(const std::string& frame_name, bool* found = nullptr) const;
-
   /** \brief Get the fixed transform to a named subframe on this body, relative to the world frame.
    * The frame_name needs to have the object's name prepended (e.g. "screwdriver/tip" returns true if the object's
    * name is "screwdriver"). Returns an identity transform if frame_name is unknown (and set found to false).

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.hpp
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.hpp
@@ -1232,8 +1232,7 @@ public:
    * but can additionally resolve parents for attached objects / subframes.
    */
   const moveit::core::LinkModel*
-  getRigidlyConnectedParentLinkModel(const std::string& frame,
-                                     const moveit::core::JointModelGroup* jmg = nullptr) const;
+  getRigidlyConnectedParentLinkModel(const std::string& frame, const moveit::core::JointModelGroup* jmg = nullptr) const;
 
   /** \brief Get the link transform w.r.t. the root link (model frame) of the RobotModel.
    *   This is typically the root link of the URDF unless a virtual joint is present.
@@ -1719,8 +1718,7 @@ private:
    * Helper function for getRigidlyConnectedParentLinkModel,
    * which resolves attached objects / subframes.
    */
-  const moveit::core::LinkModel*
-  getLinkModelIncludingAttachedBodies(const std::string& frame) const;
+  const moveit::core::LinkModel* getLinkModelIncludingAttachedBodies(const std::string& frame) const;
 
   RobotModelConstPtr robot_model_;
 

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.hpp
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.hpp
@@ -1230,8 +1230,12 @@ public:
    *
    * This behaves the same as RobotModel::getRigidlyConnectedParentLinkModel,
    * but can additionally resolve parents for attached objects / subframes.
+   *
+   * If transform is specified, return the relative transform from the returned parent link to frame.
    */
-  const moveit::core::LinkModel* getRigidlyConnectedParentLinkModel(const std::string& frame) const;
+  const moveit::core::LinkModel*
+  getRigidlyConnectedParentLinkModel(const std::string& frame, Eigen::Isometry3d* transform = nullptr,
+                                     const moveit::core::JointModelGroup* jmg = nullptr) const;
 
   /** \brief Get the link transform w.r.t. the root link (model frame) of the RobotModel.
    *   This is typically the root link of the URDF unless a virtual joint is present.

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.hpp
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.hpp
@@ -1230,11 +1230,9 @@ public:
    *
    * This behaves the same as RobotModel::getRigidlyConnectedParentLinkModel,
    * but can additionally resolve parents for attached objects / subframes.
-   *
-   * If transform is specified, return the (fixed) relative transform from the returned parent link to frame.
    */
   const moveit::core::LinkModel*
-  getRigidlyConnectedParentLinkModel(const std::string& frame, Eigen::Isometry3d* transform = nullptr,
+  getRigidlyConnectedParentLinkModel(const std::string& frame,
                                      const moveit::core::JointModelGroup* jmg = nullptr) const;
 
   /** \brief Get the link transform w.r.t. the root link (model frame) of the RobotModel.
@@ -1715,6 +1713,14 @@ private:
 
   /** \brief This function is only called in debug mode */
   bool checkCollisionTransforms() const;
+
+  /** \brief Get the closest link in the kinematic tree to `frame`.
+   *
+   * Helper function for getRigidlyConnectedParentLinkModel,
+   * which resolves attached objects / subframes.
+   */
+  const moveit::core::LinkModel*
+  getLinkModelIncludingAttachedBodies(const std::string& frame) const;
 
   RobotModelConstPtr robot_model_;
 

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.hpp
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.hpp
@@ -1231,7 +1231,7 @@ public:
    * This behaves the same as RobotModel::getRigidlyConnectedParentLinkModel,
    * but can additionally resolve parents for attached objects / subframes.
    *
-   * If transform is specified, return the relative transform from the returned parent link to frame.
+   * If transform is specified, return the (fixed) relative transform from the returned parent link to frame.
    */
   const moveit::core::LinkModel*
   getRigidlyConnectedParentLinkModel(const std::string& frame, Eigen::Isometry3d* transform = nullptr,

--- a/moveit_core/robot_state/src/cartesian_interpolator.cpp
+++ b/moveit_core/robot_state/src/cartesian_interpolator.cpp
@@ -450,12 +450,12 @@ CartesianInterpolator::Percentage CartesianInterpolator::computeCartesianPath(
     Eigen::Isometry3d pose(start_quaternion.slerp(percentage, target_quaternion));
     pose.translation() = percentage * rotated_target.translation() + (1 - percentage) * start_pose.translation();
 
-    // Explicitly use a single IK attempt only (by setting a timeout of 0.0), using the current state as the seed.
-    // Random seeding (of additional attempts) would create large joint-space jumps.
-    if (start_state->setFromIK(group, pose * offset, link->getName(), consistency_limits, 0.0, validCallback, options,
-                               cost_function))
+    // Explicitly use a single IK attempt only: We want a smooth trajectory.
+    // Random seeding (of additional attempts) would probably create IK jumps.
+    if (start_state->setFromIK(group, pose * offset, link->getName(), consistency_limits, 0.0, validCallback, options))
     {
-      path.push_back(std::make_shared<moveit::core::RobotState>(*start_state));
+      start_state->update();
+      traj.push_back(std::make_shared<moveit::core::RobotState>(*start_state));
     }
     else
     {

--- a/moveit_core/robot_state/src/cartesian_interpolator.cpp
+++ b/moveit_core/robot_state/src/cartesian_interpolator.cpp
@@ -453,10 +453,7 @@ CartesianInterpolator::Percentage CartesianInterpolator::computeCartesianPath(
     // Explicitly use a single IK attempt only: We want a smooth trajectory.
     // Random seeding (of additional attempts) would probably create IK jumps.
     if (start_state->setFromIK(group, pose * offset, link->getName(), consistency_limits, 0.0, validCallback, options))
-    {
-      start_state->update();
       traj.push_back(std::make_shared<moveit::core::RobotState>(*start_state));
-    }
     else
     {
       break;

--- a/moveit_core/robot_state/src/cartesian_interpolator.cpp
+++ b/moveit_core/robot_state/src/cartesian_interpolator.cpp
@@ -450,10 +450,14 @@ CartesianInterpolator::Percentage CartesianInterpolator::computeCartesianPath(
     Eigen::Isometry3d pose(start_quaternion.slerp(percentage, target_quaternion));
     pose.translation() = percentage * rotated_target.translation() + (1 - percentage) * start_pose.translation();
 
-    // Explicitly use a single IK attempt only: We want a smooth trajectory.
-    // Random seeding (of additional attempts) would probably create IK jumps.
-    if (start_state->setFromIK(group, pose * offset, link->getName(), consistency_limits, 0.0, validCallback, options))
-      traj.push_back(std::make_shared<moveit::core::RobotState>(*start_state));
+    // Explicitly use a single IK attempt only (by setting a timeout of 0.0), using the current state as the seed.
+    // Random seeding (of additional attempts) would create large joint-space jumps.
+    if (start_state->setFromIK(group, pose * offset, link->getName(), consistency_limits, 0.0, validCallback, options,
+                               cost_function))
+    {
+      start_state->update();
+      path.push_back(std::make_shared<moveit::core::RobotState>(*start_state));
+    }
     else
     {
       break;

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -907,8 +907,7 @@ void RobotState::updateStateWithLinkAt(const LinkModel* link, const Eigen::Isome
   }
 }
 
-const LinkModel*
-getLinkModelIncludingAttachedBodies(const std::string& frame) const
+const LinkModel* getLinkModelIncludingAttachedBodies(const std::string& frame) const
 {
   // If the frame is a link, return that link.
   if (getRobotModel()->hasLinkModel(frame))

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -907,7 +907,7 @@ void RobotState::updateStateWithLinkAt(const LinkModel* link, const Eigen::Isome
   }
 }
 
-const LinkModel* getLinkModelIncludingAttachedBodies(const std::string& frame) const
+const LinkModel* RobotState::getLinkModelIncludingAttachedBodies(const std::string& frame) const
 {
   // If the frame is a link, return that link.
   if (getRobotModel()->hasLinkModel(frame))

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -919,36 +919,38 @@ const LinkModel* RobotState::getRigidlyConnectedParentLinkModel(const std::strin
     if (!hasAttachedBody(object))
       return nullptr;
     auto body{ getAttachedBody(object) };
-    if (!body->hasSubframeTransform(frame))
-      return nullptr;
+    bool found = false;
     if (transform)
-      *transform = body->getGlobalSubframeTransform(frame);
+      *transform = body->getSubframeTransform(frame, &found);
+    else
+      body->getSubframeTransform(frame, &found);
+    if (!found)
+      return nullptr;
+    if (transform)  // prepend the body transform
+      *transform = body->getPose() * *transform;
     link = body->getAttachedLink();
   }
   else if (hasAttachedBody(frame))
   {
     auto body{ getAttachedBody(frame) };
     if (transform)
-      *transform = body->getGlobalPose();
+      *transform = body->getPose();
     link = body->getAttachedLink();
   }
   else if (getRobotModel()->hasLinkModel(frame))
   {
     link = getLinkModel(frame);
     if (transform)
-    {
-      BOOST_VERIFY(checkLinkTransforms());
-      *transform = global_link_transforms_[link->getLinkIndex()];
-    }
+      transform->setIdentity();
+    if (!link)
+      return nullptr;
   }
   // link is valid and transform describes pose of frame w.r.t. global frame
-  auto* parent = getRobotModel()->getRigidlyConnectedParentLinkModel(link, jmg);
+  Eigen::Isometry3d link_transform;
+  auto* parent = getRobotModel()->getRigidlyConnectedParentLinkModel(link, link_transform, jmg);
   if (parent && transform)
-  {
-    BOOST_VERIFY(checkLinkTransforms());
-    // compute transform from parent link to frame
-    *transform = global_link_transforms_[parent->getLinkIndex()].inverse() * *transform;
-  }
+    // prepend link_transform to get transform from parent link to frame
+    *transform = link_transform * *transform;
   return parent;
 }
 
@@ -1868,6 +1870,9 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const EigenSTL::vector_Is
   }
   else if (consistency_limit_sets.size() == 1)
     consistency_limits = consistency_limit_sets[0];
+
+  // ensure RobotState is up-to-date before employing it in the IK solver
+  update(false);
 
   const std::vector<std::string>& solver_tip_frames = solver->getTipFrames();
 

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -1870,9 +1870,6 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const EigenSTL::vector_Is
   else if (consistency_limit_sets.size() == 1)
     consistency_limits = consistency_limit_sets[0];
 
-  // ensure RobotState is up-to-date before employing it in the IK solver
-  update(false);
-
   const std::vector<std::string>& solver_tip_frames = solver->getTipFrames();
 
   // Track which possible tips frames we have filled in so far
@@ -1896,7 +1893,8 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const EigenSTL::vector_Is
     if (!setToIKSolverFrame(pose, solver))
       return false;
 
-    // try all of the solver's possible tip frames to see if they match with any of the passed-in pose tip frames
+    // try all of the solver's possible tip frames to see if they uniquely align with any of our passed in pose tip
+    // frames
     bool found_valid_frame = false;
     std::size_t solver_tip_id;  // our current index
     for (solver_tip_id = 0; solver_tip_id < solver_tip_frames.size(); ++solver_tip_id)
@@ -1915,20 +1913,20 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const EigenSTL::vector_Is
 
       if (pose_frame != solver_tip_frame)
       {
-        Eigen::Isometry3d pose_parent_to_frame;
-        auto* pose_parent = getRigidlyConnectedParentLinkModel(pose_frame, &pose_parent_to_frame, jmg);
+        auto* pose_parent = getRigidlyConnectedParentLinkModel(pose_frame);
         if (!pose_parent)
         {
-          ROS_ERROR_STREAM_NAMED(LOGNAME, "Pose frame '" << pose_frame << "' does not exist.");
+          RCLCPP_ERROR_STREAM(getLogger(), "The following Pose Frame does not exist: " << pose_frame);
           return false;
         }
-        Eigen::Isometry3d tip_parent_to_tip;
-        auto* tip_parent = getRigidlyConnectedParentLinkModel(solver_tip_frame, &tip_parent_to_tip, jmg);
+        Eigen::Isometry3d pose_parent_to_frame = getFrameTransform(pose_frame);
+        auto* tip_parent = getRigidlyConnectedParentLinkModel(solver_tip_frame);
         if (!tip_parent)
         {
-          ROS_ERROR_STREAM_NAMED(LOGNAME, "Solver tip frame '" << solver_tip_frame << "' does not exist.");
+          RCLCPP_ERROR_STREAM(getLogger(), "The following Solver Tip Frame does not exist: " << solver_tip_frame);
           return false;
         }
+        Eigen::Isometry3d tip_parent_to_tip = getFrameTransform(solver_tip_frame);
         if (pose_parent == tip_parent)
         {
           // transform goal pose as target for solver_tip_frame (instead of pose_frame)
@@ -1941,8 +1939,8 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const EigenSTL::vector_Is
       {
         found_valid_frame = true;
         break;
-      }
-    }  // end for solver_tip_frames
+      }  // end if pose_frame
+    }    // end for solver_tip_frames
 
     // Make sure one of the tip frames worked
     if (!found_valid_frame)

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -912,39 +912,38 @@ const LinkModel* RobotState::getRigidlyConnectedParentLinkModel(const std::strin
 {
   const LinkModel* link{ nullptr };
 
-  size_t idx = 0;
-  if ((idx = frame.find('/')) != std::string::npos)
-  {  // resolve sub frame
-    std::string object{ frame.substr(0, idx) };
-    if (!hasAttachedBody(object))
-      return nullptr;
-    auto body{ getAttachedBody(object) };
-    bool found = false;
-    if (transform)
-      *transform = body->getSubframeTransform(frame, &found);
-    else
-      body->getSubframeTransform(frame, &found);
-    if (!found)
-      return nullptr;
-    if (transform)  // prepend the body transform
-      *transform = body->getPose() * *transform;
-    link = body->getAttachedLink();
-  }
-  else if (hasAttachedBody(frame))
-  {
-    auto body{ getAttachedBody(frame) };
-    if (transform)
-      *transform = body->getPose();
-    link = body->getAttachedLink();
-  }
-  else if (getRobotModel()->hasLinkModel(frame))
+  if (getRobotModel()->hasLinkModel(frame))
   {
     link = getLinkModel(frame);
     if (transform)
       transform->setIdentity();
-    if (!link)
+  }
+  else if (const auto it = attached_body_map_.find(frame); it != attached_body_map_.end())
+  {
+    const auto& body{ it->second };
+    link = body->getAttachedLink();
+    if (transform)
+      *transform = body->getPose();
+  }
+  else
+  {
+    bool found = false;
+    for (const auto& it : attached_body_map_)
+    {
+      const auto& body{ it.second };
+      const Eigen::Isometry3d& subframe = body->getSubframeTransform(frame, &found);
+      if (found)
+      {
+        if (transform)  // prepend the body transform
+          *transform = body->getPose() * subframe;
+        link = body->getAttachedLink();
+        break;
+      }
+    }
+    if (!found)
       return nullptr;
   }
+
   // link is valid and transform describes pose of frame w.r.t. global frame
   Eigen::Isometry3d link_transform;
   auto* parent = getRobotModel()->getRigidlyConnectedParentLinkModel(link, link_transform, jmg);

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -948,8 +948,10 @@ const LinkModel* RobotState::getRigidlyConnectedParentLinkModel(const std::strin
   Eigen::Isometry3d link_transform;
   auto* parent = getRobotModel()->getRigidlyConnectedParentLinkModel(link, link_transform, jmg);
   if (parent && transform)
+  {
     // prepend link_transform to get transform from parent link to frame
     *transform = link_transform * *transform;
+  }
   return parent;
 }
 

--- a/moveit_core/robot_state/test/robot_state_test.cpp
+++ b/moveit_core/robot_state/test/robot_state_test.cpp
@@ -762,7 +762,7 @@ TEST_F(OneRobot, rigidlyConnectedParent)
   // attach "object" with "subframe" to link_b
   state.attachBody(std::make_unique<moveit::core::AttachedBody>(
       link_b, "object", Eigen::Isometry3d(Eigen::Translation3d(1, 0, 0)), std::vector<shapes::ShapeConstPtr>{},
-      EigenSTL::vector_Isometry3d{}, std::set<std::string>{}, trajectory_msgs::JointTrajectory{},
+      EigenSTL::vector_Isometry3d{}, std::set<std::string>{}, trajectory_msgs::msg::JointTrajectory{},
       moveit::core::FixedTransformsMap{ { "subframe", Eigen::Isometry3d(Eigen::Translation3d(0, 0, 1)) } }));
 
   // RobotState's version should resolve these too
@@ -791,7 +791,7 @@ TEST_F(OneRobot, rigidlyConnectedParent)
   state.attachBody(std::make_unique<moveit::core::AttachedBody>(
       link_with_slash, "object/with/slash", Eigen::Isometry3d(Eigen::Translation3d(1, 0, 0)),
       std::vector<shapes::ShapeConstPtr>{}, EigenSTL::vector_Isometry3d{}, std::set<std::string>{},
-      trajectory_msgs::JointTrajectory{},
+      trajectory_msgs::msg::JointTrajectory{},
       moveit::core::FixedTransformsMap{ { "sub/frame", Eigen::Isometry3d(Eigen::Translation3d(0, 0, 1)) } }));
   const moveit::core::LinkModel* rigid_parent_of_object =
       state.getRigidlyConnectedParentLinkModel("object/with/slash/sub/frame");

--- a/moveit_core/robot_state/test/robot_state_test.cpp
+++ b/moveit_core/robot_state/test/robot_state_test.cpp
@@ -755,9 +755,7 @@ TEST_F(OneRobot, rigidlyConnectedParent)
   state.setToDefaultValues();
 
   Eigen::Isometry3d a_to_b;
-  EXPECT_EQ(state.getRigidlyConnectedParentLinkModel("link_b", &a_to_b), link_a);
-  // translation from link_a to link_b is (0 0.5 0)
-  EXPECT_NEAR_TRACED(a_to_b.translation(), Eigen::Translation3d(0, 0.5, 0).translation());
+  EXPECT_EQ(state.getRigidlyConnectedParentLinkModel("link_b"), link_a);
 
   // attach "object" with "subframe" to link_b
   state.attachBody(std::make_unique<moveit::core::AttachedBody>(
@@ -768,9 +766,7 @@ TEST_F(OneRobot, rigidlyConnectedParent)
   // RobotState's version should resolve these too
   Eigen::Isometry3d transform;
   EXPECT_EQ(link_a, state.getRigidlyConnectedParentLinkModel("object"));
-  EXPECT_EQ(link_a, state.getRigidlyConnectedParentLinkModel("object/subframe", &transform));
-  // transform from link_b to object/subframe is (1 0 1)
-  EXPECT_NEAR_TRACED((a_to_b.inverse() * transform).matrix(), Eigen::Isometry3d(Eigen::Translation3d(1, 0, 1)).matrix());
+  EXPECT_EQ(link_a, state.getRigidlyConnectedParentLinkModel("object/subframe"));
 
   // test failure cases
   EXPECT_EQ(nullptr, state.getRigidlyConnectedParentLinkModel("no_object"));

--- a/moveit_core/robot_state/test/robot_state_test.cpp
+++ b/moveit_core/robot_state/test/robot_state_test.cpp
@@ -781,20 +781,25 @@ TEST_F(OneRobot, rigidlyConnectedParent)
   EXPECT_EQ(robot_model_->getRigidlyConnectedParentLinkModel(link_b), link_a);
 
   moveit::core::RobotState state(robot_model_);
-  state.setToDefaultValues();
-  state.updateLinkTransforms();
+  state.update();
 
-  EXPECT_EQ(state.getRigidlyConnectedParentLinkModel("link_b"), link_a);
+  Eigen::Isometry3d a_to_b;
+  EXPECT_EQ(state.getRigidlyConnectedParentLinkModel("link_b", &a_to_b), link_a);
+  // translation from link_a to link_b is (0 0.5 0)
+  EXPECT_NEAR_TRACED(a_to_b.translation(), Eigen::Translation3d(0, 0.5, 0).translation());
 
   // attach "object" with "subframe" to link_b
   state.attachBody(std::make_unique<moveit::core::AttachedBody>(
-      link_b, "object", Eigen::Isometry3d::Identity(), std::vector<shapes::ShapeConstPtr>{},
-      EigenSTL::vector_Isometry3d{}, std::set<std::string>{}, trajectory_msgs::msg::JointTrajectory{},
-      moveit::core::FixedTransformsMap{ { "subframe", Eigen::Isometry3d::Identity() } }));
+      link_b, "object", Eigen::Isometry3d(Eigen::Translation3d(1, 0, 0)), std::vector<shapes::ShapeConstPtr>{},
+      EigenSTL::vector_Isometry3d{}, std::set<std::string>{}, trajectory_msgs::JointTrajectory{},
+      moveit::core::FixedTransformsMap{ { "subframe", Eigen::Isometry3d(Eigen::Translation3d(0, 0, 1)) } }));
 
   // RobotState's version should resolve these too
+  Eigen::Isometry3d transform;
   EXPECT_EQ(link_a, state.getRigidlyConnectedParentLinkModel("object"));
-  EXPECT_EQ(link_a, state.getRigidlyConnectedParentLinkModel("object/subframe"));
+  EXPECT_EQ(link_a, state.getRigidlyConnectedParentLinkModel("object/subframe", &transform));
+  // transform from link_b to object/subframe is (1 0 1)
+  EXPECT_NEAR_TRACED((a_to_b.inverse() * transform).matrix(), Eigen::Isometry3d(Eigen::Translation3d(1, 0, 1)).matrix());
 
   // test failure cases
   EXPECT_EQ(nullptr, state.getRigidlyConnectedParentLinkModel("no_object"));

--- a/moveit_core/robot_state/test/robot_state_test.cpp
+++ b/moveit_core/robot_state/test/robot_state_test.cpp
@@ -781,7 +781,6 @@ TEST_F(OneRobot, rigidlyConnectedParent)
   EXPECT_EQ(robot_model_->getRigidlyConnectedParentLinkModel(link_b), link_a);
 
   moveit::core::RobotState state(robot_model_);
-  state.update();
 
   Eigen::Isometry3d a_to_b;
   EXPECT_EQ(state.getRigidlyConnectedParentLinkModel("link_b", &a_to_b), link_a);

--- a/moveit_core/robot_state/test/robot_state_test.cpp
+++ b/moveit_core/robot_state/test/robot_state_test.cpp
@@ -39,6 +39,7 @@
 #include <urdf_parser/urdf_parser.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #include <gtest/gtest.h>
+#include <gmock/gmock-matchers.h>
 #include <sstream>
 #include <algorithm>
 #include <ctype.h>
@@ -247,180 +248,185 @@ protected:
   void SetUp() override
   {
     static const std::string MODEL2 = R"(
-      <?xml version="1.0" ?>
-      <robot name="one_robot">
-      <link name="base_link">
-        <inertial>
-          <mass value="2.81"/>
-          <origin rpy="0 0 0" xyz="0.0 0.0 .0"/>
-          <inertia ixx="0.1" ixy="-0.2" ixz="0.5" iyy="-.09" iyz="1" izz="0.101"/>
-        </inertial>
-        <collision name="my_collision">
-          <origin rpy="0 0 0" xyz="0 0 0"/>
-          <geometry>
-            <box size="1 2 1" />
-          </geometry>
-        </collision>
-        <visual>
-          <origin rpy="0 0 0" xyz="0.0 0 0"/>
-          <geometry>
-            <box size="1 2 1" />
-          </geometry>
-        </visual>
-      </link>
-      <joint name="joint_a" type="continuous">
-          <axis xyz="0 0 1"/>
-          <parent link="base_link"/>
-          <child link="link_a"/>
-          <origin rpy=" 0.0 0 0 " xyz="0.0 0 0 "/>
-      </joint>
-      <link name="link_a">
-        <inertial>
-          <mass value="1.0"/>
-          <origin rpy="0 0 0" xyz="0.0 0.0 .0"/>
-          <inertia ixx="0.1" ixy="-0.2" ixz="0.5" iyy="-.09" iyz="1" izz="0.101"/>
-        </inertial>
-        <collision>
-          <origin rpy="0 0 0" xyz="0 0 0"/>
-          <geometry>
-            <box size="1 2 1" />
-          </geometry>
-        </collision>
-        <visual>
-          <origin rpy="0 0 0" xyz="0.0 0 0"/>
-          <geometry>
-            <box size="1 2 1" />
-          </geometry>
-        </visual>
-      </link>
-      <joint name="joint_b" type="fixed">
-        <parent link="link_a"/>
-        <child link="link_b"/>
-        <origin rpy=" 0.0 -0.42 0 " xyz="0.0 0.5 0 "/>
-      </joint>
-      <link name="link_b">
-        <inertial>
-          <mass value="1.0"/>
-          <origin rpy="0 0 0" xyz="0.0 0.0 .0"/>
-          <inertia ixx="0.1" ixy="-0.2" ixz="0.5" iyy="-.09" iyz="1" izz="0.101"/>
-        </inertial>
-        <collision>
-          <origin rpy="0 0 0" xyz="0 0 0"/>
-          <geometry>
-            <box size="1 2 1" />
-          </geometry>
-        </collision>
-        <visual>
-          <origin rpy="0 0 0" xyz="0.0 0 0"/>
-          <geometry>
-            <box size="1 2 1" />
-          </geometry>
-        </visual>
-      </link>
-      <joint name="joint_c" type="prismatic">
-        <axis xyz="1 0 0"/>
-        <limit effort="100.0" lower="0.0" upper="0.09" velocity="0.2"/>
-        <safety_controller k_position="20.0" k_velocity="500.0" soft_lower_limit="0.0"
-    soft_upper_limit="0.089"/>
-        <parent link="link_b"/>
-        <child link="link_c"/>
-        <origin rpy=" 0.0 0.42 0.0 " xyz="0.0 -0.1 0 "/>
-      </joint>
-      <link name="link_c">
-        <inertial>
-          <mass value="1.0"/>
-          <origin rpy="0 0 0" xyz="0.0 0 .0"/>
-          <inertia ixx="0.1" ixy="-0.2" ixz="0.5" iyy="-.09" iyz="1" izz="0.101"/>
-        </inertial>
-        <collision>
-          <origin rpy="0 0 0" xyz="0 0 0"/>
-          <geometry>
-            <box size="1 2 1" />
-          </geometry>
-        </collision>
-        <visual>
-          <origin rpy="0 0 0" xyz="0.0 0 0"/>
-          <geometry>
-            <box size="1 2 1" />
-          </geometry>
-        </visual>
-      </link>
-      <joint name="mim_f" type="prismatic">
-        <axis xyz="1 0 0"/>
-        <limit effort="100.0" lower="0.0" upper="0.19" velocity="0.2"/>
-        <parent link="link_c"/>
-        <child link="link_d"/>
-        <origin rpy=" 0.0 0.0 0.0 " xyz="0.1 0.1 0 "/>
-        <mimic joint="joint_f" multiplier="1.5" offset="0.1"/>
-      </joint>
-      <joint name="joint_f" type="prismatic">
-        <axis xyz="1 0 0"/>
-        <limit effort="100.0" lower="0.0" upper="0.19" velocity="0.2"/>
-        <parent link="link_d"/>
-        <child link="link_e"/>
-        <origin rpy=" 0.0 0.0 0.0 " xyz="0.1 0.1 0 "/>
-      </joint>
-      <link name="link_d">
-        <collision>
-          <origin rpy="0 0 0" xyz="0 0 0"/>
-          <geometry>
-            <box size="1 2 1" />
-          </geometry>
-        </collision>
-        <visual>
-          <origin rpy="0 1 0" xyz="0 0.1 0"/>
-          <geometry>
-            <box size="1 2 1" />
-          </geometry>
-        </visual>
-      </link>
-      <link name="link_e">
-        <collision>
-          <origin rpy="0 0 0" xyz="0 0 0"/>
-          <geometry>
-            <box size="1 2 1" />
-          </geometry>
-        </collision>
-        <visual>
-          <origin rpy="0 1 0" xyz="0 0.1 0"/>
-          <geometry>
-            <box size="1 2 1" />
-          </geometry>
-        </visual>
-      </link>
-      </robot>
-    )";
-
-    static const std::string SMODEL2 = R"xml(
-      <?xml version="1.0" ?>
-      <robot name="one_robot">
-        <virtual_joint name="base_joint" child_link="base_link" parent_frame="odom_combined" type="planar"/>
-        <group name="base_from_joints">
-          <joint name="base_joint"/>
-          <joint name="joint_a"/>
-          <joint name="joint_c"/>
-        </group>
-        <group name="mim_joints">
-          <joint name="joint_f"/>
-          <joint name="mim_f"/>
-        </group>
-        <group name="base_with_subgroups">
-          <group name="base_from_base_to_tip"/>
-            <joint name="joint_c"/>
-          </group>
-          <group name="base_from_base_to_tip">
-            <chain base_link="base_link" tip_link="link_b"/>
-            <joint name="base_joint"/>
-          </group>
-          <group name="base_from_base_to_e">
-            <chain base_link="base_link" tip_link="link_e"/>
-            <joint name="base_joint"/>
-          </group>
-          <group name="base_with_bad_subgroups">
-            <group name="error"/>
-        </group>
-      </robot>
-      )xml";
+<?xml version="1.0" ?>
+<robot name="one_robot">
+<link name="base_link">
+  <inertial>
+    <mass value="2.81"/>
+    <origin rpy="0 0 0" xyz="0.0 0.0 .0"/>
+    <inertia ixx="0.1" ixy="-0.2" ixz="0.5" iyy="-.09" iyz="1" izz="0.101"/>
+  </inertial>
+  <collision name="my_collision">
+    <origin rpy="0 0 0" xyz="0 0 0"/>
+    <geometry>
+      <box size="1 2 1" />
+    </geometry>
+  </collision>
+  <visual>
+    <origin rpy="0 0 0" xyz="0.0 0 0"/>
+    <geometry>
+      <box size="1 2 1" />
+    </geometry>
+  </visual>
+</link>
+<joint name="joint_a" type="continuous">
+   <axis xyz="0 0 1"/>
+   <parent link="base_link"/>
+   <child link="link_a"/>
+   <origin rpy=" 0.0 0 0 " xyz="0.0 0 0 "/>
+</joint>
+<link name="link_a">
+  <inertial>
+    <mass value="1.0"/>
+    <origin rpy="0 0 0" xyz="0.0 0.0 .0"/>
+    <inertia ixx="0.1" ixy="-0.2" ixz="0.5" iyy="-.09" iyz="1" izz="0.101"/>
+  </inertial>
+  <collision>
+    <origin rpy="0 0 0" xyz="0 0 0"/>
+    <geometry>
+      <box size="1 2 1" />
+    </geometry>
+  </collision>
+  <visual>
+    <origin rpy="0 0 0" xyz="0.0 0 0"/>
+    <geometry>
+      <box size="1 2 1" />
+    </geometry>
+  </visual>
+</link>
+<joint name="joint_b" type="fixed">
+  <parent link="link_a"/>
+  <child link="link_b"/>
+  <origin rpy=" 0.0 -0.42 0 " xyz="0.0 0.5 0 "/>
+</joint>
+<link name="link_b">
+  <inertial>
+    <mass value="1.0"/>
+    <origin rpy="0 0 0" xyz="0.0 0.0 .0"/>
+    <inertia ixx="0.1" ixy="-0.2" ixz="0.5" iyy="-.09" iyz="1" izz="0.101"/>
+  </inertial>
+  <collision>
+    <origin rpy="0 0 0" xyz="0 0 0"/>
+    <geometry>
+      <box size="1 2 1" />
+    </geometry>
+  </collision>
+  <visual>
+    <origin rpy="0 0 0" xyz="0.0 0 0"/>
+    <geometry>
+      <box size="1 2 1" />
+    </geometry>
+  </visual>
+</link>
+  <joint name="joint_c" type="prismatic">
+    <axis xyz="1 0 0"/>
+    <limit effort="100.0" lower="0.0" upper="0.09" velocity="0.2"/>
+    <safety_controller k_position="20.0" k_velocity="500.0" soft_lower_limit="0.0"
+soft_upper_limit="0.089"/>
+    <parent link="link_b"/>
+    <child link="link_c"/>
+    <origin rpy=" 0.0 0.42 0.0 " xyz="0.0 -0.1 0 "/>
+  </joint>
+<link name="link_c">
+  <inertial>
+    <mass value="1.0"/>
+    <origin rpy="0 0 0" xyz="0.0 0 .0"/>
+    <inertia ixx="0.1" ixy="-0.2" ixz="0.5" iyy="-.09" iyz="1" izz="0.101"/>
+  </inertial>
+  <collision>
+    <origin rpy="0 0 0" xyz="0 0 0"/>
+    <geometry>
+      <box size="1 2 1" />
+    </geometry>
+  </collision>
+  <visual>
+    <origin rpy="0 0 0" xyz="0.0 0 0"/>
+    <geometry>
+      <box size="1 2 1" />
+    </geometry>
+  </visual>
+</link>
+  <joint name="mim_f" type="prismatic">
+    <axis xyz="1 0 0"/>
+    <limit effort="100.0" lower="0.0" upper="0.19" velocity="0.2"/>
+    <parent link="link_c"/>
+    <child link="link_d"/>
+    <origin rpy=" 0.0 0.0 0.0 " xyz="0.1 0.1 0 "/>
+    <mimic joint="joint_f" multiplier="1.5" offset="0.1"/>
+  </joint>
+  <joint name="joint_f" type="prismatic">
+    <axis xyz="1 0 0"/>
+    <limit effort="100.0" lower="0.0" upper="0.19" velocity="0.2"/>
+    <parent link="link_d"/>
+    <child link="link_e"/>
+    <origin rpy=" 0.0 0.0 0.0 " xyz="0.1 0.1 0 "/>
+  </joint>
+<link name="link_d">
+  <collision>
+    <origin rpy="0 0 0" xyz="0 0 0"/>
+    <geometry>
+      <box size="1 2 1" />
+    </geometry>
+  </collision>
+  <visual>
+    <origin rpy="0 1 0" xyz="0 0.1 0"/>
+    <geometry>
+      <box size="1 2 1" />
+    </geometry>
+  </visual>
+</link>
+<link name="link_e">
+  <collision>
+    <origin rpy="0 0 0" xyz="0 0 0"/>
+    <geometry>
+      <box size="1 2 1" />
+    </geometry>
+  </collision>
+  <visual>
+    <origin rpy="0 1 0" xyz="0 0.1 0"/>
+    <geometry>
+      <box size="1 2 1" />
+    </geometry>
+  </visual>
+</link>
+<link name="link/with/slash" />
+<joint name="joint_link_with_slash" type="fixed">
+  <parent link="base_link"/>
+  <child link="link/with/slash"/>
+  <origin rpy="0 0 0" xyz="0 0 0"/>
+</joint>
+</robot>
+)";
+    static const std::string SMODEL2 = R"(
+<?xml version="1.0" ?>
+<robot name="one_robot">
+<virtual_joint name="base_joint" child_link="base_link" parent_frame="odom_combined" type="planar"/>
+<group name="base_from_joints">
+<joint name="base_joint"/>
+<joint name="joint_a"/>
+<joint name="joint_c"/>
+</group>
+<group name="mim_joints">
+<joint name="joint_f"/>
+<joint name="mim_f"/>
+</group>
+<group name="base_with_subgroups">
+<group name="base_from_base_to_tip"/>
+<joint name="joint_c"/>
+</group>
+<group name="base_from_base_to_tip">
+<chain base_link="base_link" tip_link="link_b"/>
+<joint name="base_joint"/>
+</group>
+<group name="base_from_base_to_e">
+<chain base_link="base_link" tip_link="link_e"/>
+<joint name="base_joint"/>
+</group>
+<group name="base_with_bad_subgroups">
+<group name="error"/>
+</group>
+</robot>
+)";
 
     urdf::ModelInterfaceSharedPtr urdf_model = urdf::parseURDF(MODEL2);
     auto srdf_model = std::make_shared<srdf::Model>();
@@ -480,60 +486,25 @@ TEST_F(OneRobot, FK)
   ASSERT_TRUE(g_three != nullptr);
   ASSERT_TRUE(g_four == nullptr);
 
-  // joint_b is a fixed joint, so no one should have it
-  ASSERT_EQ(g_one->getJointModelNames().size(), 3u);
-  ASSERT_EQ(g_two->getJointModelNames().size(), 3u);
-  ASSERT_EQ(g_three->getJointModelNames().size(), 4u);
-  ASSERT_EQ(g_mim->getJointModelNames().size(), 2u);
+  EXPECT_THAT(g_one->getJointModelNames(), ::testing::ElementsAreArray({ "base_joint", "joint_a", "joint_c" }));
+  EXPECT_THAT(g_two->getJointModelNames(), ::testing::ElementsAreArray({ "base_joint", "joint_a", "joint_b" }));
+  EXPECT_THAT(g_three->getJointModelNames(),
+              ::testing::ElementsAreArray({ "base_joint", "joint_a", "joint_b", "joint_c" }));
+  EXPECT_THAT(g_mim->getJointModelNames(), ::testing::ElementsAreArray({ "mim_f", "joint_f" }));
 
-  // only the links in between the joints, and the children of the leafs
-  ASSERT_EQ(g_one->getLinkModelNames().size(), 3u);
-  // g_two only has three links
-  ASSERT_EQ(g_two->getLinkModelNames().size(), 3u);
-  ASSERT_EQ(g_three->getLinkModelNames().size(), 4u);
-
-  std::vector<std::string> jmn = g_one->getJointModelNames();
-  std::sort(jmn.begin(), jmn.end());
-  EXPECT_EQ(jmn[0], "base_joint");
-  EXPECT_EQ(jmn[1], "joint_a");
-  EXPECT_EQ(jmn[2], "joint_c");
-  jmn = g_two->getJointModelNames();
-  std::sort(jmn.begin(), jmn.end());
-  EXPECT_EQ(jmn[0], "base_joint");
-  EXPECT_EQ(jmn[1], "joint_a");
-  EXPECT_EQ(jmn[2], "joint_b");
-  jmn = g_three->getJointModelNames();
-  std::sort(jmn.begin(), jmn.end());
-  EXPECT_EQ(jmn[0], "base_joint");
-  EXPECT_EQ(jmn[1], "joint_a");
-  EXPECT_EQ(jmn[2], "joint_b");
-  EXPECT_EQ(jmn[3], "joint_c");
+  EXPECT_THAT(g_one->getLinkModelNames(), ::testing::ElementsAreArray({ "base_link", "link_a", "link_c" }));
+  EXPECT_THAT(g_two->getLinkModelNames(), ::testing::ElementsAreArray({ "base_link", "link_a", "link_b" }));
+  EXPECT_THAT(g_three->getLinkModelNames(), ::testing::ElementsAreArray({ "base_link", "link_a", "link_b", "link_c" }));
 
   // but they should have the same links to be updated
-  ASSERT_EQ(g_one->getUpdatedLinkModels().size(), 6u);
-  ASSERT_EQ(g_two->getUpdatedLinkModels().size(), 6u);
-  ASSERT_EQ(g_three->getUpdatedLinkModels().size(), 6u);
-
-  EXPECT_EQ(g_one->getUpdatedLinkModels()[0]->getName(), "base_link");
-  EXPECT_EQ(g_one->getUpdatedLinkModels()[1]->getName(), "link_a");
-  EXPECT_EQ(g_one->getUpdatedLinkModels()[2]->getName(), "link_b");
-  EXPECT_EQ(g_one->getUpdatedLinkModels()[3]->getName(), "link_c");
-
-  EXPECT_EQ(g_two->getUpdatedLinkModels()[0]->getName(), "base_link");
-  EXPECT_EQ(g_two->getUpdatedLinkModels()[1]->getName(), "link_a");
-  EXPECT_EQ(g_two->getUpdatedLinkModels()[2]->getName(), "link_b");
-  EXPECT_EQ(g_two->getUpdatedLinkModels()[3]->getName(), "link_c");
-
-  EXPECT_EQ(g_three->getUpdatedLinkModels()[0]->getName(), "base_link");
-  EXPECT_EQ(g_three->getUpdatedLinkModels()[1]->getName(), "link_a");
-  EXPECT_EQ(g_three->getUpdatedLinkModels()[2]->getName(), "link_b");
-  EXPECT_EQ(g_three->getUpdatedLinkModels()[3]->getName(), "link_c");
-
-  // bracketing so the state gets destroyed before we bring down the model
+  auto updated_link_model_names = { "base_link", "link_a", "link_b", "link_c", "link_d", "link_e", "link/with/slash" };
+  EXPECT_THAT(g_one->getUpdatedLinkModelNames(), ::testing::ElementsAreArray(updated_link_model_names));
+  EXPECT_THAT(g_two->getUpdatedLinkModelNames(), ::testing::ElementsAreArray(updated_link_model_names));
+  EXPECT_THAT(g_three->getUpdatedLinkModelNames(), ::testing::ElementsAreArray(updated_link_model_names));
 
   moveit::core::RobotState state(model);
 
-  EXPECT_EQ(7u, state.getVariableCount());
+  EXPECT_EQ(state.getVariableCount(), 7u);
 
   state.setToDefaultValues();
 
@@ -781,6 +752,7 @@ TEST_F(OneRobot, rigidlyConnectedParent)
   EXPECT_EQ(robot_model_->getRigidlyConnectedParentLinkModel(link_b), link_a);
 
   moveit::core::RobotState state(robot_model_);
+  state.setToDefaultValues();
 
   Eigen::Isometry3d a_to_b;
   EXPECT_EQ(state.getRigidlyConnectedParentLinkModel("link_b", &a_to_b), link_a);
@@ -806,6 +778,25 @@ TEST_F(OneRobot, rigidlyConnectedParent)
   EXPECT_EQ(nullptr, state.getRigidlyConnectedParentLinkModel(""));
   EXPECT_EQ(nullptr, state.getRigidlyConnectedParentLinkModel("object/"));
   EXPECT_EQ(nullptr, state.getRigidlyConnectedParentLinkModel("/"));
+
+  // link names with '/' should still work as before
+  const moveit::core::LinkModel* link_with_slash{ robot_model_->getLinkModel("link/with/slash") };
+  EXPECT_TRUE(link_with_slash);
+  const moveit::core::LinkModel* rigid_parent_of_link_with_slash =
+      state.getRigidlyConnectedParentLinkModel("link/with/slash");
+  ASSERT_TRUE(rigid_parent_of_link_with_slash);
+  EXPECT_EQ("base_link", rigid_parent_of_link_with_slash->getName());
+
+  // the last /-separated component of an object might be a subframe
+  state.attachBody(std::make_unique<moveit::core::AttachedBody>(
+      link_with_slash, "object/with/slash", Eigen::Isometry3d(Eigen::Translation3d(1, 0, 0)),
+      std::vector<shapes::ShapeConstPtr>{}, EigenSTL::vector_Isometry3d{}, std::set<std::string>{},
+      trajectory_msgs::JointTrajectory{},
+      moveit::core::FixedTransformsMap{ { "sub/frame", Eigen::Isometry3d(Eigen::Translation3d(0, 0, 1)) } }));
+  const moveit::core::LinkModel* rigid_parent_of_object =
+      state.getRigidlyConnectedParentLinkModel("object/with/slash/sub/frame");
+  ASSERT_TRUE(rigid_parent_of_object);
+  EXPECT_EQ(rigid_parent_of_link_with_slash, rigid_parent_of_object);
 }
 
 TEST(getJacobian, RevoluteJoints)

--- a/moveit_ros/move_group/src/default_capabilities/cartesian_path_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/cartesian_path_service_capability.cpp
@@ -182,28 +182,11 @@ bool MoveGroupCartesianPathService::computeService(
           {
             jump_threshold = moveit::core::JumpThreshold::relative(req->jump_threshold);
           }
-          // resolve link_name
-          bool global_frame = !moveit::core::Transforms::sameFrame(link_name, req.header.frame_id);
-          const moveit::core::LinkModel* link_model = nullptr;
-          bool found = false;
-          const Eigen::Isometry3d frame_pose = start_state.getFrameInfo(link_name, link_model, found);
-          if (!found)
-          {
-            ROS_ERROR_STREAM_NAMED(getName(), "Unknown frame: " << link_name);
-            res.error_code.val = moveit_msgs::MoveItErrorCodes::FAILURE;
-          }
-          ROS_INFO_NAMED(getName(),
-                         "Attempting to follow %u waypoints for link '%s' using a step of %lf m "
-                         "and jump threshold %lf (in %s reference frame)",
-                         (unsigned int)waypoints.size(), link_name.c_str(), req.max_step, req.jump_threshold,
-                         global_frame ? "global" : "link");
-
           std::vector<moveit::core::RobotStatePtr> traj;
-          res.fraction = moveit::core::CartesianInterpolator::computeCartesianPath(
-              &start_state, jmg, traj, link_model, waypoints, global_frame, moveit::core::MaxEEFStep(req.max_step),
-              moveit::core::JumpThreshold(req.jump_threshold), constraint_fn, kinematics::KinematicsQueryOptions(),
-              start_state.getGlobalLinkTransform(link_model).inverse() * frame_pose);
-          moveit::core::robotStateToRobotStateMsg(start_state, res.start_state);
+          res->fraction = moveit::core::CartesianInterpolator::computeCartesianPath(
+              &start_state, jmg, traj, start_state.getLinkModel(link_name), waypoints, global_frame,
+              moveit::core::MaxEEFStep(req->max_step), moveit::core::CartesianPrecision{}, constraint_fn);
+          moveit::core::robotStateToRobotStateMsg(start_state, res->start_state);
 
           robot_trajectory::RobotTrajectory rt(context_->planning_scene_monitor_->getRobotModel(), req->group_name);
           for (const moveit::core::RobotStatePtr& traj_state : traj)

--- a/moveit_ros/move_group/src/default_capabilities/cartesian_path_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/cartesian_path_service_capability.cpp
@@ -182,11 +182,28 @@ bool MoveGroupCartesianPathService::computeService(
           {
             jump_threshold = moveit::core::JumpThreshold::relative(req->jump_threshold);
           }
+          // resolve link_name
+          bool global_frame = !moveit::core::Transforms::sameFrame(link_name, req.header.frame_id);
+          const moveit::core::LinkModel* link_model = nullptr;
+          bool found = false;
+          const Eigen::Isometry3d frame_pose = start_state.getFrameInfo(link_name, link_model, found);
+          if (!found)
+          {
+            ROS_ERROR_STREAM_NAMED(getName(), "Unknown frame: " << link_name);
+            res.error_code.val = moveit_msgs::MoveItErrorCodes::FAILURE;
+          }
+          ROS_INFO_NAMED(getName(),
+                         "Attempting to follow %u waypoints for link '%s' using a step of %lf m "
+                         "and jump threshold %lf (in %s reference frame)",
+                         (unsigned int)waypoints.size(), link_name.c_str(), req.max_step, req.jump_threshold,
+                         global_frame ? "global" : "link");
+
           std::vector<moveit::core::RobotStatePtr> traj;
-          res->fraction = moveit::core::CartesianInterpolator::computeCartesianPath(
-              &start_state, jmg, traj, start_state.getLinkModel(link_name), waypoints, global_frame,
-              moveit::core::MaxEEFStep(req->max_step), moveit::core::CartesianPrecision{}, constraint_fn);
-          moveit::core::robotStateToRobotStateMsg(start_state, res->start_state);
+          res.fraction = moveit::core::CartesianInterpolator::computeCartesianPath(
+              &start_state, jmg, traj, link_model, waypoints, global_frame, moveit::core::MaxEEFStep(req.max_step),
+              moveit::core::JumpThreshold(req.jump_threshold), constraint_fn, kinematics::KinematicsQueryOptions(),
+              start_state.getGlobalLinkTransform(link_model).inverse() * frame_pose);
+          moveit::core::robotStateToRobotStateMsg(start_state, res.start_state);
 
           robot_trajectory::RobotTrajectory rt(context_->planning_scene_monitor_->getRobotModel(), req->group_name);
           for (const moveit::core::RobotStatePtr& traj_state : traj)

--- a/moveit_ros/planning_interface/test/move_group_interface_cpp_test.cpp
+++ b/moveit_ros/planning_interface/test/move_group_interface_cpp_test.cpp
@@ -348,6 +348,18 @@ TEST_F(MoveGroupTestFixture, JointSpaceGoalTest)
   testJointPositions(plan_joint_positions);
 }
 
+TEST_F(MoveGroupTestFixture, CartesianGoalTest)
+{
+  move_group_->setPoseReferenceFrame("world");
+  move_group_->setEndEffectorLink("panda_hand");
+  geometry_msgs::Pose pose;
+  pose.position.x = 0.417;
+  pose.position.y = 0.240;
+  pose.position.z = 0.532;
+  pose.orientation.w = 1.0;
+  EXPECT_TRUE(move_group_->setJointValueTarget(pose));
+}
+
 int main(int argc, char** argv)
 {
   ros::init(argc, argv, "move_group_interface_cpp_test");


### PR DESCRIPTION
### Description

 - Fixes #3279 
 - As https://github.com/moveit/moveit2/pull/3280, but with history correctly preserved. (Also includes a few commits in the same PRs, which #3280 missed)
 - N.B. does not include changes to `cartesian_path_service_capability`, as that has changed significantly since the Moveit1 PRs were made.
 - Please back-port to Humble and Jazzy when merged

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
