### PR TITLE
Add missing target dependencies to eigen_stl_containers

### DIFF
--- a/moveit_core/collision_detection/CMakeLists.txt
+++ b/moveit_core/collision_detection/CMakeLists.txt
@@ -18,6 +18,7 @@ generate_export_header(moveit_collision_detection)
 
 ament_target_dependencies(
   moveit_collision_detection
+  eigen_stl_containers
   pluginlib
   rclcpp
   rmw_implementation

--- a/moveit_core/distance_field/CMakeLists.txt
+++ b/moveit_core/distance_field/CMakeLists.txt
@@ -12,6 +12,7 @@ set_target_properties(moveit_distance_field
 ament_target_dependencies(
   moveit_distance_field
   Boost
+  eigen_stl_containers
   urdfdom
   urdfdom_headers
   visualization_msgs

--- a/moveit_core/robot_model/CMakeLists.txt
+++ b/moveit_core/robot_model/CMakeLists.txt
@@ -33,6 +33,7 @@ ament_target_dependencies(
   angles
   moveit_msgs
   Eigen3
+  eigen_stl_containers
   geometric_shapes
   urdf
   urdfdom_headers

--- a/moveit_core/robot_state/CMakeLists.txt
+++ b/moveit_core/robot_state/CMakeLists.txt
@@ -7,8 +7,14 @@ target_include_directories(
          $<INSTALL_INTERFACE:include/moveit_core>)
 set_target_properties(moveit_robot_state PROPERTIES VERSION
                                                     ${${PROJECT_NAME}_VERSION})
-ament_target_dependencies(moveit_robot_state urdf tf2_geometry_msgs
-                          geometric_shapes urdfdom_headers Boost)
+ament_target_dependencies(
+  moveit_robot_state
+  eigen_stl_containers
+  urdf
+  tf2_geometry_msgs
+  geometric_shapes
+  urdfdom_headers
+  Boost)
 target_link_libraries(moveit_robot_state moveit_robot_model
                       moveit_kinematics_base moveit_transforms)
 


### PR DESCRIPTION
### Description

I was doing a "build on potato computer" build of MoveIt 2 with `-j 4` and `--executor sequential`, and found myself with some errors related to missing `eigen_stl_containers` headers.

Turns out there has been a missing target dependency in these targets that use the library? Not sure how others haven't run into this, or whether some upstream dependency recently removed this transitively?

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
