### PR TITLE
[humble] Fix clang-tidy warnings in hybrid planning package

### DIFF
--- a/moveit_ros/hybrid_planning/global_planner/global_planner_component/src/global_planner_component.cpp
+++ b/moveit_ros/hybrid_planning/global_planner/global_planner_component/src/global_planner_component.cpp
@@ -109,7 +109,7 @@ bool GlobalPlannerComponent::initializeGlobalPlanner()
         return rclcpp_action::CancelResponse::ACCEPT;
       },
       // Execution callback
-      [this](std::shared_ptr<rclcpp_action::ServerGoalHandle<moveit_msgs::action::GlobalPlanner>> goal_handle) {
+      [this](const std::shared_ptr<rclcpp_action::ServerGoalHandle<moveit_msgs::action::GlobalPlanner>>& goal_handle) {
         // this needs to return quickly to avoid blocking the executor, so spin up a new thread
         if (long_callback_thread_.joinable())
         {

--- a/moveit_ros/hybrid_planning/hybrid_planning_manager/hybrid_planning_manager_component/src/hybrid_planning_manager.cpp
+++ b/moveit_ros/hybrid_planning/hybrid_planning_manager/hybrid_planning_manager_component/src/hybrid_planning_manager.cpp
@@ -161,7 +161,7 @@ bool HybridPlanningManager::initialize()
         return rclcpp_action::CancelResponse::ACCEPT;
       },
       // Execution callback
-      [this](std::shared_ptr<rclcpp_action::ServerGoalHandle<moveit_msgs::action::HybridPlanner>> goal_handle) {
+      [this](const std::shared_ptr<rclcpp_action::ServerGoalHandle<moveit_msgs::action::HybridPlanner>>& goal_handle) {
         // this needs to return quickly to avoid blocking the executor, so spin up a new thread
         if (long_callback_thread_.joinable())
         {


### PR DESCRIPTION
### Description

Based on https://github.com/moveit/moveit2/actions/runs/13114230759/job/36584600940, it seems like clang-tidy is not happy. Why it wasn't before is confusing, but 🤷🏻 

Weirdly enough, most of these changes were backported in https://github.com/moveit/moveit2/pull/1704, but seems these 2 specific lines were not part of that PR by accident...

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
