### PR TITLE
Add `stomp` target link to `moveit_planners_stomp` tests

### DIFF
--- a/moveit_planners/stomp/test/CMakeLists.txt
+++ b/moveit_planners/stomp/test/CMakeLists.txt
@@ -1,8 +1,8 @@
 find_package(ament_cmake_gtest REQUIRED)
 ament_add_gtest(test_noise_generator test_noise_generator.cpp)
 ament_target_dependencies(test_noise_generator tf2_eigen)
-target_link_libraries(test_noise_generator rsl::rsl)
+target_link_libraries(test_noise_generator stomp::stomp rsl::rsl)
 
 ament_add_gtest(test_cost_functions test_cost_functions.cpp)
 ament_target_dependencies(test_cost_functions moveit_core)
-target_link_libraries(test_cost_functions rsl::rsl)
+target_link_libraries(test_cost_functions stomp::stomp rsl::rsl)


### PR DESCRIPTION
### Description

Fix missing linkage in `moveit_planners_stomp` tests via `target_link_libraries` declaration as suggested in https://github.com/moveit/moveit2/issues/3436#issuecomment-2801840569

Fixes https://github.com/moveit/moveit2/issues/3436

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
