### PR TITLE
Fix seg fault with attached objects during motion execution

### DIFF
--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -1217,16 +1217,24 @@ void RobotState::getAttachedBodies(std::vector<const AttachedBody*>& attached_bo
   attached_bodies.clear();
   attached_bodies.reserve(attached_body_map_.size());
   for (const auto& it : attached_body_map_)
+  {
     if (it.second)
+    {
       attached_bodies.push_back(it.second.get());
+    }
+  }
 }
 
 void RobotState::getAttachedBodies(std::map<std::string, const AttachedBody*>& attached_bodies) const
 {
   attached_bodies.clear();
   for (const auto& it : attached_body_map_)
+  {
     if (it.second && !it.first.empty())
+    {
       attached_bodies[it.first] = it.second.get();
+    }
+  }
 }
 
 void RobotState::getAttachedBodies(std::vector<const AttachedBody*>& attached_bodies, const JointModelGroup* group) const

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -1217,14 +1217,16 @@ void RobotState::getAttachedBodies(std::vector<const AttachedBody*>& attached_bo
   attached_bodies.clear();
   attached_bodies.reserve(attached_body_map_.size());
   for (const auto& it : attached_body_map_)
-    attached_bodies.push_back(it.second.get());
+    if (it.second)
+      attached_bodies.push_back(it.second.get());
 }
 
 void RobotState::getAttachedBodies(std::map<std::string, const AttachedBody*>& attached_bodies) const
 {
   attached_bodies.clear();
   for (const auto& it : attached_body_map_)
-    attached_bodies[it.first] = it.second.get();
+    if (it.second && !it.first.empty())
+      attached_bodies[it.first] = it.second.get();
 }
 
 void RobotState::getAttachedBodies(std::vector<const AttachedBody*>& attached_bodies, const JointModelGroup* group) const

--- a/moveit_ros/planning/plan_execution/src/plan_execution.cpp
+++ b/moveit_ros/planning/plan_execution/src/plan_execution.cpp
@@ -484,7 +484,7 @@ moveit_msgs::msg::MoveItErrorCodes plan_execution::PlanExecution::executeAndMoni
         }
       }
     }
-    if (trajectory_attached_objects.size() > 0)
+    if (!trajectory_attached_objects.empty())
       plan_components_attached_objects_.push_back(trajectory_attached_objects);
   }
 

