### PR TITLE
Fix one more buildtool_depend tag in moveit_setup_app_plugins

### DIFF
--- a/moveit_setup_assistant/moveit_setup_app_plugins/package.xml
+++ b/moveit_setup_assistant/moveit_setup_app_plugins/package.xml
@@ -8,7 +8,7 @@
   <license>BSD-3-Clause</license>
   <author email="davidvlu@gmail.com">David V. Lu!!</author>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
   <depend>ament_index_cpp</depend>
   <depend>moveit_configs_utils</depend>


### PR DESCRIPTION
### Description

Shoot, missed one in #3441. Buildfarm still unhappy.

As I've said before, attention to detail is not my strength.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
