### PR TITLE
feat: add remapping argument to MoveItPy initialization

### DIFF
--- a/moveit_py/src/moveit/moveit_ros/moveit_cpp/moveit_cpp.cpp
+++ b/moveit_py/src/moveit/moveit_ros/moveit_cpp/moveit_cpp.cpp
@@ -64,7 +64,8 @@ void initMoveitPy(py::module& m)
 
       .def(py::init([](const std::string& node_name, const std::string& name_space,
                        const std::vector<std::string>& launch_params_filepaths, const py::object& config_dict,
-                       bool provide_planning_service, const std::optional<std::map<std::string, std::string>>& remappings) {
+                       bool provide_planning_service,
+                       const std::optional<std::map<std::string, std::string>>& remappings) {
              // This section is used to load the appropriate node parameters before spinning a moveit_cpp instance
              // Priority is given to parameters supplied directly via a config_dict, followed by launch parameters
              // and finally no supplied parameters.
@@ -89,10 +90,10 @@ void initMoveitPy(py::module& m)
 
              if (remappings.has_value())
              {
-               for (const auto &[key, value]: *remappings)
+               for (const auto& [key, value] : *remappings)
                {
-                  launch_arguments.push_back("--remap");
-                  launch_arguments.push_back(key + ":=" + value);
+                 launch_arguments.push_back("--remap");
+                 launch_arguments.push_back(key + ":=" + value);
                }
              }
 

--- a/moveit_py/src/moveit/moveit_ros/moveit_cpp/moveit_cpp.cpp
+++ b/moveit_py/src/moveit/moveit_ros/moveit_cpp/moveit_cpp.cpp
@@ -64,7 +64,7 @@ void initMoveitPy(py::module& m)
 
       .def(py::init([](const std::string& node_name, const std::string& name_space,
                        const std::vector<std::string>& launch_params_filepaths, const py::object& config_dict,
-                       bool provide_planning_service, const py::object& remappings) {
+                       bool provide_planning_service, const std::optional<std::map<std::string, std::string>>& remappings) {
              // This section is used to load the appropriate node parameters before spinning a moveit_cpp instance
              // Priority is given to parameters supplied directly via a config_dict, followed by launch parameters
              // and finally no supplied parameters.
@@ -87,18 +87,12 @@ void initMoveitPy(py::module& m)
                }
              }
 
-             if (py::isinstance<py::list>(remappings))
+             if (remappings.has_value())
              {
-               for (auto item : remappings)
+               for (const auto &[key, value]: *remappings)
                {
-                 py::tuple item_tuple = item.cast<py::tuple>();
-                 if (item_tuple.size() != 2)
-                 {
-                   throw std::runtime_error("Remapping must be a list of tuples with 2 elements");
-                 }
-                 launch_arguments.push_back("--remap");
-                 launch_arguments.push_back(item_tuple[0].cast<std::string>() +
-                                            ":=" + item_tuple[1].cast<std::string>());
+                  launch_arguments.push_back("--remap");
+                  launch_arguments.push_back(key + ":=" + value);
                }
              }
 

--- a/moveit_py/src/moveit/moveit_ros/moveit_cpp/moveit_cpp.cpp
+++ b/moveit_py/src/moveit/moveit_ros/moveit_cpp/moveit_cpp.cpp
@@ -91,13 +91,14 @@ void initMoveitPy(py::module& m)
              {
                for (auto item : remappings)
                {
-                py::tuple item_tuple = item.cast<py::tuple>();
+                 py::tuple item_tuple = item.cast<py::tuple>();
                  if (item_tuple.size() != 2)
                  {
-                  throw std::runtime_error("Remapping must be a list of tuples with 2 elements");
+                   throw std::runtime_error("Remapping must be a list of tuples with 2 elements");
                  }
                  launch_arguments.push_back("--remap");
-                 launch_arguments.push_back(item_tuple[0].cast<std::string>() + ":=" + item_tuple[1].cast<std::string>());
+                 launch_arguments.push_back(item_tuple[0].cast<std::string>() +
+                                            ":=" + item_tuple[1].cast<std::string>());
                }
              }
 
@@ -154,8 +155,7 @@ void initMoveitPy(py::module& m)
            py::arg("launch_params_filepaths") =
                utils.attr("get_launch_params_filepaths")().cast<std::vector<std::string>>(),
            py::arg("config_dict") = py::none(), py::arg("provide_planning_service") = true,
-           py::arg("remappings") = py::none(),
-           py::return_value_policy::take_ownership,
+           py::arg("remappings") = py::none(), py::return_value_policy::take_ownership,
            R"(
            Initialize moveit_cpp node and the planning scene service.
            )")

--- a/moveit_py/src/moveit/moveit_ros/moveit_cpp/moveit_cpp.cpp
+++ b/moveit_py/src/moveit/moveit_ros/moveit_cpp/moveit_cpp.cpp
@@ -92,8 +92,10 @@ void initMoveitPy(py::module& m)
              {
                for (const auto& [key, value] : *remappings)
                {
+                 std::string argument = key;
+                 argument.append(":=").append(value);
                  launch_arguments.push_back("--remap");
-                 launch_arguments.push_back(key + ":=" + value);
+                 launch_arguments.push_back(std::move(argument));
                }
              }
 


### PR DESCRIPTION
### Description
Previously, the topics started by MoveItPy could not be remapped.
To address this, I added an argument for remapping, allowing remapping to be handled within Python scripts.

Ideally, I wanted MoveItPy to support remapping via the remappings option specified in the launch file. However, due to the design philosophy of rclpy, this seems difficult. As a compromise, I have ensured that remapping can at least be performed via an argument.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