--- a/moveit_ros/planning/plan_execution/src/plan_execution.cpp
+++ b/moveit_ros/planning/plan_execution/src/plan_execution.cpp
@@ -283,15 +283,15 @@ bool plan_execution::PlanExecution::isRemainingPathValid(const ExecutableMotionP
     collision_detection::CollisionRequest req;
     req.group_name = t.getGroupName();
     req.pad_environment_collisions = false;
-    moveit::core::RobotState state = plan.planning_scene->getCurrentState();
+    moveit::core::RobotState start_state = plan.planning_scene->getCurrentState();
     std::map<std::string, const moveit::core::AttachedBody*> current_attached_objects, waypoint_attached_objects;
-    state.getAttachedBodies(current_attached_objects);
+    start_state.getAttachedBodies(current_attached_objects);
     if (plan_components_attached_objects_.size() > static_cast<size_t>(path_segment.first))
       waypoint_attached_objects = plan_components_attached_objects_[path_segment.first];
     for (std::size_t i = std::max(path_segment.second - 1, 0); i < wpc; ++i)
     {
       collision_detection::CollisionResult res;
-      state = t.getWayPoint(i);
+      moveit::core::RobotState state = t.getWayPoint(i);
       if (plan_components_attached_objects_[path_segment.first].empty())
       {
         state.getAttachedBodies(waypoint_attached_objects);

--- a/moveit_ros/planning/plan_execution/src/plan_execution.cpp
+++ b/moveit_ros/planning/plan_execution/src/plan_execution.cpp
@@ -286,7 +286,8 @@ bool plan_execution::PlanExecution::isRemainingPathValid(const ExecutableMotionP
     moveit::core::RobotState state = plan.planning_scene->getCurrentState();
     std::map<std::string, const moveit::core::AttachedBody*> current_attached_objects, waypoint_attached_objects;
     state.getAttachedBodies(current_attached_objects);
-    waypoint_attached_objects = plan_components_attached_objects_[path_segment.first];
+    if (plan_components_attached_objects_.size() > path_segment.first)
+      waypoint_attached_objects = plan_components_attached_objects_[path_segment.first];
     for (std::size_t i = std::max(path_segment.second - 1, 0); i < wpc; ++i)
     {
       collision_detection::CollisionResult res;
@@ -469,7 +470,7 @@ moveit_msgs::msg::MoveItErrorCodes plan_execution::PlanExecution::executeAndMoni
   {
     const auto& trajectory = component.trajectory;
     std::map<std::string, const moveit::core::AttachedBody*> trajectory_attached_objects;
-    if (trajectory)
+    if (trajectory && trajectory->getWayPointCount() > 0)
     {
       std::map<std::string, const moveit::core::AttachedBody*> attached_objects;
       trajectory->getWayPoint(0).getAttachedBodies(trajectory_attached_objects);
@@ -483,7 +484,8 @@ moveit_msgs::msg::MoveItErrorCodes plan_execution::PlanExecution::executeAndMoni
         }
       }
     }
-    plan_components_attached_objects_.push_back(trajectory_attached_objects);
+    if (trajectory_attached_objects.size() > 0)
+      plan_components_attached_objects_.push_back(trajectory_attached_objects);
   }
 
   while (rclcpp::ok() && !execution_complete_ && !path_became_invalid_)

--- a/moveit_ros/planning/plan_execution/src/plan_execution.cpp
+++ b/moveit_ros/planning/plan_execution/src/plan_execution.cpp
@@ -286,7 +286,7 @@ bool plan_execution::PlanExecution::isRemainingPathValid(const ExecutableMotionP
     moveit::core::RobotState state = plan.planning_scene->getCurrentState();
     std::map<std::string, const moveit::core::AttachedBody*> current_attached_objects, waypoint_attached_objects;
     state.getAttachedBodies(current_attached_objects);
-    if (plan_components_attached_objects_.size() > path_segment.first)
+    if (plan_components_attached_objects_.size() > static_cast<size_t>(path_segment.first))
       waypoint_attached_objects = plan_components_attached_objects_[path_segment.first];
     for (std::size_t i = std::max(path_segment.second - 1, 0); i < wpc; ++i)
     {

--- a/moveit_ros/planning/plan_execution/src/plan_execution.cpp
+++ b/moveit_ros/planning/plan_execution/src/plan_execution.cpp
@@ -288,13 +288,15 @@ bool plan_execution::PlanExecution::isRemainingPathValid(const ExecutableMotionP
     start_state.getAttachedBodies(current_attached_objects);
     if (plan_components_attached_objects_.size() > static_cast<size_t>(path_segment.first))
       waypoint_attached_objects = plan_components_attached_objects_[path_segment.first];
+    moveit::core::RobotState waypoint_state(start_state);
     for (std::size_t i = std::max(path_segment.second - 1, 0); i < wpc; ++i)
     {
       collision_detection::CollisionResult res;
-      moveit::core::RobotState state = t.getWayPoint(i);
+      waypoint_attached_objects.clear();  // clear out the last waypoints attached objects
+      waypoint_state = t.getWayPoint(i);
       if (plan_components_attached_objects_[path_segment.first].empty())
       {
-        state.getAttachedBodies(waypoint_attached_objects);
+        waypoint_state.getAttachedBodies(waypoint_attached_objects);
       }
 
       // If sample state has attached objects that are not in the current state, remove them from the sample state
@@ -303,7 +305,7 @@ bool plan_execution::PlanExecution::isRemainingPathValid(const ExecutableMotionP
         if (current_attached_objects.find(name) == current_attached_objects.end())
         {
           RCLCPP_DEBUG(logger_, "Attached object '%s' is not in the current scene. Removing it.", name.c_str());
-          state.clearAttachedBody(name);
+          waypoint_state.clearAttachedBody(name);
         }
       }
 
@@ -313,35 +315,35 @@ bool plan_execution::PlanExecution::isRemainingPathValid(const ExecutableMotionP
         if (waypoint_attached_objects.find(name) == waypoint_attached_objects.end())
         {
           RCLCPP_DEBUG(logger_, "Attached object '%s' is not in the robot state. Adding it.", name.c_str());
-          state.attachBody(std::make_unique<moveit::core::AttachedBody>(*object));
+          waypoint_state.attachBody(std::make_unique<moveit::core::AttachedBody>(*object));
         }
       }
 
       if (acm)
       {
-        plan.planning_scene->checkCollision(req, res, state, *acm);
+        plan.planning_scene->checkCollision(req, res, waypoint_state, *acm);
       }
       else
       {
-        plan.planning_scene->checkCollision(req, res, state);
+        plan.planning_scene->checkCollision(req, res, waypoint_state);
       }
 
-      if (res.collision || !plan.planning_scene->isStateFeasible(state, false))
+      if (res.collision || !plan.planning_scene->isStateFeasible(waypoint_state, false))
       {
         RCLCPP_INFO(logger_, "Trajectory component '%s' is invalid for waypoint %ld out of %ld",
                     plan.plan_components[path_segment.first].description.c_str(), i, wpc);
 
         // call the same functions again, in verbose mode, to show what issues have been detected
-        plan.planning_scene->isStateFeasible(state, true);
+        plan.planning_scene->isStateFeasible(waypoint_state, true);
         req.verbose = true;
         res.clear();
         if (acm)
         {
-          plan.planning_scene->checkCollision(req, res, state, *acm);
+          plan.planning_scene->checkCollision(req, res, waypoint_state, *acm);
         }
         else
         {
-          plan.planning_scene->checkCollision(req, res, state);
+          plan.planning_scene->checkCollision(req, res, waypoint_state);
         }
         return false;
       }


### PR DESCRIPTION
### Description

#3327 introduced a bug where motion execution can segfault by attempting to indexing into arrays of zero length.
```
[move_group-5] [INFO moveit_task_constructor_visualization.execute_task_solution 1746211985.025712029]: Executing TaskSolution
[move_group-5] [INFO move_group.moveit.moveit.plugins.simple_controller_manager 1746211985.025804455]: Returned 1 controllers in list
[move_group-5] [INFO move_group.moveit.moveit.ros.trajectory_execution_manager 1746211985.025904844]: Validating trajectory with allowed_start_tolerance 0.01
[move_group-5] [INFO move_group.moveit.moveit.ros.trajectory_execution_manager 1746211985.026685553]: Starting trajectory execution ...
[move_group-5] Stack trace (most recent call last) in thread 3045:
[move_group-5] #10   Object "", at 0xffffffffffffffff, in 
[move_group-5] #9    Object "/usr/lib/x86_64-linux-gnu/libc.so.6", at 0x78936d34fc3b, in 
[move_group-5] terminate called after throwing an instance of 'std::length_error'
[move_group-5]   what():  basic_string::_M_create
[move_group-5] #8    Object "/usr/lib/x86_64-linux-gnu/libc.so.6", at 0x78936d2c2aa3, in 
[move_group-5] Stack trace (most recent call last) in thread 3046:
[move_group-5] #7    Object "/usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.33", at 0x78936d552db3, in 
[move_group-5] #6    Object "/root/underlay_ws/install/moveit_task_constructor_capabilities/lib/libmoveit_task_constructor_capabilities.so", at 0x78934c6ff157, in std::__future_base::_Async_state_impl<std::thread::_Invoker<std::tuple<void (move_group::ExecuteTaskSolutionCapability::*)(std::shared_ptr<rclcpp_action::ServerGoalHandle<moveit_task_constructor_msgs::action::ExecuteTaskSolution> > const&), move_group::ExecuteTaskSolutionCapability*, std::shared_ptr<rclcpp_action::ServerGoalHandle<moveit_task_constructor_msgs::action::ExecuteTaskSolution> > > >, void>::_M_run()
[move_group-5] #5    Object "/usr/lib/x86_64-linux-gnu/libc.so.6", at 0x78936d2c7ed2, in 
[move_group-5] #4    Object "/opt/ros/jazzy/lib/libmoveit_planning_scene_monitor.so.2.12.3", at 0x78936dac97f1, in std::__future_base::_State_baseV2::_M_do_set(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*)
[move_group-5] #3    Object "/root/underlay_ws/install/moveit_task_constructor_capabilities/lib/libmoveit_task_constructor_capabilities.so", at 0x78934c6fdd1f, in std::_Function_handler<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> (), std::__future_base::_Task_setter<std::unique_ptr<std::__future_base::_Result<void>, std::__future_base::_Result_base::_Deleter>, std::thread::_Invoker<std::tuple<void (move_group::ExecuteTaskSolutionCapability::*)(std::shared_ptr<rclcpp_action::ServerGoalHandle<moveit_task_constructor_msgs::action::ExecuteTaskSolution> > const&), move_group::ExecuteTaskSolutionCapability*, std::shared_ptr<rclcpp_action::ServerGoalHandle<moveit_task_constructor_msgs::action::ExecuteTaskSolution> > > >, void> >::_M_invoke(std::_Any_data const&)
[move_group-5] #2    Object "/root/underlay_ws/install/moveit_task_constructor_capabilities/lib/libmoveit_task_constructor_capabilities.so", at 0x78934c6fd29e, in move_group::ExecuteTaskSolutionCapability::execCallback(std::shared_ptr<rclcpp_action::ServerGoalHandle<moveit_task_constructor_msgs::action::ExecuteTaskSolution> > const&)
[move_group-5] #1    Object "/opt/ros/jazzy/lib/libmoveit_plan_execution.so.2.12.3", at 0x78936d16703c, in plan_execution::PlanExecution::executeAndMonitor(plan_execution::ExecutableMotionPlan&, bool)
[move_group-5] #0    Object "/opt/ros/jazzy/lib/libmoveit_robot_state.so.2.12.3", at 0x78936d10674b, in moveit::core::RobotState::getAttachedBodies(std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, moveit::core::AttachedBody const*, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, moveit::core::AttachedBody const*> > >&) const
[move_group-5] Segmentation fault (Address not mapped to object [0xe8])
[move_group-5] #14   Object "", at 0xffffffffffffffff, in 
```

I assume this is because MTC sends execution requests where only the planing scene in modified, so trajectory lengths are zero. I also added some guards in robot_state to make sure we are not adding null objects to the `attached_bodies` list/map.
