### PR TITLE
Fix Ros2ControlManager chained controller logic

### DIFF
--- a/moveit_plugins/moveit_ros_control_interface/src/controller_manager_plugin.cpp
+++ b/moveit_plugins/moveit_ros_control_interface/src/controller_manager_plugin.cpp
@@ -516,10 +516,12 @@ public:
       {
         auto ind = controller_name_map[chained_controller.name];
         dependency_map_[controller.name].push_back(chained_controller.name);
-        controller.required_command_interfaces = result->controller[ind].required_command_interfaces;
-        controller.claimed_interfaces = result->controller[ind].claimed_interfaces;
-        result->controller[ind].claimed_interfaces.clear();
-        result->controller[ind].required_command_interfaces.clear();
+        std::copy(result->controller[ind].required_command_interfaces.begin(),
+                  result->controller[ind].required_command_interfaces.end(),
+                  std::back_inserter(controller.required_command_interfaces));
+        std::copy(result->controller[ind].reference_interfaces.begin(),
+                  result->controller[ind].reference_interfaces.end(),
+                  std::back_inserter(controller.required_command_interfaces));
       }
     }
 


### PR DESCRIPTION
### Description

It looks like [this](https://github.com/moveit/moveit2/pull/785) PR might have broken the chained controller management logic. 
Previously, `claimed_interfaces` were being used to determine which joints each controller was associated with, but now `required_command_interfaces` is used. That seems reasonable, but it was not updated everywhere. Specifically, there is some logic to handle ros2_control's chained controllers that was not updated. This PR fixes that issue.
