### PR TITLE
Respect robot alpha value in trail trajectory visual

### DIFF
--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
@@ -271,6 +271,7 @@ void TrajectoryVisualization::changedShowTrail()
     if (enable_robot_color_property_->getBool())
       setRobotColor(&(r->getRobot()), robot_color_property_->getColor());
     r->setVisible(display_->isEnabled() && (!animating_path_ || waypoint_i <= current_state_));
+    r->updateAttachedObjectColors(default_attached_object_color_);
     trajectory_trail_[i] = std::move(r);
   }
 }
@@ -543,6 +544,7 @@ void TrajectoryVisualization::update(double wall_dt, double sim_dt)
   display_path_robot_->setVisible(display_->isEnabled() && displaying_trajectory_message_ &&
                                   (animating_path_ || trail_display_property_->getBool() ||
                                    (trajectory_slider_panel_ && trajectory_slider_panel_->isVisible())));
+  display_path_robot_->updateAttachedObjectColors(default_attached_object_color_);
 }
 
 void TrajectoryVisualization::incomingDisplayTrajectory(const moveit_msgs::msg::DisplayTrajectory::ConstSharedPtr& msg)


### PR DESCRIPTION
### Description

The motion planning plugin in RViz does not respect the alpha values for attached bodies when visualizing the trail of the planned path. The alpha values of the trail are only updated if the attached body color is changed at a later point. 

Updating the attached body color upon creation of the trail fixes this problem. The same thing applies to drawing the robot along the planned path which is handeled in the update function.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
