### PR TITLE
SERVICE_CALL_TIMEOUT = 1 second is harsh 🥵

### DIFF
--- a/moveit_plugins/moveit_ros_control_interface/src/controller_manager_plugin.cpp
+++ b/moveit_plugins/moveit_ros_control_interface/src/controller_manager_plugin.cpp
@@ -57,7 +57,7 @@
 #include <moveit/utils/logger.hpp>
 
 static const rclcpp::Duration CONTROLLER_INFORMATION_VALIDITY_AGE = rclcpp::Duration::from_seconds(1.0);
-static const double SERVICE_CALL_TIMEOUT = 10.0;
+static const double SERVICE_CALL_TIMEOUT = 3.0;  // TODO: Create a ROS parameter allowing to customize this default timeout
 
 namespace moveit_ros_control_interface
 {

--- a/moveit_plugins/moveit_ros_control_interface/src/controller_manager_plugin.cpp
+++ b/moveit_plugins/moveit_ros_control_interface/src/controller_manager_plugin.cpp
@@ -57,7 +57,8 @@
 #include <moveit/utils/logger.hpp>
 
 static const rclcpp::Duration CONTROLLER_INFORMATION_VALIDITY_AGE = rclcpp::Duration::from_seconds(1.0);
-static const double SERVICE_CALL_TIMEOUT = 3.0;  // TODO: Create a ROS parameter allowing to customize this default timeout
+// TODO: Create a ROS parameter allowing to customize this default timeout
+static constexpr double SERVICE_CALL_TIMEOUT = 3.0;
 
 namespace moveit_ros_control_interface
 {

--- a/moveit_plugins/moveit_ros_control_interface/src/controller_manager_plugin.cpp
+++ b/moveit_plugins/moveit_ros_control_interface/src/controller_manager_plugin.cpp
@@ -57,7 +57,7 @@
 #include <moveit/utils/logger.hpp>
 
 static const rclcpp::Duration CONTROLLER_INFORMATION_VALIDITY_AGE = rclcpp::Duration::from_seconds(1.0);
-static const double SERVICE_CALL_TIMEOUT = 1.0;
+static const double SERVICE_CALL_TIMEOUT = 10.0;
 
 namespace moveit_ros_control_interface
 {


### PR DESCRIPTION
### Description

For some reason, maybe over loaded network or CPU, listing the ros2 controllers of my robot is quite slow, a bit more than 1.0 second in average:

```bash
$ time ros2 control list_controllers
arm_controller          joint_trajectory_controller/JointTrajectoryController         active  
[...]
real    0m1.349s
user    0m0.658s
sys     0m0.144s
```
In consequence, the MoveIt ROS interface fails at executing the trajectory while the controller is actually ready to work.

I propose to increase the 1.0 second timeout to 10.0 seconds because 1.0 is really harsh, especially on slow computers.

Maybe a lower timeout would be more acceptable, as you prefer.

