### PR TITLE
Fix docstring for Servo smoothHalt function

### DIFF
--- a/moveit_ros/moveit_servo/include/moveit_servo/servo.hpp
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo.hpp
@@ -113,6 +113,7 @@ public:
 
   /**
    * \brief Returns the most recent servo parameters.
+   * @return The servo parameters.
    */
   servo::Params& getParams();
 
@@ -126,8 +127,9 @@ public:
 
   /**
    * \brief Smoothly halt at a commanded state when command goes stale.
-   * @param halt_state The desired stop state.
-   * @return The next state stepping towards the required halting state.
+   * @param halt_state The desired halting state.
+   * @return A pair where the first element is a Boolean indicating whether the robot has stopped, and the second is a
+   * state stepping towards the desired halting state.
    */
   std::pair<bool, KinematicState> smoothHalt(const KinematicState& halt_state);
 


### PR DESCRIPTION
### Description

I was debugging something related to https://github.com/moveit/moveit2/pull/3251 and noticed that the docstring for `Servo::smoothHalt()` was slightly out of date in explaining its return type.

Super small change.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [x] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [x] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [x] Include a screenshot if changing a GUI
- [x] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
