### PR TITLE
Add allowed_start_tolerance_joints parameter (Port moveit#3287)

### DIFF
--- a/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.hpp
+++ b/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.hpp
@@ -293,7 +293,8 @@ private:
   void loadControllerParams();
 
   double getJointAllowedStartTolerance(std::string const& joint_name) const;
-  void updateJointsAllowedStartTolerance();
+  void setJointAllowedStartTolerance(std::string const& joint_name, double joint_start_tolerance);
+  void initializeJointsAllowedStartTolerance();
 
   // Name of this class for logging
   const std::string name_ = "trajectory_execution_manager";

--- a/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.hpp
+++ b/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.hpp
@@ -292,6 +292,9 @@ private:
 
   void loadControllerParams();
 
+  double getJointAllowedStartTolerance(std::string const& jointName) const;
+  void updateJointsAllowedStartTolerance();
+
   // Name of this class for logging
   const std::string name_ = "trajectory_execution_manager";
 
@@ -340,6 +343,8 @@ private:
   std::map<std::string, double> controller_allowed_goal_duration_margin_;
 
   double allowed_start_tolerance_;  // joint tolerance for validate(): radians for revolute joints
+  // tolerance per joint, overrides global allowed_start_tolerance_.
+  std::map<std::string, double> joints_allowed_start_tolerance_;
   double execution_velocity_scaling_;
   bool wait_for_trajectory_completion_;
 

--- a/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.hpp
+++ b/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.hpp
@@ -292,9 +292,9 @@ private:
 
   void loadControllerParams();
 
-  double getJointAllowedStartTolerance(const std::string& joint_name) const;
-  void setJointAllowedStartTolerance(const std::string& joint_name, double joint_start_tolerance);
-  void initializeJointsAllowedStartTolerance();
+  double getAllowedStartToleranceJoint(const std::string& joint_name) const;
+  void setAllowedStartToleranceJoint(const std::string& joint_name, double joint_start_tolerance);
+  void initializeAllowedStartToleranceJoints();
 
   // Name of this class for logging
   const std::string name_ = "trajectory_execution_manager";
@@ -345,7 +345,7 @@ private:
 
   double allowed_start_tolerance_;  // joint tolerance for validate(): radians for revolute joints
   // tolerance per joint, overrides global allowed_start_tolerance_.
-  std::map<std::string, double> joints_allowed_start_tolerance_;
+  std::map<std::string, double> allowed_start_tolerance_joints_;
   double execution_velocity_scaling_;
   bool wait_for_trajectory_completion_;
 

--- a/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.hpp
+++ b/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.hpp
@@ -292,8 +292,8 @@ private:
 
   void loadControllerParams();
 
-  double getJointAllowedStartTolerance(std::string const& joint_name) const;
-  void setJointAllowedStartTolerance(std::string const& joint_name, double joint_start_tolerance);
+  double getJointAllowedStartTolerance(const std::string& joint_name) const;
+  void setJointAllowedStartTolerance(const std::string& joint_name, double joint_start_tolerance);
   void initializeJointsAllowedStartTolerance();
 
   // Name of this class for logging

--- a/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.hpp
+++ b/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.hpp
@@ -292,7 +292,7 @@ private:
 
   void loadControllerParams();
 
-  double getJointAllowedStartTolerance(std::string const& jointName) const;
+  double getJointAllowedStartTolerance(std::string const& joint_name) const;
   void updateJointsAllowedStartTolerance();
 
   // Name of this class for logging

--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -924,16 +924,22 @@ bool TrajectoryExecutionManager::validate(const TrajectoryExecutionContext& cont
   if (allowed_start_tolerance_ == 0 && joints_allowed_start_tolerance_.empty())  // skip validation on this magic number
     return true;
 
-  if (joints_allowed_start_tolerance_.empty()) {
+  if (joints_allowed_start_tolerance_.empty())
+  {
     RCLCPP_INFO_STREAM(logger_, "Validating trajectory with allowed_start_tolerance " << allowed_start_tolerance_);
-  } else {
+  }
+  else
+  {
     std::ostringstream ss;
-    for (const auto& [joint_name, joints_start_tolerance] : joints_allowed_start_tolerance_) {
-        if (ss.tellp() > 1) ss << ", "; // skip the comma at the end
-        ss << joint_name << ": " << joints_start_tolerance;
+    for (const auto& [joint_name, joints_start_tolerance] : joints_allowed_start_tolerance_)
+    {
+      if (ss.tellp() > 1)
+        ss << ", ";  // skip the comma at the end
+      ss << joint_name << ": " << joints_start_tolerance;
     }
-    RCLCPP_INFO_STREAM(logger_, "Validating trajectory with allowed_start_tolerance " << allowed_start_tolerance_<<
-                                " and joints_allowed_start_tolerance {" << ss.str() << "}");
+    RCLCPP_INFO_STREAM(logger_, "Validating trajectory with allowed_start_tolerance "
+                                    << allowed_start_tolerance_ << " and joints_allowed_start_tolerance {" << ss.str()
+                                    << "}");
   }
 
   moveit::core::RobotStatePtr current_state;
@@ -1855,19 +1861,20 @@ void TrajectoryExecutionManager::loadControllerParams()
   // }
 }
 
-double TrajectoryExecutionManager::getJointAllowedStartTolerance(std::string const& joint_name) const
+double TrajectoryExecutionManager::getJointAllowedStartTolerance(const std::string& joint_name) const
 {
   auto start_tolerance_it = joints_allowed_start_tolerance_.find(joint_name);
   return start_tolerance_it != joints_allowed_start_tolerance_.end() ? start_tolerance_it->second :
                                                                        allowed_start_tolerance_;
 }
 
-void TrajectoryExecutionManager::setJointAllowedStartTolerance(std::string const& parameter_name,
+void TrajectoryExecutionManager::setJointAllowedStartTolerance(const std::string& parameter_name,
                                                                double joint_start_tolerance)
 {
-  if (joint_start_tolerance < 0) {
-    RCLCPP_WARN(logger_, "%s has a negative value. "
-                         "The start tolerance value for that joint was not updated.", parameter_name.c_str());
+  if (joint_start_tolerance < 0)
+  {
+    RCLCPP_WARN(logger_, "%s has a negative value. The start tolerance value for that joint was not updated.",
+                parameter_name.c_str());
     return;
   }
 
@@ -1875,11 +1882,14 @@ void TrajectoryExecutionManager::setJointAllowedStartTolerance(std::string const
   std::string joint_name = parameter_name;
   const std::string parameter_prefix = "trajectory_execution.joints_allowed_start_tolerance.";
   if (parameter_name.find(parameter_prefix) == 0)
-    joint_name = joint_name.substr(parameter_prefix.length()); // remove prefix
+    joint_name = joint_name.substr(parameter_prefix.length());  // remove prefix
 
-  if (!robot_model_->hasJointModel(joint_name)) {
-    RCLCPP_WARN(logger_, "Joint '%s' was not found in the robot model. "
-                         "The start tolerance value for that joint was not updated.", joint_name.c_str());
+  if (!robot_model_->hasJointModel(joint_name))
+  {
+    RCLCPP_WARN(logger_,
+                "Joint '%s' was not found in the robot model. "
+                "The start tolerance value for that joint was not updated.",
+                joint_name.c_str());
     return;
   }
 
@@ -1892,16 +1902,21 @@ void TrajectoryExecutionManager::initializeJointsAllowedStartTolerance()
 
   // retrieve all parameters under "trajectory_execution.joints_allowed_start_tolerance"
   // that correspond to existing joints in the robot model
-  for (const auto& joint_name : robot_model_->getJointModelNames()) {
+  for (const auto& joint_name : robot_model_->getJointModelNames())
+  {
     double start_joint_tolerance;
     const std::string parameter_name = "trajectory_execution.joints_allowed_start_tolerance." + joint_name;
-    if (node_->get_parameter(parameter_name, start_joint_tolerance)) {
-      if (start_joint_tolerance < 0) {
-        RCLCPP_WARN(logger_, "%s has a negative value. The start tolerance value for that joint "
-                             "will default to allowed_start_tolerance.", parameter_name.c_str());
+    if (node_->get_parameter(parameter_name, start_joint_tolerance))
+    {
+      if (start_joint_tolerance < 0)
+      {
+        RCLCPP_WARN(logger_,
+                    "%s has a negative value. The start tolerance value for that joint "
+                    "will default to allowed_start_tolerance.",
+                    parameter_name.c_str());
         continue;
       }
-      joints_allowed_start_tolerance_.insert({joint_name, start_joint_tolerance});
+      joints_allowed_start_tolerance_.insert({ joint_name, start_joint_tolerance });
     }
   }
 }

--- a/moveit_ros/planning/trajectory_execution_manager/test/test_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/test/test_execution_manager.cpp
@@ -74,7 +74,7 @@ public:
     traj2.multi_dof_joint_trajectory.points[0].transforms.resize(1);
     traj2.multi_dof_joint_trajectory.points[1].transforms.resize(1);
 
-    ros::param::del("~/trajectory_execution/joints_allowed_start_tolerance");
+    ros::param::del("~/trajectory_execution/allowed_start_tolerance_joints");
   }
 
 protected:
@@ -131,7 +131,7 @@ TEST_F(MoveItCppTest, AcceptAllowedJointStartTolerance)
   traj.joint_trajectory.points[0].positions[0] = 0.3;
 
   trajectory_execution_manager_ptr->setAllowedStartTolerance(0.01);
-  ros::param::set("~/trajectory_execution/joints_allowed_start_tolerance/panda_joint1", 0.5);
+  ros::param::set("~/trajectory_execution/allowed_start_tolerance_joints/panda_joint1", 0.5);
   ASSERT_TRUE(trajectory_execution_manager_ptr->push(traj));
   auto last_execution_status = trajectory_execution_manager_ptr->executeAndWait();
   ASSERT_EQ(last_execution_status, moveit_controller_manager::ExecutionStatus::SUCCEEDED);
@@ -152,7 +152,7 @@ TEST_F(MoveItCppTest, DoNotValidateJointStartToleranceZero)
   last_execution_status = trajectory_execution_manager_ptr->executeAndWait();
   ASSERT_EQ(last_execution_status, moveit_controller_manager::ExecutionStatus::ABORTED);
 
-  ros::param::set("~/trajectory_execution/joints_allowed_start_tolerance/panda_joint1", 0);
+  ros::param::set("~/trajectory_execution/allowed_start_tolerance_joints/panda_joint1", 0);
   ASSERT_TRUE(trajectory_execution_manager_ptr->push(traj));
   last_execution_status = trajectory_execution_manager_ptr->executeAndWait();
   ASSERT_EQ(last_execution_status, moveit_controller_manager::ExecutionStatus::SUCCEEDED);

--- a/moveit_ros/planning/trajectory_execution_manager/test/test_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/test/test_execution_manager.cpp
@@ -60,15 +60,21 @@ public:
     trajectory_execution_manager_ptr = moveit_cpp_ptr->getTrajectoryExecutionManagerNonConst();
 
     traj1.joint_trajectory.joint_names.push_back("panda_joint1");
-    traj1.joint_trajectory.points.resize(1);
+    traj1.joint_trajectory.points.resize(2);
     traj1.joint_trajectory.points[0].positions.push_back(0.0);
+    traj1.joint_trajectory.points[1].positions.push_back(0.5);
+    traj1.joint_trajectory.points[1].time_from_start.fromSec(0.5);
 
     traj2 = traj1;
     traj2.joint_trajectory.joint_names.push_back("panda_joint2");
     traj2.joint_trajectory.points[0].positions.push_back(1.0);
+    traj2.joint_trajectory.points[1].positions.push_back(1.5);
     traj2.multi_dof_joint_trajectory.joint_names.push_back("panda_joint3");
-    traj2.multi_dof_joint_trajectory.points.resize(1);
+    traj2.multi_dof_joint_trajectory.points.resize(2);
     traj2.multi_dof_joint_trajectory.points[0].transforms.resize(1);
+    traj2.multi_dof_joint_trajectory.points[1].transforms.resize(1);
+
+    ros::param::del("~/trajectory_execution/joints_allowed_start_tolerance");
   }
 
 protected:
@@ -105,6 +111,50 @@ TEST_F(MoveItCppTest, PushExecuteAndWaitTest)
   traj1.multi_dof_joint_trajectory = traj2.multi_dof_joint_trajectory;
   ASSERT_TRUE(trajectory_execution_manager_ptr->push(traj1));
   auto last_execution_status = trajectory_execution_manager_ptr->executeAndWait();
+  ASSERT_EQ(last_execution_status, moveit_controller_manager::ExecutionStatus::SUCCEEDED);
+}
+
+TEST_F(MoveItCppTest, RejectTooFarFromStart)
+{
+  moveit_msgs::RobotTrajectory traj = traj1;
+  traj.joint_trajectory.points[0].positions[0] = 0.3;
+
+  trajectory_execution_manager_ptr->setAllowedStartTolerance(0.01);
+  ASSERT_TRUE(trajectory_execution_manager_ptr->push(traj));
+  auto last_execution_status = trajectory_execution_manager_ptr->executeAndWait();
+  ASSERT_EQ(last_execution_status, moveit_controller_manager::ExecutionStatus::ABORTED);
+}
+
+TEST_F(MoveItCppTest, AcceptAllowedJointStartTolerance)
+{
+  moveit_msgs::RobotTrajectory traj = traj1;
+  traj.joint_trajectory.points[0].positions[0] = 0.3;
+
+  trajectory_execution_manager_ptr->setAllowedStartTolerance(0.01);
+  ros::param::set("~/trajectory_execution/joints_allowed_start_tolerance/panda_joint1", 0.5);
+  ASSERT_TRUE(trajectory_execution_manager_ptr->push(traj));
+  auto last_execution_status = trajectory_execution_manager_ptr->executeAndWait();
+  ASSERT_EQ(last_execution_status, moveit_controller_manager::ExecutionStatus::SUCCEEDED);
+}
+
+TEST_F(MoveItCppTest, DoNotValidateJointStartToleranceZero)
+{
+  moveit_msgs::RobotTrajectory traj = traj1;
+  traj.joint_trajectory.points[0].positions[0] = 0.3;
+
+  trajectory_execution_manager_ptr->setAllowedStartTolerance(0);
+  ASSERT_TRUE(trajectory_execution_manager_ptr->push(traj));
+  auto last_execution_status = trajectory_execution_manager_ptr->executeAndWait();
+  ASSERT_EQ(last_execution_status, moveit_controller_manager::ExecutionStatus::SUCCEEDED);
+
+  trajectory_execution_manager_ptr->setAllowedStartTolerance(0.1);
+  ASSERT_TRUE(trajectory_execution_manager_ptr->push(traj));
+  last_execution_status = trajectory_execution_manager_ptr->executeAndWait();
+  ASSERT_EQ(last_execution_status, moveit_controller_manager::ExecutionStatus::ABORTED);
+
+  ros::param::set("~/trajectory_execution/joints_allowed_start_tolerance/panda_joint1", 0);
+  ASSERT_TRUE(trajectory_execution_manager_ptr->push(traj));
+  last_execution_status = trajectory_execution_manager_ptr->executeAndWait();
   ASSERT_EQ(last_execution_status, moveit_controller_manager::ExecutionStatus::SUCCEEDED);
 }
 


### PR DESCRIPTION
### Description

Allow to specify a per joint allowed start tolerance for the TrajectoryExecutionManager. Port from https://github.com/moveit/moveit/pull/3287 with some changes to be able to dynamically update its values at runtime.

### Example of usage
In `moveit_controllers.yaml`:
```yaml
trajectory_execution:
  allowed_execution_duration_scaling: 1.2
  allowed_goal_duration_margin: 0.5
  allowed_start_tolerance: 0.01
  allowed_start_tolerance_joints: {panda_joint3: 0.02, panda_joint5: 0.03, panda_finger_joint1: 0.005}

```
Joints that are not declared in `allowed_start_tolerance_joints` will use `allowed_start_tolerance` as the default.

### Some remarks
- ~~I would personally have named this parameter "allowed_start_tolerance_joints" to be next to "allowed_start_tolerance" when sorted alphabetically. However, to maintain continuity with the original PR, I kept it as is.~~
- I left the tests as they are because `test_execution_manager.cpp` is [not used at the moment](https://github.com/moveit/moveit2/blob/fbdd8c51cdeb9858e5c77da427694ef0f89b6246/moveit_ros/planning/trajectory_execution_manager/CMakeLists.txt#L28C1-L42C8), right?
- Why [skip negative tolerances](https://github.com/moveit/moveit/pull/3287/commits/0d58f8d4e268f25ec665503a0d818272e46ff649)? I think, rather than defaulting to `allowed_start_tolerance`, it would be more intuitive to use the absolute value in that case.


### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
