### PR TITLE
[kilted] Update deprecated call to ament_target_dependencies

### DIFF
--- a/moveit_core/collision_detection/CMakeLists.txt
+++ b/moveit_core/collision_detection/CMakeLists.txt
@@ -16,8 +16,8 @@ target_include_directories(
 include(GenerateExportHeader)
 generate_export_header(moveit_collision_detection)
 
-ament_target_dependencies(
-  moveit_collision_detection
+target_link_libraries(moveit_collision_detection
+  PUBLIC
   eigen_stl_containers
   pluginlib
   rclcpp

--- a/moveit_core/collision_detection_bullet/CMakeLists.txt
+++ b/moveit_core/collision_detection_bullet/CMakeLists.txt
@@ -18,9 +18,9 @@ target_include_directories(
   PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
 set_target_properties(moveit_collision_detection_bullet
                       PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-ament_target_dependencies(moveit_collision_detection_bullet SYSTEM BULLET)
-ament_target_dependencies(
-  moveit_collision_detection_bullet
+target_link_libraries(moveit_collision_detection_bullet SYSTEM BULLET)
+target_link_libraries(moveit_collision_detection_bullet
+  PUBLIC
   rclcpp
   rmw_implementation
   urdf
@@ -35,9 +35,9 @@ add_library(collision_detector_bullet_plugin SHARED
             src/collision_detector_bullet_plugin_loader.cpp)
 set_target_properties(collision_detector_bullet_plugin
                       PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-ament_target_dependencies(collision_detector_bullet_plugin SYSTEM BULLET)
-ament_target_dependencies(
-  collision_detector_bullet_plugin
+target_link_libraries(collision_detector_bullet_plugin SYSTEM BULLET)
+target_link_libraries(collision_detector_bullet_plugin
+  PUBLIC
   rclcpp
   urdf
   visualization_msgs

--- a/moveit_core/collision_detection_fcl/CMakeLists.txt
+++ b/moveit_core/collision_detection_fcl/CMakeLists.txt
@@ -11,8 +11,8 @@ target_include_directories(
   PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
 set_target_properties(moveit_collision_detection_fcl
                       PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-ament_target_dependencies(
-  moveit_collision_detection_fcl
+target_link_libraries(moveit_collision_detection_fcl
+  PUBLIC
   rclcpp
   rmw_implementation
   urdf
@@ -26,8 +26,8 @@ add_library(collision_detector_fcl_plugin SHARED
             src/collision_detector_fcl_plugin_loader.cpp)
 set_target_properties(collision_detector_fcl_plugin
                       PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-ament_target_dependencies(collision_detector_fcl_plugin rclcpp urdf
-                          visualization_msgs pluginlib rmw_implementation)
+target_link_libraries(collision_detector_fcl_plugin PUBLIC
+                      rclcpp urdf visualization_msgs pluginlib rmw_implementation)
 target_link_libraries(
   collision_detector_fcl_plugin moveit_collision_detection_fcl
   moveit_planning_scene moveit_utils)

--- a/moveit_core/collision_distance_field/CMakeLists.txt
+++ b/moveit_core/collision_distance_field/CMakeLists.txt
@@ -15,8 +15,8 @@ target_include_directories(
 set_target_properties(moveit_collision_distance_field
                       PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 
-ament_target_dependencies(moveit_collision_distance_field urdf
-                          visualization_msgs tf2_eigen geometric_shapes octomap)
+target_link_libraries(moveit_collision_distance_field PUBLIC
+                      urdf visualization_msgs tf2_eigen geometric_shapes octomap)
 
 target_link_libraries(
   moveit_collision_distance_field moveit_planning_scene moveit_distance_field

--- a/moveit_core/constraint_samplers/CMakeLists.txt
+++ b/moveit_core/constraint_samplers/CMakeLists.txt
@@ -9,8 +9,8 @@ target_include_directories(
          $<INSTALL_INTERFACE:include/moveit_core>)
 set_target_properties(moveit_constraint_samplers
                       PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-ament_target_dependencies(moveit_constraint_samplers urdf urdfdom
-                          urdfdom_headers visualization_msgs)
+target_link_libraries(moveit_constraint_samplers PUBLIC
+                      urdf urdfdom urdfdom_headers visualization_msgs)
 target_link_libraries(
   moveit_constraint_samplers
   moveit_robot_trajectory

--- a/moveit_core/distance_field/CMakeLists.txt
+++ b/moveit_core/distance_field/CMakeLists.txt
@@ -9,8 +9,8 @@ target_include_directories(
 target_link_libraries(moveit_distance_field moveit_macros moveit_utils)
 set_target_properties(moveit_distance_field
                       PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-ament_target_dependencies(
-  moveit_distance_field
+target_link_libraries(moveit_distance_field
+  PUBLIC
   Boost
   eigen_stl_containers
   urdfdom

--- a/moveit_core/dynamics_solver/CMakeLists.txt
+++ b/moveit_core/dynamics_solver/CMakeLists.txt
@@ -6,8 +6,8 @@ target_include_directories(
 set_target_properties(moveit_dynamics_solver
                       PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 
-ament_target_dependencies(moveit_dynamics_solver urdf urdfdom_headers
-                          orocos_kdl visualization_msgs kdl_parser)
+target_link_libraries(moveit_dynamics_solver PUBLIC
+                      urdf urdfdom_headers orocos_kdl visualization_msgs kdl_parser)
 target_link_libraries(moveit_dynamics_solver moveit_robot_state moveit_utils)
 
 install(DIRECTORY include/ DESTINATION include/moveit_core)

--- a/moveit_core/exceptions/CMakeLists.txt
+++ b/moveit_core/exceptions/CMakeLists.txt
@@ -5,8 +5,8 @@ target_include_directories(
          $<INSTALL_INTERFACE:include/moveit_core>)
 set_target_properties(moveit_exceptions PROPERTIES VERSION
                                                    "${${PROJECT_NAME}_VERSION}")
-ament_target_dependencies(moveit_exceptions Boost rclcpp urdfdom
-                          urdfdom_headers)
+target_link_libraries(moveit_exceptions PUBLIC
+                      Boost rclcpp urdfdom urdfdom_headers)
 target_link_libraries(moveit_exceptions moveit_utils)
 
 install(DIRECTORY include/ DESTINATION include/moveit_core)

--- a/moveit_core/kinematic_constraints/CMakeLists.txt
+++ b/moveit_core/kinematic_constraints/CMakeLists.txt
@@ -16,8 +16,8 @@ target_include_directories(
 set_target_properties(moveit_kinematic_constraints
                       PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 
-ament_target_dependencies(
-  moveit_kinematic_constraints
+target_link_libraries(moveit_kinematic_constraints
+  PUBLIC
   urdf
   urdfdom
   urdfdom_headers

--- a/moveit_core/kinematics_base/CMakeLists.txt
+++ b/moveit_core/kinematics_base/CMakeLists.txt
@@ -12,8 +12,8 @@ target_include_directories(
 )# for this library
 
 # This line ensures that messages are built before the library is built
-ament_target_dependencies(
-  moveit_kinematics_base
+target_link_libraries(moveit_kinematics_base
+  PUBLIC
   rclcpp
   urdf
   urdfdom_headers

--- a/moveit_core/kinematics_metrics/CMakeLists.txt
+++ b/moveit_core/kinematics_metrics/CMakeLists.txt
@@ -6,8 +6,8 @@ target_include_directories(
 set_target_properties(moveit_kinematics_metrics
                       PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 
-ament_target_dependencies(moveit_kinematics_metrics urdf urdfdom_headers
-                          visualization_msgs)
+target_link_libraries(moveit_kinematics_metrics PUBLIC
+                      urdf urdfdom_headers visualization_msgs)
 
 target_link_libraries(moveit_kinematics_metrics moveit_robot_model
                       moveit_robot_state moveit_utils)

--- a/moveit_core/online_signal_smoothing/CMakeLists.txt
+++ b/moveit_core/online_signal_smoothing/CMakeLists.txt
@@ -10,7 +10,7 @@ include(GenerateExportHeader)
 generate_export_header(moveit_smoothing_base)
 set_target_properties(moveit_smoothing_base
                       PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-ament_target_dependencies(moveit_smoothing_base rclcpp tf2_eigen)
+target_link_libraries(moveit_smoothing_base PUBLIC rclcpp tf2_eigen)
 
 # Plugin implementations
 add_library(moveit_acceleration_filter SHARED src/acceleration_filter.cpp)
@@ -25,10 +25,10 @@ generate_parameter_library(moveit_acceleration_filter_parameters
 target_link_libraries(
   moveit_acceleration_filter moveit_acceleration_filter_parameters
   moveit_robot_state moveit_smoothing_base osqp::osqp)
-ament_target_dependencies(
-  moveit_acceleration_filter srdfdom # include dependency from
-                                     # moveit_robot_model
-  pluginlib)
+target_link_libraries(
+  moveit_acceleration_filter  # include dependency from
+  PUBLIC srdfdom pluginlib    # moveit_robot_model
+)
 
 add_library(moveit_butterworth_filter SHARED src/butterworth_filter.cpp)
 generate_export_header(moveit_butterworth_filter)
@@ -42,8 +42,8 @@ generate_parameter_library(moveit_butterworth_filter_parameters
 target_link_libraries(
   moveit_butterworth_filter moveit_butterworth_filter_parameters
   moveit_robot_model moveit_smoothing_base)
-ament_target_dependencies(
-  moveit_butterworth_filter
+target_link_libraries(
+  moveit_butterworth_filter PUBLIC
   srdfdom # include dependency from moveit_robot_model
   pluginlib)
 
@@ -58,8 +58,8 @@ generate_parameter_library(moveit_ruckig_filter_parameters
 target_link_libraries(
   moveit_ruckig_filter moveit_robot_state moveit_ruckig_filter_parameters
   moveit_smoothing_base ruckig::ruckig)
-ament_target_dependencies(
-  moveit_ruckig_filter srdfdom # include dependency from moveit_robot_model
+target_link_libraries(moveit_ruckig_filter PUBLIC
+  srdfdom # include dependency from moveit_robot_model
   pluginlib)
 
 # Installation

--- a/moveit_core/planning_interface/CMakeLists.txt
+++ b/moveit_core/planning_interface/CMakeLists.txt
@@ -6,8 +6,8 @@ target_include_directories(
          $<INSTALL_INTERFACE:include/moveit_core>)
 set_target_properties(moveit_planning_interface
                       PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-ament_target_dependencies(moveit_planning_interface moveit_msgs urdf urdfdom
-                          urdfdom_headers)
+target_link_libraries(moveit_planning_interface PUBLIC
+                      moveit_msgs urdf urdfdom urdfdom_headers)
 target_link_libraries(moveit_planning_interface moveit_robot_trajectory
                       moveit_robot_state moveit_planning_scene moveit_utils)
 

--- a/moveit_core/planning_scene/CMakeLists.txt
+++ b/moveit_core/planning_scene/CMakeLists.txt
@@ -10,8 +10,8 @@ target_include_directories(
 # TODO: Fix the versioning
 set_target_properties(moveit_planning_scene
                       PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-ament_target_dependencies(
-  moveit_planning_scene
+target_link_libraries(moveit_planning_scene
+  PUBLIC
   Boost
   rclcpp
   urdfdom

--- a/moveit_core/robot_model/CMakeLists.txt
+++ b/moveit_core/robot_model/CMakeLists.txt
@@ -28,8 +28,8 @@ target_include_directories(
     $<INSTALL_INTERFACE:include/moveit_core>)
 set_target_properties(moveit_robot_model
                       PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-ament_target_dependencies(
-  moveit_robot_model
+target_link_libraries(moveit_robot_model
+  PUBLIC
   angles
   moveit_msgs
   Eigen3

--- a/moveit_core/robot_state/CMakeLists.txt
+++ b/moveit_core/robot_state/CMakeLists.txt
@@ -7,8 +7,8 @@ target_include_directories(
          $<INSTALL_INTERFACE:include/moveit_core>)
 set_target_properties(moveit_robot_state PROPERTIES VERSION
                                                     ${${PROJECT_NAME}_VERSION})
-ament_target_dependencies(
-  moveit_robot_state
+target_link_libraries(moveit_robot_state
+  PUBLIC
   eigen_stl_containers
   urdf
   tf2_geometry_msgs

--- a/moveit_core/robot_trajectory/CMakeLists.txt
+++ b/moveit_core/robot_trajectory/CMakeLists.txt
@@ -5,8 +5,8 @@ target_include_directories(
          $<INSTALL_INTERFACE:include/moveit_core>)
 set_target_properties(moveit_robot_trajectory
                       PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
-ament_target_dependencies(moveit_robot_trajectory rclcpp urdfdom
-                          urdfdom_headers)
+target_link_libraries(moveit_robot_trajectory PUBLIC
+                      rclcpp urdfdom urdfdom_headers)
 
 target_link_libraries(moveit_robot_trajectory moveit_robot_model
                       moveit_robot_state moveit_utils)

--- a/moveit_core/trajectory_processing/CMakeLists.txt
+++ b/moveit_core/trajectory_processing/CMakeLists.txt
@@ -8,8 +8,8 @@ target_include_directories(
          $<INSTALL_INTERFACE:include/moveit_core>)
 set_target_properties(moveit_trajectory_processing
                       PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-ament_target_dependencies(
-  moveit_trajectory_processing
+target_link_libraries(moveit_trajectory_processing
+  PUBLIC
   rclcpp
   rmw_implementation
   urdf

--- a/moveit_core/transforms/CMakeLists.txt
+++ b/moveit_core/transforms/CMakeLists.txt
@@ -6,8 +6,8 @@ target_include_directories(
 target_link_libraries(moveit_transforms moveit_macros moveit_utils)
 set_target_properties(moveit_transforms PROPERTIES VERSION
                                                    "${${PROJECT_NAME}_VERSION}")
-ament_target_dependencies(
-  moveit_transforms
+target_link_libraries(moveit_transforms
+  PUBLIC
   geometric_shapes
   tf2_eigen
   rclcpp

--- a/moveit_core/utils/CMakeLists.txt
+++ b/moveit_core/utils/CMakeLists.txt
@@ -3,7 +3,7 @@ add_library(moveit_utils SHARED src/lexical_casts.cpp src/message_checks.cpp
 target_include_directories(
   moveit_utils PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
                       $<INSTALL_INTERFACE:include/moveit_core>)
-ament_target_dependencies(moveit_utils Boost moveit_msgs rclcpp fmt)
+target_link_libraries(moveit_utils PUBLIC Boost moveit_msgs rclcpp fmt)
 target_link_libraries(moveit_utils rsl::rsl)
 set_target_properties(moveit_utils PROPERTIES VERSION
                                               "${${PROJECT_NAME}_VERSION}")
@@ -18,8 +18,8 @@ target_include_directories(
          $<INSTALL_INTERFACE:include/moveit_core>)
 target_link_libraries(moveit_test_utils moveit_robot_model
                       moveit_kinematics_base rsl::rsl)
-ament_target_dependencies(
-  moveit_test_utils
+target_link_libraries(moveit_test_utils
+  PUBLIC
   ament_index_cpp
   Boost
   geometry_msgs

--- a/moveit_kinematics/cached_ik_kinematics_plugin/CMakeLists.txt
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/CMakeLists.txt
@@ -5,8 +5,8 @@ find_package(ur_kinematics QUIET)
 add_library(moveit_cached_ik_kinematics_base SHARED src/ik_cache.cpp)
 set_target_properties(moveit_cached_ik_kinematics_base
                       PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-ament_target_dependencies(moveit_cached_ik_kinematics_base PUBLIC rclcpp
-                          moveit_core moveit_msgs)
+target_link_libraries(moveit_cached_ik_kinematics_base PUBLIC
+                      rclcpp moveit_core moveit_msgs)
 
 if(trac_ik_kinematics_plugin_FOUND)
   include_directories(${trac_ik_kinematics_plugin_INCLUDE_DIRS})
@@ -27,8 +27,8 @@ add_library(moveit_cached_ik_kinematics_plugin SHARED
             src/cached_ik_kinematics_plugin.cpp)
 set_target_properties(moveit_cached_ik_kinematics_plugin
                       PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-ament_target_dependencies(moveit_cached_ik_kinematics_plugin PUBLIC rclcpp
-                          moveit_core moveit_msgs rsl)
+target_link_libraries(moveit_cached_ik_kinematics_plugin PUBLIC
+                      rclcpp moveit_core moveit_msgs rsl)
 target_link_libraries(
   moveit_cached_ik_kinematics_plugin
   PRIVATE cached_ik_kinematics_parameters moveit_kdl_kinematics_plugin

--- a/moveit_kinematics/ikfast_kinematics_plugin/templates/CMakeLists.txt
+++ b/moveit_kinematics/ikfast_kinematics_plugin/templates/CMakeLists.txt
@@ -26,7 +26,7 @@ generate_parameter_library(
 set(IKFAST_LIBRARY_NAME _LIBRARY_NAME_)
 add_library(${IKFAST_LIBRARY_NAME} SHARED
             src/_ROBOT_NAME___GROUP_NAME__ikfast_moveit_plugin.cpp)
-ament_target_dependencies(
+target_link_libraries(
   ${IKFAST_LIBRARY_NAME}
   rclcpp
   moveit_core

--- a/moveit_kinematics/kdl_kinematics_plugin/CMakeLists.txt
+++ b/moveit_kinematics/kdl_kinematics_plugin/CMakeLists.txt
@@ -6,8 +6,8 @@ generate_parameter_library(
 add_library(moveit_kdl_kinematics_plugin SHARED
             src/kdl_kinematics_plugin.cpp src/chainiksolver_vel_mimic_svd.cpp)
 
-ament_target_dependencies(
-  moveit_kdl_kinematics_plugin
+target_link_libraries(moveit_kdl_kinematics_plugin
+  PUBLIC
   rclcpp
   random_numbers
   pluginlib

--- a/moveit_kinematics/srv_kinematics_plugin/CMakeLists.txt
+++ b/moveit_kinematics/srv_kinematics_plugin/CMakeLists.txt
@@ -7,8 +7,8 @@ add_library(moveit_srv_kinematics_plugin SHARED src/srv_kinematics_plugin.cpp)
 set_target_properties(moveit_srv_kinematics_plugin
                       PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 
-ament_target_dependencies(moveit_srv_kinematics_plugin rclcpp moveit_core
-                          moveit_msgs)
+target_link_libraries(moveit_srv_kinematics_plugin PUBLIC
+                      rclcpp moveit_core moveit_msgs)
 
 target_link_libraries(moveit_srv_kinematics_plugin srv_kinematics_parameters)
 

--- a/moveit_planners/chomp/chomp_interface/CMakeLists.txt
+++ b/moveit_planners/chomp/chomp_interface/CMakeLists.txt
@@ -22,12 +22,14 @@ add_library(moveit_chomp_interface SHARED src/chomp_interface.cpp
                                           src/chomp_planning_context.cpp)
 set_target_properties(moveit_chomp_interface
                       PROPERTIES VERSION "${moveit_planners_chomp_VERSION}")
-ament_target_dependencies(moveit_chomp_interface
-                          ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(moveit_chomp_interface PUBLIC
+                      ${THIS_PACKAGE_INCLUDE_DEPENDS}
+)
 
 add_library(moveit_chomp_planner_plugin SHARED src/chomp_plugin.cpp)
-ament_target_dependencies(moveit_chomp_planner_plugin
-                          ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(moveit_chomp_planner_plugin PUBLIC
+                      ${THIS_PACKAGE_INCLUDE_DEPENDS}
+)
 target_link_libraries(moveit_chomp_planner_plugin moveit_chomp_interface)
 
 install(

--- a/moveit_planners/chomp/chomp_motion_planner/CMakeLists.txt
+++ b/moveit_planners/chomp/chomp_motion_planner/CMakeLists.txt
@@ -23,7 +23,7 @@ add_library(
   src/chomp_optimizer.cpp src/chomp_planner.cpp)
 set_target_properties(chomp_motion_planner
                       PROPERTIES VERSION "${chomp_motion_planner_VERSION}")
-ament_target_dependencies(chomp_motion_planner ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(chomp_motion_planner PUBLIC ${THIS_PACKAGE_INCLUDE_DEPENDS})
 
 install(
   TARGETS chomp_motion_planner

--- a/moveit_planners/ompl/ompl_interface/CMakeLists.txt
+++ b/moveit_planners/ompl/ompl_interface/CMakeLists.txt
@@ -29,7 +29,7 @@ if(APPLE)
   target_link_directories(moveit_ompl_interface PUBLIC ${OMPL_LIBRARY_DIRS})
 endif()
 
-ament_target_dependencies(
+target_link_libraries(
   moveit_ompl_interface
   moveit_core
   moveit_msgs
@@ -57,7 +57,7 @@ set_target_properties(moveit_generate_state_database
 add_library(moveit_ompl_planner_plugin SHARED src/ompl_planner_manager.cpp)
 set_target_properties(moveit_ompl_planner_plugin
                       PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-ament_target_dependencies(
+target_link_libraries(
   moveit_ompl_planner_plugin
   moveit_core
   moveit_ros_planning

--- a/moveit_planners/pilz_industrial_motion_planner/CMakeLists.txt
+++ b/moveit_planners/pilz_industrial_motion_planner/CMakeLists.txt
@@ -65,29 +65,29 @@ generate_parameter_library(
 
 add_library(planning_context_loader_base SHARED src/planning_context_loader.cpp)
 target_link_libraries(planning_context_loader_base cartesian_limits_parameters)
-ament_target_dependencies(planning_context_loader_base
-                          ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(planning_context_loader_base PUBLIC
+                      ${THIS_PACKAGE_INCLUDE_DEPENDS})
 
 add_library(
   joint_limits_common SHARED
   src/joint_limits_aggregator.cpp src/joint_limits_container.cpp
   src/joint_limits_validator.cpp src/limits_container.cpp)
 target_link_libraries(joint_limits_common cartesian_limits_parameters)
-ament_target_dependencies(joint_limits_common ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(joint_limits_common PUBLIC ${THIS_PACKAGE_INCLUDE_DEPENDS})
 
 add_library(
   trajectory_generation_common SHARED
   src/trajectory_functions.cpp src/trajectory_generator.cpp
   src/trajectory_blender_transition_window.cpp)
 target_link_libraries(trajectory_generation_common cartesian_limits_parameters)
-ament_target_dependencies(trajectory_generation_common
-                          ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(trajectory_generation_common PUBLIC
+                      ${THIS_PACKAGE_INCLUDE_DEPENDS})
 
 add_library(command_list_manager SHARED src/command_list_manager.cpp
                                         src/plan_components_builder.cpp)
 target_link_libraries(command_list_manager trajectory_generation_common
                       joint_limits_common)
-ament_target_dependencies(command_list_manager ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(command_list_manager PUBLIC ${THIS_PACKAGE_INCLUDE_DEPENDS})
 
 # ##############################################################################
 # Plugins ##
@@ -95,8 +95,8 @@ ament_target_dependencies(command_list_manager ${THIS_PACKAGE_INCLUDE_DEPENDS})
 
 add_library(pilz_industrial_motion_planner SHARED
             src/pilz_industrial_motion_planner.cpp)
-ament_target_dependencies(pilz_industrial_motion_planner
-                          ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(pilz_industrial_motion_planner PUBLIC
+                      ${THIS_PACKAGE_INCLUDE_DEPENDS})
 target_link_libraries(pilz_industrial_motion_planner
                       planning_context_loader_base joint_limits_common)
 
@@ -104,8 +104,8 @@ add_library(
   planning_context_loader_ptp SHARED
   src/planning_context_loader_ptp.cpp src/trajectory_generator_ptp.cpp
   src/velocity_profile_atrap.cpp)
-ament_target_dependencies(planning_context_loader_ptp
-                          ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(planning_context_loader_ptp PUBLIC
+                      ${THIS_PACKAGE_INCLUDE_DEPENDS})
 target_link_libraries(planning_context_loader_ptp planning_context_loader_base
                       joint_limits_common trajectory_generation_common)
 
@@ -113,8 +113,8 @@ add_library(
   planning_context_loader_lin SHARED
   src/planning_context_loader_lin.cpp src/trajectory_generator_lin.cpp
   src/velocity_profile_atrap.cpp)
-ament_target_dependencies(planning_context_loader_lin
-                          ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(planning_context_loader_lin PUBLIC
+                      ${THIS_PACKAGE_INCLUDE_DEPENDS})
 target_link_libraries(planning_context_loader_lin planning_context_loader_base
                       joint_limits_common trajectory_generation_common)
 
@@ -122,14 +122,14 @@ add_library(
   planning_context_loader_circ SHARED
   src/planning_context_loader_circ.cpp src/trajectory_generator_circ.cpp
   src/path_circle_generator.cpp)
-ament_target_dependencies(planning_context_loader_circ
-                          ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(planning_context_loader_circ PUBLIC
+                      ${THIS_PACKAGE_INCLUDE_DEPENDS})
 target_link_libraries(planning_context_loader_circ planning_context_loader_base
                       joint_limits_common trajectory_generation_common)
 
 add_library(sequence_capability SHARED src/move_group_sequence_action.cpp
                                        src/move_group_sequence_service.cpp)
-ament_target_dependencies(sequence_capability ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(sequence_capability PUBLIC ${THIS_PACKAGE_INCLUDE_DEPENDS})
 target_link_libraries(sequence_capability joint_limits_common
                       command_list_manager trajectory_generation_common)
 

--- a/moveit_planners/pilz_industrial_motion_planner/test/CMakeLists.txt
+++ b/moveit_planners/pilz_industrial_motion_planner/test/CMakeLists.txt
@@ -12,8 +12,8 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
 # pilz_industrial_motion_testhelpers
 add_library(${PROJECT_NAME}_test_utils test_utils.cpp)
-ament_target_dependencies(${PROJECT_NAME}_test_utils
-                          ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(${PROJECT_NAME}_test_utils PUBLIC
+                      ${THIS_PACKAGE_INCLUDE_DEPENDS})
 target_link_libraries(${PROJECT_NAME}_test_utils joint_limits_common
                       trajectory_generation_common)
 

--- a/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/CMakeLists.txt
+++ b/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/CMakeLists.txt
@@ -38,7 +38,7 @@ target_link_libraries(unittest_trajectory_generator ${PROJECT_NAME})
 # Trajectory Functions Unit Test
 ament_add_gtest_executable(unittest_trajectory_functions
                            src/unittest_trajectory_functions.cpp)
-ament_target_dependencies(unittest_trajectory_functions Boost)
+target_link_libraries(unittest_trajectory_functions PUBLIC Boost)
 target_link_libraries(unittest_trajectory_functions ${PROJECT_NAME}_test_utils
                       trajectory_generation_common joint_limits_common)
 add_ros_test(launch/unittest_trajectory_functions.test.py ARGS
@@ -49,8 +49,8 @@ ament_add_gtest_executable(
   unittest_trajectory_blender_transition_window
   src/unittest_trajectory_blender_transition_window.cpp
   ${CMAKE_SOURCE_DIR}/src/trajectory_blender_transition_window.cpp)
-ament_target_dependencies(unittest_trajectory_blender_transition_window
-                          pilz_industrial_motion_planner_testutils)
+target_link_libraries(unittest_trajectory_blender_transition_window PUBLIC
+                      pilz_industrial_motion_planner_testutils)
 target_link_libraries(
   unittest_trajectory_blender_transition_window ${PROJECT_NAME}_test_utils
   trajectory_generation_common planning_context_loader_lin)
@@ -70,8 +70,8 @@ add_ros_test(launch/unittest_trajectory_generator_common.test.py ARGS
 # trajectory generator circ Unit Test
 ament_add_gtest_executable(unittest_trajectory_generator_circ
                            src/unittest_trajectory_generator_circ.cpp)
-ament_target_dependencies(unittest_trajectory_generator_circ
-                          pilz_industrial_motion_planner_testutils)
+target_link_libraries(unittest_trajectory_generator_circ PUBLIC
+                      pilz_industrial_motion_planner_testutils)
 target_link_libraries(unittest_trajectory_generator_circ
                       ${PROJECT_NAME}_test_utils planning_context_loader_circ)
 add_ros_test(launch/unittest_trajectory_generator_circ.test.py ARGS
@@ -80,8 +80,8 @@ add_ros_test(launch/unittest_trajectory_generator_circ.test.py ARGS
 # trajectory generator lin Unit Test
 ament_add_gtest_executable(unittest_trajectory_generator_lin
                            src/unittest_trajectory_generator_lin.cpp)
-ament_target_dependencies(unittest_trajectory_generator_lin
-                          pilz_industrial_motion_planner_testutils)
+target_link_libraries(unittest_trajectory_generator_lin PUBLIC
+                      pilz_industrial_motion_planner_testutils)
 target_link_libraries(unittest_trajectory_generator_lin
                       ${PROJECT_NAME}_test_utils planning_context_loader_lin)
 add_ros_test(launch/unittest_trajectory_generator_lin.test.py ARGS

--- a/moveit_planners/pilz_industrial_motion_planner_testutils/CMakeLists.txt
+++ b/moveit_planners/pilz_industrial_motion_planner_testutils/CMakeLists.txt
@@ -29,8 +29,8 @@ add_library(
   src/robotconfiguration.cpp src/sequence.cpp src/xml_testdata_loader.cpp)
 
 # Specify libraries to link a library or executable target against
-ament_target_dependencies(
-  pilz_industrial_motion_planner_testutils
+target_link_libraries(pilz_industrial_motion_planner_testutils
+  PUBLIC
   Boost
   Eigen3
   eigen3_cmake_module

--- a/moveit_planners/stomp/CMakeLists.txt
+++ b/moveit_planners/stomp/CMakeLists.txt
@@ -22,8 +22,8 @@ include_directories(include)
 # Planner Plugin
 add_library(stomp_moveit_plugin SHARED src/stomp_moveit_planner_plugin.cpp
                                        src/stomp_moveit_planning_context.cpp)
-ament_target_dependencies(stomp_moveit_plugin moveit_core std_msgs tf2_eigen
-                          visualization_msgs)
+target_link_libraries(stomp_moveit_plugin PUBLIC
+                      moveit_core std_msgs tf2_eigen visualization_msgs)
 target_link_libraries(stomp_moveit_plugin stomp::stomp stomp_moveit_parameters
                       rsl::rsl)
 

--- a/moveit_planners/stomp/test/CMakeLists.txt
+++ b/moveit_planners/stomp/test/CMakeLists.txt
@@ -1,8 +1,8 @@
 find_package(ament_cmake_gtest REQUIRED)
 ament_add_gtest(test_noise_generator test_noise_generator.cpp)
-ament_target_dependencies(test_noise_generator tf2_eigen)
+target_link_libraries(test_noise_generator PUBLIC tf2_eigen)
 target_link_libraries(test_noise_generator stomp::stomp rsl::rsl)
 
 ament_add_gtest(test_cost_functions test_cost_functions.cpp)
-ament_target_dependencies(test_cost_functions moveit_core)
+target_link_libraries(test_cost_functions PUBLIC moveit_core)
 target_link_libraries(test_cost_functions stomp::stomp rsl::rsl)

--- a/moveit_planners/test_configs/prbt_ikfast_manipulator_plugin/CMakeLists.txt
+++ b/moveit_planners/test_configs/prbt_ikfast_manipulator_plugin/CMakeLists.txt
@@ -43,8 +43,8 @@ if(NOT WIN32)
   target_compile_options(prbt_manipulator_moveit_ikfast_plugin
                          PRIVATE -Wno-unused-variable)
 endif()
-ament_target_dependencies(
-  prbt_manipulator_moveit_ikfast_plugin
+target_link_libraries(prbt_manipulator_moveit_ikfast_plugin
+  PUBLIC
   moveit_core
   pluginlib
   rclcpp

--- a/moveit_plugins/moveit_ros_control_interface/CMakeLists.txt
+++ b/moveit_plugins/moveit_ros_control_interface/CMakeLists.txt
@@ -24,8 +24,8 @@ set_target_properties(
   moveit_ros_control_interface_plugin
   PROPERTIES VERSION "${moveit_ros_control_interface_VERSION}")
 target_include_directories(moveit_ros_control_interface_plugin PRIVATE include)
-ament_target_dependencies(moveit_ros_control_interface_plugin
-                          ${THIS_PACKAGE_INCLUDE_DEPENDS} Boost)
+target_link_libraries(moveit_ros_control_interface_plugin PUBLIC
+                      ${THIS_PACKAGE_INCLUDE_DEPENDS} Boost)
 
 add_library(moveit_ros_control_interface_trajectory_plugin SHARED
             src/joint_trajectory_controller_plugin.cpp)
@@ -34,8 +34,8 @@ set_target_properties(
   PROPERTIES VERSION "${moveit_ros_control_interface_VERSION}")
 target_include_directories(moveit_ros_control_interface_trajectory_plugin
                            PRIVATE include)
-ament_target_dependencies(moveit_ros_control_interface_trajectory_plugin
-                          ${THIS_PACKAGE_INCLUDE_DEPENDS} Boost)
+target_link_libraries(moveit_ros_control_interface_trajectory_plugin PUBLIC
+                      ${THIS_PACKAGE_INCLUDE_DEPENDS} Boost)
 
 add_library(moveit_ros_control_interface_gripper_plugin SHARED
             src/gripper_command_controller_plugin.cpp)
@@ -44,8 +44,8 @@ set_target_properties(
   PROPERTIES VERSION "${moveit_ros_control_interface_VERSION}")
 target_include_directories(moveit_ros_control_interface_gripper_plugin
                            PRIVATE include)
-ament_target_dependencies(moveit_ros_control_interface_gripper_plugin
-                          ${THIS_PACKAGE_INCLUDE_DEPENDS} Boost)
+target_link_libraries(moveit_ros_control_interface_gripper_plugin PUBLIC
+                      ${THIS_PACKAGE_INCLUDE_DEPENDS} Boost)
 
 add_library(moveit_ros_control_interface_parallel_gripper_plugin SHARED
             src/parallel_gripper_command_controller_plugin.cpp)
@@ -54,8 +54,8 @@ set_target_properties(
   PROPERTIES VERSION "${moveit_ros_control_interface_VERSION}")
 target_include_directories(moveit_ros_control_interface_parallel_gripper_plugin
                            PRIVATE include)
-ament_target_dependencies(moveit_ros_control_interface_parallel_gripper_plugin
-                          ${THIS_PACKAGE_INCLUDE_DEPENDS} Boost)
+target_link_libraries(moveit_ros_control_interface_parallel_gripper_plugin PUBLIC
+                      ${THIS_PACKAGE_INCLUDE_DEPENDS} Boost)
 
 add_library(moveit_ros_control_interface_empty_plugin SHARED
             src/empty_controller_plugin.cpp)
@@ -64,8 +64,8 @@ set_target_properties(
   PROPERTIES VERSION "${moveit_ros_control_interface_VERSION}")
 target_include_directories(moveit_ros_control_interface_empty_plugin
                            PRIVATE include)
-ament_target_dependencies(moveit_ros_control_interface_empty_plugin
-                          ${THIS_PACKAGE_INCLUDE_DEPENDS} Boost)
+target_link_libraries(moveit_ros_control_interface_empty_plugin PUBLIC
+                      ${THIS_PACKAGE_INCLUDE_DEPENDS} Boost)
 
 if(BUILD_TESTING)
   add_subdirectory(test)

--- a/moveit_plugins/moveit_simple_controller_manager/CMakeLists.txt
+++ b/moveit_plugins/moveit_simple_controller_manager/CMakeLists.txt
@@ -29,8 +29,8 @@ set_target_properties(
   moveit_simple_controller_manager
   PROPERTIES VERSION "${moveit_simple_controller_manager_VERSION}")
 
-ament_target_dependencies(moveit_simple_controller_manager
-                          ${THIS_PACKAGE_INCLUDE_DEPENDS} Boost)
+target_link_libraries(moveit_simple_controller_manager PUBLIC
+                      ${THIS_PACKAGE_INCLUDE_DEPENDS} Boost)
 
 install(
   TARGETS moveit_simple_controller_manager

--- a/moveit_py/src/moveit/moveit_py_utils/CMakeLists.txt
+++ b/moveit_py/src/moveit/moveit_py_utils/CMakeLists.txt
@@ -6,8 +6,8 @@ target_include_directories(
 set_target_properties(moveit_py_utils PROPERTIES VERSION
                                                  "${${PROJECT_NAME}_VERSION}")
 
-ament_target_dependencies(moveit_py_utils rclcpp moveit_msgs geometry_msgs
-                          pybind11)
+target_link_libraries(moveit_py_utils PUBLIC
+                      rclcpp moveit_msgs geometry_msgs pybind11)
 
 install(
   TARGETS moveit_py_utils

--- a/moveit_ros/benchmarks/CMakeLists.txt
+++ b/moveit_ros/benchmarks/CMakeLists.txt
@@ -34,11 +34,11 @@ set_target_properties(moveit_ros_benchmarks
 if(WIN32)
   set(EXTRA_LIB ws2_32.lib)
 endif()
-ament_target_dependencies(moveit_ros_benchmarks ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(moveit_ros_benchmarks PUBLIC ${THIS_PACKAGE_INCLUDE_DEPENDS})
 target_link_libraries(moveit_ros_benchmarks ${EXTRA_LIB})
 
 add_executable(moveit_run_benchmark src/RunBenchmark.cpp)
-ament_target_dependencies(moveit_run_benchmark ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(moveit_run_benchmark PUBLIC ${THIS_PACKAGE_INCLUDE_DEPENDS})
 target_link_libraries(moveit_run_benchmark moveit_ros_benchmarks)
 
 install(

--- a/moveit_ros/hybrid_planning/global_planner/global_planner_component/CMakeLists.txt
+++ b/moveit_ros/hybrid_planning/global_planner/global_planner_component/CMakeLists.txt
@@ -3,5 +3,5 @@ add_library(moveit_global_planner_component SHARED
             src/global_planner_component.cpp)
 set_target_properties(moveit_global_planner_component
                       PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-ament_target_dependencies(moveit_global_planner_component
-                          ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(moveit_global_planner_component PUBLIC
+                      ${THIS_PACKAGE_INCLUDE_DEPENDS})

--- a/moveit_ros/hybrid_planning/global_planner/global_planner_plugins/CMakeLists.txt
+++ b/moveit_ros/hybrid_planning/global_planner/global_planner_plugins/CMakeLists.txt
@@ -2,5 +2,5 @@ add_library(motion_planning_pipeline_plugin SHARED
             src/moveit_planning_pipeline.cpp)
 set_target_properties(motion_planning_pipeline_plugin
                       PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-ament_target_dependencies(motion_planning_pipeline_plugin
-                          ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(motion_planning_pipeline_plugin PUBLIC
+                      ${THIS_PACKAGE_INCLUDE_DEPENDS})

--- a/moveit_ros/hybrid_planning/hybrid_planning_manager/hybrid_planning_manager_component/CMakeLists.txt
+++ b/moveit_ros/hybrid_planning/hybrid_planning_manager/hybrid_planning_manager_component/CMakeLists.txt
@@ -5,5 +5,5 @@ add_library(moveit_hybrid_planning_manager SHARED
 set_target_properties(moveit_hybrid_planning_manager
                       PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 target_link_libraries(moveit_hybrid_planning_manager hp_manager_parameters)
-ament_target_dependencies(moveit_hybrid_planning_manager
-                          ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(moveit_hybrid_planning_manager PUBLIC
+                      ${THIS_PACKAGE_INCLUDE_DEPENDS})

--- a/moveit_ros/hybrid_planning/hybrid_planning_manager/planner_logic_plugins/CMakeLists.txt
+++ b/moveit_ros/hybrid_planning/hybrid_planning_manager/planner_logic_plugins/CMakeLists.txt
@@ -1,8 +1,8 @@
 add_library(single_plan_execution_plugin SHARED src/single_plan_execution.cpp)
 set_target_properties(single_plan_execution_plugin
                       PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-ament_target_dependencies(single_plan_execution_plugin
-                          ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(single_plan_execution_plugin PUBLIC
+                      ${THIS_PACKAGE_INCLUDE_DEPENDS})
 target_link_libraries(single_plan_execution_plugin
                       moveit_hybrid_planning_manager)
 
@@ -10,8 +10,8 @@ add_library(replan_invalidated_trajectory_plugin SHARED
             src/replan_invalidated_trajectory.cpp)
 set_target_properties(replan_invalidated_trajectory_plugin
                       PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-ament_target_dependencies(replan_invalidated_trajectory_plugin
-                          ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(replan_invalidated_trajectory_plugin PUBLIC
+                      ${THIS_PACKAGE_INCLUDE_DEPENDS})
 target_link_libraries(
   replan_invalidated_trajectory_plugin moveit_hybrid_planning_manager
   single_plan_execution_plugin)

--- a/moveit_ros/hybrid_planning/local_planner/local_constraint_solver_plugins/CMakeLists.txt
+++ b/moveit_ros/hybrid_planning/local_planner/local_constraint_solver_plugins/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library(forward_trajectory_plugin SHARED src/forward_trajectory.cpp)
 set_target_properties(forward_trajectory_plugin
                       PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-ament_target_dependencies(forward_trajectory_plugin
-                          ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(forward_trajectory_plugin PUBLIC
+                      ${THIS_PACKAGE_INCLUDE_DEPENDS})

--- a/moveit_ros/hybrid_planning/local_planner/local_planner_component/CMakeLists.txt
+++ b/moveit_ros/hybrid_planning/local_planner/local_planner_component/CMakeLists.txt
@@ -6,5 +6,5 @@ add_library(moveit_local_planner_component SHARED
 set_target_properties(moveit_local_planner_component
                       PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 target_link_libraries(moveit_local_planner_component local_planner_parameters)
-ament_target_dependencies(moveit_local_planner_component
-                          ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(moveit_local_planner_component PUBLIC
+                      ${THIS_PACKAGE_INCLUDE_DEPENDS})

--- a/moveit_ros/hybrid_planning/local_planner/trajectory_operator_plugins/CMakeLists.txt
+++ b/moveit_ros/hybrid_planning/local_planner/trajectory_operator_plugins/CMakeLists.txt
@@ -1,4 +1,4 @@
 add_library(simple_sampler_plugin SHARED src/simple_sampler.cpp)
 set_target_properties(simple_sampler_plugin
                       PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-ament_target_dependencies(simple_sampler_plugin ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(simple_sampler_plugin PUBLIC ${THIS_PACKAGE_INCLUDE_DEPENDS})

--- a/moveit_ros/hybrid_planning/test/CMakeLists.txt
+++ b/moveit_ros/hybrid_planning/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(cancel_action cancel_action.cpp)
-ament_target_dependencies(cancel_action PUBLIC ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(cancel_action PUBLIC ${THIS_PACKAGE_INCLUDE_DEPENDS})
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)

--- a/moveit_ros/move_group/CMakeLists.txt
+++ b/moveit_ros/move_group/CMakeLists.txt
@@ -34,8 +34,8 @@ target_include_directories(
          $<INSTALL_INTERFACE:include/moveit_ros_move_group>)
 set_target_properties(moveit_move_group_capabilities_base
                       PROPERTIES VERSION "${moveit_ros_move_group_VERSION}")
-ament_target_dependencies(moveit_move_group_capabilities_base
-                          ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(moveit_move_group_capabilities_base PUBLIC
+                      ${THIS_PACKAGE_INCLUDE_DEPENDS})
 
 add_library(
   moveit_move_group_default_capabilities SHARED
@@ -59,19 +59,19 @@ target_include_directories(
          $<INSTALL_INTERFACE:include/moveit_ros_move_group>)
 set_target_properties(moveit_move_group_default_capabilities
                       PROPERTIES VERSION "${moveit_ros_move_group_VERSION}")
-ament_target_dependencies(moveit_move_group_default_capabilities
-                          ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(moveit_move_group_default_capabilities PUBLIC
+                      ${THIS_PACKAGE_INCLUDE_DEPENDS})
 target_link_libraries(moveit_move_group_default_capabilities
                       moveit_move_group_capabilities_base)
 
 add_executable(move_group src/move_group.cpp)
 target_include_directories(move_group PUBLIC include)
-ament_target_dependencies(move_group ${THIS_PACKAGE_INCLUDE_DEPENDS} Boost)
+target_link_libraries(move_group PUBLIC ${THIS_PACKAGE_INCLUDE_DEPENDS} Boost)
 target_link_libraries(move_group moveit_move_group_capabilities_base)
 
 add_executable(list_move_group_capabilities src/list_capabilities.cpp)
-ament_target_dependencies(list_move_group_capabilities
-                          ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(list_move_group_capabilities PUBLIC
+                      ${THIS_PACKAGE_INCLUDE_DEPENDS})
 target_link_libraries(list_move_group_capabilities
                       moveit_move_group_capabilities_base fmt)
 

--- a/moveit_ros/moveit_servo/CMakeLists.txt
+++ b/moveit_ros/moveit_servo/CMakeLists.txt
@@ -46,13 +46,13 @@ add_library(
 set_target_properties(moveit_servo_lib_cpp PROPERTIES VERSION
                                                       "${moveit_servo_VERSION}")
 target_link_libraries(moveit_servo_lib_cpp moveit_servo_lib_parameters)
-ament_target_dependencies(moveit_servo_lib_cpp ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(moveit_servo_lib_cpp PUBLIC ${THIS_PACKAGE_INCLUDE_DEPENDS})
 
 add_library(moveit_servo_lib_ros SHARED src/servo_node.cpp)
 set_target_properties(moveit_servo_lib_ros PROPERTIES VERSION
                                                       "${moveit_servo_VERSION}")
 target_link_libraries(moveit_servo_lib_ros moveit_servo_lib_cpp)
-ament_target_dependencies(moveit_servo_lib_ros ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(moveit_servo_lib_ros PUBLIC ${THIS_PACKAGE_INCLUDE_DEPENDS})
 
 # ##############################################################################
 # Components ##
@@ -68,22 +68,22 @@ rclcpp_components_register_node(moveit_servo_lib_ros PLUGIN
 # Executable node for the joint jog demo
 add_executable(demo_joint_jog demos/cpp_interface/demo_joint_jog.cpp)
 target_link_libraries(demo_joint_jog moveit_servo_lib_cpp)
-ament_target_dependencies(demo_joint_jog ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(demo_joint_jog PUBLIC ${THIS_PACKAGE_INCLUDE_DEPENDS})
 
 # Executable node for the twist demo
 add_executable(demo_twist demos/cpp_interface/demo_twist.cpp)
 target_link_libraries(demo_twist moveit_servo_lib_cpp)
-ament_target_dependencies(demo_twist ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(demo_twist PUBLIC ${THIS_PACKAGE_INCLUDE_DEPENDS})
 
 # Executable node for the pose demo
 add_executable(demo_pose demos/cpp_interface/demo_pose.cpp)
 target_link_libraries(demo_pose moveit_servo_lib_cpp)
-ament_target_dependencies(demo_pose ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(demo_pose PUBLIC ${THIS_PACKAGE_INCLUDE_DEPENDS})
 
 # Keyboard control example for servo
 add_executable(servo_keyboard_input demos/servo_keyboard_input.cpp)
 target_include_directories(servo_keyboard_input PUBLIC include)
-ament_target_dependencies(servo_keyboard_input ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(servo_keyboard_input PUBLIC ${THIS_PACKAGE_INCLUDE_DEPENDS})
 
 # ##############################################################################
 # Install ##

--- a/moveit_ros/occupancy_map_monitor/CMakeLists.txt
+++ b/moveit_ros/occupancy_map_monitor/CMakeLists.txt
@@ -38,12 +38,12 @@ add_library(
 set_target_properties(
   moveit_ros_occupancy_map_monitor
   PROPERTIES VERSION "${moveit_ros_occupancy_map_monitor_VERSION}")
-ament_target_dependencies(moveit_ros_occupancy_map_monitor
-                          ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(moveit_ros_occupancy_map_monitor PUBLIC
+                      ${THIS_PACKAGE_INCLUDE_DEPENDS})
 
 add_executable(moveit_ros_occupancy_map_server src/occupancy_map_server.cpp)
-ament_target_dependencies(moveit_ros_occupancy_map_server PUBLIC
-                          ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(moveit_ros_occupancy_map_server PUBLIC
+                      ${THIS_PACKAGE_INCLUDE_DEPENDS})
 target_link_libraries(moveit_ros_occupancy_map_server
                       PRIVATE moveit_ros_occupancy_map_monitor)
 

--- a/moveit_ros/perception/depth_image_octomap_updater/CMakeLists.txt
+++ b/moveit_ros/perception/depth_image_octomap_updater/CMakeLists.txt
@@ -2,8 +2,8 @@ add_library(moveit_depth_image_octomap_updater_core SHARED
             src/depth_image_octomap_updater.cpp)
 set_target_properties(moveit_depth_image_octomap_updater_core
                       PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-ament_target_dependencies(
-  moveit_depth_image_octomap_updater_core
+target_link_libraries(moveit_depth_image_octomap_updater_core
+  PUBLIC
   rclcpp
   moveit_core
   image_transport
@@ -18,8 +18,8 @@ target_link_libraries(moveit_depth_image_octomap_updater_core
 add_library(moveit_depth_image_octomap_updater SHARED src/updater_plugin.cpp)
 set_target_properties(moveit_depth_image_octomap_updater
                       PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-ament_target_dependencies(
-  moveit_depth_image_octomap_updater
+target_link_libraries(moveit_depth_image_octomap_updater
+  PUBLIC
   rclcpp
   moveit_core
   image_transport

--- a/moveit_ros/perception/lazy_free_space_updater/CMakeLists.txt
+++ b/moveit_ros/perception/lazy_free_space_updater/CMakeLists.txt
@@ -10,7 +10,7 @@ set_target_properties(moveit_lazy_free_space_updater
 if(APPLE)
   target_link_libraries(moveit_lazy_free_space_updater OpenMP::OpenMP_CXX)
 endif()
-ament_target_dependencies(moveit_lazy_free_space_updater rclcpp
-                          moveit_ros_occupancy_map_monitor sensor_msgs)
+target_link_libraries(moveit_lazy_free_space_updater PUBLIC
+                      rclcpp moveit_ros_occupancy_map_monitor sensor_msgs)
 
 install(DIRECTORY include/ DESTINATION include/moveit_ros_perception)

--- a/moveit_ros/perception/mesh_filter/CMakeLists.txt
+++ b/moveit_ros/perception/mesh_filter/CMakeLists.txt
@@ -8,8 +8,8 @@ target_include_directories(
   moveit_mesh_filter PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
 set_target_properties(moveit_mesh_filter
                       PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-ament_target_dependencies(moveit_mesh_filter rclcpp moveit_core
-                          geometric_shapes Eigen3)
+target_link_libraries(moveit_mesh_filter PUBLIC
+                      rclcpp moveit_core geometric_shapes Eigen3)
 
 target_link_libraries(moveit_mesh_filter ${GL_LIBS} ${SYSTEM_GL_LIBRARIES})
 

--- a/moveit_ros/perception/point_containment_filter/CMakeLists.txt
+++ b/moveit_ros/perception/point_containment_filter/CMakeLists.txt
@@ -6,7 +6,7 @@ set_target_properties(
   PROPERTIES COMPILE_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
 set_target_properties(moveit_point_containment_filter
                       PROPERTIES LINK_FLAGS "${OpenMP_CXX_FLAGS}")
-ament_target_dependencies(moveit_point_containment_filter rclcpp sensor_msgs
-                          geometric_shapes moveit_core)
+target_link_libraries(moveit_point_containment_filter PUBLIC
+                      rclcpp sensor_msgs geometric_shapes moveit_core)
 
 install(DIRECTORY include/ DESTINATION include/moveit_ros_perception)

--- a/moveit_ros/perception/pointcloud_octomap_updater/CMakeLists.txt
+++ b/moveit_ros/perception/pointcloud_octomap_updater/CMakeLists.txt
@@ -2,8 +2,8 @@ add_library(moveit_pointcloud_octomap_updater_core SHARED
             src/pointcloud_octomap_updater.cpp)
 set_target_properties(moveit_pointcloud_octomap_updater_core
                       PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-ament_target_dependencies(
-  moveit_pointcloud_octomap_updater_core
+target_link_libraries(moveit_pointcloud_octomap_updater_core
+  PUBLIC
   rclcpp
   moveit_core
   tf2_ros
@@ -24,8 +24,8 @@ set_target_properties(
 add_library(moveit_pointcloud_octomap_updater SHARED src/plugin_init.cpp)
 set_target_properties(moveit_pointcloud_octomap_updater
                       PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-ament_target_dependencies(
-  moveit_pointcloud_octomap_updater
+target_link_libraries(moveit_pointcloud_octomap_updater
+  PUBLIC
   rclcpp
   moveit_core
   tf2_ros

--- a/moveit_ros/perception/semantic_world/CMakeLists.txt
+++ b/moveit_ros/perception/semantic_world/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_library(moveit_semantic_world SHARED src/semantic_world.cpp)
 set_target_properties(moveit_semantic_world
                       PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-ament_target_dependencies(
+target_link_libraries(
   moveit_semantic_world
   PUBLIC
   rclcpp

--- a/moveit_ros/planning/collision_plugin_loader/CMakeLists.txt
+++ b/moveit_ros/planning/collision_plugin_loader/CMakeLists.txt
@@ -2,7 +2,7 @@ add_library(moveit_collision_plugin_loader SHARED
             src/collision_plugin_loader.cpp)
 set_target_properties(moveit_collision_plugin_loader
                       PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-ament_target_dependencies(moveit_collision_plugin_loader moveit_core rclcpp
-                          pluginlib)
+target_link_libraries(moveit_collision_plugin_loader PUBLIC
+                      moveit_core rclcpp pluginlib)
 
 install(DIRECTORY include/ DESTINATION include/moveit_ros_planning)

--- a/moveit_ros/planning/constraint_sampler_manager_loader/CMakeLists.txt
+++ b/moveit_ros/planning/constraint_sampler_manager_loader/CMakeLists.txt
@@ -3,8 +3,8 @@ add_library(moveit_constraint_sampler_manager_loader SHARED
 
 set_target_properties(moveit_constraint_sampler_manager_loader
                       PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-ament_target_dependencies(moveit_constraint_sampler_manager_loader moveit_core
-                          rclcpp Boost pluginlib)
+target_link_libraries(moveit_constraint_sampler_manager_loader PUBLIC
+                      moveit_core rclcpp Boost pluginlib)
 target_link_libraries(moveit_constraint_sampler_manager_loader
                       moveit_rdf_loader)
 

--- a/moveit_ros/planning/kinematics_plugin_loader/CMakeLists.txt
+++ b/moveit_ros/planning/kinematics_plugin_loader/CMakeLists.txt
@@ -2,8 +2,8 @@ add_library(moveit_kinematics_plugin_loader SHARED
             src/kinematics_plugin_loader.cpp)
 set_target_properties(moveit_kinematics_plugin_loader
                       PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-ament_target_dependencies(moveit_kinematics_plugin_loader rclcpp urdf pluginlib
-                          class_loader moveit_core)
+target_link_libraries(moveit_kinematics_plugin_loader PUBLIC
+                      rclcpp urdf pluginlib class_loader moveit_core)
 
 generate_parameter_library(
   kinematics_parameters # cmake target name for the parameter library

--- a/moveit_ros/planning/moveit_cpp/CMakeLists.txt
+++ b/moveit_ros/planning/moveit_cpp/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_library(moveit_cpp SHARED src/moveit_cpp.cpp src/planning_component.cpp)
 set_target_properties(moveit_cpp PROPERTIES VERSION
                                             "${${PROJECT_NAME}_VERSION}")
-ament_target_dependencies(moveit_cpp rclcpp moveit_core)
+target_link_libraries(moveit_cpp PUBLIC rclcpp moveit_core)
 target_link_libraries(
   moveit_cpp moveit_planning_scene_monitor moveit_planning_pipeline
   moveit_planning_pipeline_interfaces moveit_trajectory_execution_manager)

--- a/moveit_ros/planning/plan_execution/CMakeLists.txt
+++ b/moveit_ros/planning/plan_execution/CMakeLists.txt
@@ -4,7 +4,7 @@ set_target_properties(moveit_plan_execution
 target_link_libraries(
   moveit_plan_execution moveit_planning_pipeline moveit_planning_scene_monitor
   moveit_trajectory_execution_manager)
-ament_target_dependencies(moveit_plan_execution moveit_core rclcpp Boost
-                          class_loader pluginlib)
+target_link_libraries(moveit_plan_execution PUBLIC
+                      moveit_core rclcpp Boost class_loader pluginlib)
 
 install(DIRECTORY include/ DESTINATION include/moveit_ros_planning)

--- a/moveit_ros/planning/planning_components_tools/CMakeLists.txt
+++ b/moveit_ros/planning/planning_components_tools/CMakeLists.txt
@@ -6,30 +6,30 @@ add_executable(moveit_print_planning_model_info
                src/print_planning_model_info.cpp)
 target_link_libraries(moveit_print_planning_model_info
                       moveit_robot_model_loader)
-ament_target_dependencies(moveit_print_planning_model_info rclcpp)
+target_link_libraries(moveit_print_planning_model_info PUBLIC rclcpp)
 
 add_executable(moveit_print_planning_scene_info
                src/print_planning_scene_info.cpp)
 target_link_libraries(moveit_print_planning_scene_info
                       moveit_planning_scene_monitor)
-ament_target_dependencies(moveit_print_planning_scene_info rclcpp)
+target_link_libraries(moveit_print_planning_scene_info PUBLIC rclcpp)
 
 add_executable(moveit_display_random_state src/display_random_state.cpp)
 target_link_libraries(moveit_display_random_state moveit_planning_scene_monitor)
-ament_target_dependencies(moveit_display_random_state rclcpp)
+target_link_libraries(moveit_display_random_state PUBLIC rclcpp)
 
 add_executable(moveit_visualize_robot_collision_volume
                src/visualize_robot_collision_volume.cpp)
 target_link_libraries(moveit_visualize_robot_collision_volume
                       PRIVATE moveit_planning_scene_monitor)
-ament_target_dependencies(moveit_visualize_robot_collision_volume PUBLIC rclcpp
-                          tf2_ros)
+target_link_libraries(moveit_visualize_robot_collision_volume PUBLIC
+                      rclcpp tf2_ros)
 
 add_executable(moveit_evaluate_collision_checking_speed
                src/evaluate_collision_checking_speed.cpp)
 target_link_libraries(moveit_evaluate_collision_checking_speed
                       moveit_planning_scene_monitor)
-ament_target_dependencies(moveit_evaluate_collision_checking_speed rclcpp Boost)
+target_link_libraries(moveit_evaluate_collision_checking_speed PUBLIC rclcpp Boost)
 
 if("${catkin_LIBRARIES}" MATCHES "moveit_collision_detection_bullet")
   add_executable(moveit_compare_collision_checking_speed_fcl_bullet
@@ -43,7 +43,7 @@ add_executable(moveit_publish_scene_from_text src/publish_scene_from_text.cpp)
 target_link_libraries(
   moveit_publish_scene_from_text PRIVATE moveit_planning_scene_monitor
                                          moveit_robot_model_loader)
-ament_target_dependencies(moveit_publish_scene_from_text PUBLIC rclcpp)
+target_link_libraries(moveit_publish_scene_from_text PUBLIC rclcpp)
 
 install(
   TARGETS moveit_print_planning_model_info

--- a/moveit_ros/planning/planning_pipeline/CMakeLists.txt
+++ b/moveit_ros/planning/planning_pipeline/CMakeLists.txt
@@ -11,8 +11,8 @@ target_include_directories(
 set_target_properties(moveit_planning_pipeline
                       PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 
-ament_target_dependencies(moveit_planning_pipeline moveit_core moveit_msgs
-                          rclcpp pluginlib)
+target_link_libraries(moveit_planning_pipeline PUBLIC
+                      moveit_core moveit_msgs rclcpp pluginlib)
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)

--- a/moveit_ros/planning/planning_pipeline_interfaces/CMakeLists.txt
+++ b/moveit_ros/planning/planning_pipeline_interfaces/CMakeLists.txt
@@ -13,8 +13,8 @@ set_target_properties(moveit_planning_pipeline_interfaces
 target_link_libraries(moveit_planning_pipeline_interfaces
                       moveit_planning_pipeline)
 
-ament_target_dependencies(moveit_planning_pipeline_interfaces moveit_core
-                          moveit_msgs rclcpp)
+target_link_libraries(moveit_planning_pipeline_interfaces PUBLIC
+                      moveit_core moveit_msgs rclcpp)
 
 install(DIRECTORY include/ DESTINATION include/moveit_ros_planning)
 install(

--- a/moveit_ros/planning/planning_request_adapter_plugins/CMakeLists.txt
+++ b/moveit_ros/planning/planning_request_adapter_plugins/CMakeLists.txt
@@ -12,8 +12,8 @@ target_link_libraries(moveit_default_planning_request_adapter_plugins
 
 set_target_properties(moveit_default_planning_request_adapter_plugins
                       PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-ament_target_dependencies(moveit_default_planning_request_adapter_plugins
-                          moveit_core rclcpp pluginlib)
+target_link_libraries(moveit_default_planning_request_adapter_plugins PUBLIC
+                      moveit_core rclcpp pluginlib)
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)

--- a/moveit_ros/planning/planning_response_adapter_plugins/CMakeLists.txt
+++ b/moveit_ros/planning/planning_response_adapter_plugins/CMakeLists.txt
@@ -11,5 +11,5 @@ target_link_libraries(moveit_default_planning_response_adapter_plugins
 
 set_target_properties(moveit_default_planning_response_adapter_plugins
                       PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-ament_target_dependencies(moveit_default_planning_response_adapter_plugins
-                          Boost moveit_core rclcpp pluginlib)
+target_link_libraries(moveit_default_planning_response_adapter_plugins PUBLIC
+                      Boost moveit_core rclcpp pluginlib)

--- a/moveit_ros/planning/planning_scene_monitor/CMakeLists.txt
+++ b/moveit_ros/planning/planning_scene_monitor/CMakeLists.txt
@@ -10,8 +10,8 @@ target_include_directories(
   PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
 set_target_properties(moveit_planning_scene_monitor
                       PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-ament_target_dependencies(
-  moveit_planning_scene_monitor
+target_link_libraries(moveit_planning_scene_monitor
+  PUBLIC
   moveit_ros_occupancy_map_monitor
   message_filters
   urdf
@@ -23,7 +23,7 @@ target_link_libraries(moveit_planning_scene_monitor moveit_robot_model_loader
                       moveit_collision_plugin_loader)
 
 add_executable(demo_scene demos/demo_scene.cpp)
-ament_target_dependencies(
+target_link_libraries(
   demo_scene
   PUBLIC
   rclcpp

--- a/moveit_ros/planning/rdf_loader/CMakeLists.txt
+++ b/moveit_ros/planning/rdf_loader/CMakeLists.txt
@@ -2,8 +2,8 @@ add_library(moveit_rdf_loader SHARED src/rdf_loader.cpp
                                      src/synchronized_string_parameter.cpp)
 set_target_properties(moveit_rdf_loader PROPERTIES VERSION
                                                    "${${PROJECT_NAME}_VERSION}")
-ament_target_dependencies(moveit_rdf_loader rclcpp ament_index_cpp urdf srdfdom
-                          moveit_core)
+target_link_libraries(moveit_rdf_loader PUBLIC
+                      rclcpp ament_index_cpp urdf srdfdom moveit_core)
 
 install(DIRECTORY include/ DESTINATION include/moveit_ros_planning)
 install(DIRECTORY test/data test/launch

--- a/moveit_ros/planning/robot_model_loader/CMakeLists.txt
+++ b/moveit_ros/planning/robot_model_loader/CMakeLists.txt
@@ -5,8 +5,8 @@ endif()
 add_library(moveit_robot_model_loader SHARED src/robot_model_loader.cpp)
 set_target_properties(moveit_robot_model_loader
                       PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-ament_target_dependencies(moveit_robot_model_loader rclcpp urdf Boost
-                          moveit_core moveit_msgs)
+target_link_libraries(moveit_robot_model_loader PUBLIC
+                      rclcpp urdf Boost moveit_core moveit_msgs)
 target_link_libraries(moveit_robot_model_loader moveit_rdf_loader
                       moveit_kinematics_plugin_loader)
 

--- a/moveit_ros/planning/srdf_publisher_node/CMakeLists.txt
+++ b/moveit_ros/planning/srdf_publisher_node/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_library(srdf_publisher_node SHARED src/srdf_publisher_node.cpp)
-ament_target_dependencies(srdf_publisher_node PUBLIC std_msgs rclcpp
-                          rclcpp_components)
+target_link_libraries(srdf_publisher_node PUBLIC
+                      std_msgs rclcpp rclcpp_components)
 
 if(BUILD_TESTING)
   find_package(launch_testing_ament_cmake REQUIRED)

--- a/moveit_ros/planning/trajectory_execution_manager/CMakeLists.txt
+++ b/moveit_ros/planning/trajectory_execution_manager/CMakeLists.txt
@@ -7,8 +7,8 @@ target_include_directories(
   PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
 set_target_properties(moveit_trajectory_execution_manager
                       PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-ament_target_dependencies(
-  moveit_trajectory_execution_manager
+target_link_libraries(moveit_trajectory_execution_manager
+  PUBLIC
   moveit_core
   moveit_ros_occupancy_map_monitor
   rclcpp

--- a/moveit_ros/planning_interface/common_planning_interface_objects/CMakeLists.txt
+++ b/moveit_ros/planning_interface/common_planning_interface_objects/CMakeLists.txt
@@ -2,7 +2,7 @@ add_library(moveit_common_planning_interface_objects SHARED
             src/common_objects.cpp)
 set_target_properties(moveit_common_planning_interface_objects
                       PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-ament_target_dependencies(moveit_common_planning_interface_objects rclcpp
-                          moveit_ros_planning tf2_ros)
+target_link_libraries(moveit_common_planning_interface_objects PUBLIC
+                      rclcpp moveit_ros_planning tf2_ros)
 
 install(DIRECTORY include/ DESTINATION include/moveit_ros_planning_interface)

--- a/moveit_ros/planning_interface/move_group_interface/CMakeLists.txt
+++ b/moveit_ros/planning_interface/move_group_interface/CMakeLists.txt
@@ -9,8 +9,8 @@ set_target_properties(moveit_move_group_interface
 target_link_libraries(
   moveit_move_group_interface moveit_common_planning_interface_objects
   moveit_planning_scene_interface ${Boost_THREAD_LIBRARY})
-ament_target_dependencies(
-  moveit_move_group_interface
+target_link_libraries(moveit_move_group_interface
+  PUBLIC
   moveit_core
   moveit_msgs
   moveit_ros_move_group

--- a/moveit_ros/planning_interface/planning_scene_interface/CMakeLists.txt
+++ b/moveit_ros/planning_interface/planning_scene_interface/CMakeLists.txt
@@ -2,8 +2,8 @@ add_library(moveit_planning_scene_interface SHARED
             src/planning_scene_interface.cpp)
 set_target_properties(moveit_planning_scene_interface
                       PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-ament_target_dependencies(moveit_planning_scene_interface moveit_msgs
-                          moveit_core moveit_ros_move_group)
+target_link_libraries(moveit_planning_scene_interface PUBLIC
+                      moveit_msgs moveit_core moveit_ros_move_group)
 
 # TODO(JafarAbdi): Support python wrapper
 # add_library(moveit_planning_scene_interface_python

--- a/moveit_ros/robot_interaction/CMakeLists.txt
+++ b/moveit_ros/robot_interaction/CMakeLists.txt
@@ -32,8 +32,8 @@ target_include_directories(
 set_target_properties(
   moveit_robot_interaction PROPERTIES VERSION
                                       "${moveit_ros_robot_interaction_VERSION}")
-ament_target_dependencies(moveit_robot_interaction
-                          ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(moveit_robot_interaction PUBLIC
+                      ${THIS_PACKAGE_INCLUDE_DEPENDS})
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)

--- a/moveit_ros/trajectory_cache/CMakeLists.txt
+++ b/moveit_ros/trajectory_cache/CMakeLists.txt
@@ -41,8 +41,8 @@ target_include_directories(
   moveit_ros_trajectory_cache_utils_lib
   PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
          $<INSTALL_INTERFACE:include/moveit_ros_trajectory_cache>)
-ament_target_dependencies(moveit_ros_trajectory_cache_utils_lib
-                          ${TRAJECTORY_CACHE_DEPENDENCIES})
+target_link_libraries(moveit_ros_trajectory_cache_utils_lib PUBLIC
+                      ${TRAJECTORY_CACHE_DEPENDENCIES})
 
 # Features library
 add_library(
@@ -56,8 +56,8 @@ target_include_directories(
   moveit_ros_trajectory_cache_features_lib
   PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
          $<INSTALL_INTERFACE:include/moveit_ros_trajectory_cache>)
-ament_target_dependencies(moveit_ros_trajectory_cache_features_lib
-                          ${TRAJECTORY_CACHE_DEPENDENCIES})
+target_link_libraries(moveit_ros_trajectory_cache_features_lib PUBLIC
+                      ${TRAJECTORY_CACHE_DEPENDENCIES})
 
 # Cache insert policies library
 add_library(
@@ -73,8 +73,8 @@ target_include_directories(
   moveit_ros_trajectory_cache_cache_insert_policies_lib
   PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
          $<INSTALL_INTERFACE:include/moveit_ros_trajectory_cache>)
-ament_target_dependencies(moveit_ros_trajectory_cache_cache_insert_policies_lib
-                          ${TRAJECTORY_CACHE_DEPENDENCIES})
+target_link_libraries(moveit_ros_trajectory_cache_cache_insert_policies_lib PUBLIC
+                      ${TRAJECTORY_CACHE_DEPENDENCIES})
 
 # Trajectory cache library
 add_library(moveit_ros_trajectory_cache_lib SHARED src/trajectory_cache.cpp)
@@ -88,8 +88,8 @@ target_include_directories(
   moveit_ros_trajectory_cache_lib
   PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
          $<INSTALL_INTERFACE:include/moveit_ros_trajectory_cache>)
-ament_target_dependencies(moveit_ros_trajectory_cache_lib
-                          ${TRAJECTORY_CACHE_DEPENDENCIES})
+target_link_libraries(moveit_ros_trajectory_cache_lib PUBLIC
+                      ${TRAJECTORY_CACHE_DEPENDENCIES})
 
 install(
   TARGETS ${TRAJECTORY_CACHE_LIBRARIES}

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/CMakeLists.txt
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/CMakeLists.txt
@@ -31,8 +31,8 @@ set_target_properties(moveit_motion_planning_rviz_plugin_core
 target_link_libraries(
   moveit_motion_planning_rviz_plugin_core moveit_rviz_plugin_render_tools
   moveit_planning_scene_rviz_plugin)
-ament_target_dependencies(
-  moveit_motion_planning_rviz_plugin_core
+target_link_libraries(moveit_motion_planning_rviz_plugin_core
+  PUBLIC
   moveit_ros_robot_interaction
   moveit_ros_planning_interface
   moveit_ros_warehouse
@@ -48,9 +48,8 @@ set_target_properties(moveit_motion_planning_rviz_plugin
                       PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 target_link_libraries(moveit_motion_planning_rviz_plugin
                       moveit_motion_planning_rviz_plugin_core)
-ament_target_dependencies(
-  moveit_motion_planning_rviz_plugin moveit_ros_robot_interaction
-  moveit_ros_warehouse pluginlib rviz_ogre_vendor)
+target_link_libraries(moveit_motion_planning_rviz_plugin  PUBLIC
+  moveit_ros_robot_interaction moveit_ros_warehouse pluginlib rviz_ogre_vendor)
 target_include_directories(moveit_motion_planning_rviz_plugin
                            PRIVATE "${OGRE_PREFIX_DIR}/include")
 

--- a/moveit_ros/visualization/planning_scene_rviz_plugin/CMakeLists.txt
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/CMakeLists.txt
@@ -11,8 +11,8 @@ set_target_properties(moveit_planning_scene_rviz_plugin_core
                       PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 target_link_libraries(moveit_planning_scene_rviz_plugin_core
                       moveit_rviz_plugin_render_tools)
-ament_target_dependencies(
-  moveit_planning_scene_rviz_plugin_core
+target_link_libraries(moveit_planning_scene_rviz_plugin_core
+  PUBLIC
   rclcpp
   rviz2
   moveit_ros_planning_interface
@@ -28,8 +28,8 @@ set_target_properties(moveit_planning_scene_rviz_plugin
                       PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 target_link_libraries(moveit_planning_scene_rviz_plugin
                       moveit_planning_scene_rviz_plugin_core Qt5::Widgets)
-ament_target_dependencies(moveit_planning_scene_rviz_plugin pluginlib
-                          rviz_ogre_vendor)
+target_link_libraries(moveit_planning_scene_rviz_plugin PUBLIC
+                      pluginlib rviz_ogre_vendor)
 target_include_directories(moveit_planning_scene_rviz_plugin
                            PRIVATE "${OGRE_PREFIX_DIR}/include")
 

--- a/moveit_ros/visualization/robot_state_rviz_plugin/CMakeLists.txt
+++ b/moveit_ros/visualization/robot_state_rviz_plugin/CMakeLists.txt
@@ -6,8 +6,8 @@ set_target_properties(moveit_robot_state_rviz_plugin_core
                       PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 target_link_libraries(moveit_robot_state_rviz_plugin_core
                       moveit_rviz_plugin_render_tools)
-ament_target_dependencies(
-  moveit_robot_state_rviz_plugin_core
+target_link_libraries(moveit_robot_state_rviz_plugin_core
+  PUBLIC
   rclcpp
   rviz2
   moveit_ros_planning
@@ -23,8 +23,8 @@ set_target_properties(moveit_robot_state_rviz_plugin
                       PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 target_link_libraries(moveit_robot_state_rviz_plugin
                       moveit_robot_state_rviz_plugin_core)
-ament_target_dependencies(moveit_robot_state_rviz_plugin rclcpp pluginlib Boost
-                          rviz_ogre_vendor)
+target_link_libraries(moveit_robot_state_rviz_plugin PUBLIC
+                      rclcpp pluginlib Boost rviz_ogre_vendor)
 target_include_directories(moveit_robot_state_rviz_plugin
                            PRIVATE "${OGRE_PREFIX_DIR}/include")
 

--- a/moveit_ros/visualization/rviz_plugin_render_tools/CMakeLists.txt
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/CMakeLists.txt
@@ -26,8 +26,8 @@ set_target_properties(moveit_rviz_plugin_render_tools
 
 target_link_libraries(moveit_rviz_plugin_render_tools Qt5::Widgets)
 
-ament_target_dependencies(
-  moveit_rviz_plugin_render_tools
+target_link_libraries(moveit_rviz_plugin_render_tools
+  PUBLIC
   rclcpp
   moveit_core
   Boost

--- a/moveit_ros/visualization/trajectory_rviz_plugin/CMakeLists.txt
+++ b/moveit_ros/visualization/trajectory_rviz_plugin/CMakeLists.txt
@@ -12,8 +12,8 @@ target_link_libraries(
   moveit_trajectory_rviz_plugin_core moveit_rviz_plugin_render_tools
   moveit_planning_scene_rviz_plugin_core rviz_ogre_vendor::OgreMain)
 
-ament_target_dependencies(
-  moveit_trajectory_rviz_plugin_core
+target_link_libraries(moveit_trajectory_rviz_plugin_core
+  PUBLIC
   rclcpp
   rviz2
   moveit_msgs
@@ -29,8 +29,8 @@ set_target_properties(moveit_trajectory_rviz_plugin
                       PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 target_link_libraries(moveit_trajectory_rviz_plugin
                       moveit_trajectory_rviz_plugin_core)
-ament_target_dependencies(moveit_trajectory_rviz_plugin rclcpp pluginlib Boost
-                          rviz_ogre_vendor)
+target_link_libraries(moveit_trajectory_rviz_plugin PUBLIC
+                      rclcpp pluginlib Boost rviz_ogre_vendor)
 target_include_directories(moveit_trajectory_rviz_plugin
                            PRIVATE "${OGRE_PREFIX_DIR}/include")
 

--- a/moveit_ros/warehouse/CMakeLists.txt
+++ b/moveit_ros/warehouse/CMakeLists.txt
@@ -45,37 +45,37 @@ target_include_directories(
   moveit_warehouse PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
 set_target_properties(moveit_warehouse
                       PROPERTIES VERSION "${moveit_ros_warehouse_VERSION}")
-ament_target_dependencies(moveit_warehouse ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(moveit_warehouse PUBLIC ${THIS_PACKAGE_INCLUDE_DEPENDS})
 
 # Executables
 add_executable(moveit_warehouse_broadcast src/broadcast.cpp)
-ament_target_dependencies(moveit_warehouse_broadcast
-                          ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(moveit_warehouse_broadcast PUBLIC
+                      ${THIS_PACKAGE_INCLUDE_DEPENDS})
 target_link_libraries(moveit_warehouse_broadcast moveit_warehouse)
 
 add_executable(moveit_save_to_warehouse src/save_to_warehouse.cpp)
-ament_target_dependencies(moveit_save_to_warehouse
-                          ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(moveit_save_to_warehouse PUBLIC
+                      ${THIS_PACKAGE_INCLUDE_DEPENDS})
 target_link_libraries(moveit_save_to_warehouse moveit_warehouse fmt)
 
 add_executable(moveit_warehouse_import_from_text src/import_from_text.cpp)
-ament_target_dependencies(moveit_warehouse_import_from_text
-                          ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(moveit_warehouse_import_from_text PUBLIC
+                      ${THIS_PACKAGE_INCLUDE_DEPENDS})
 target_link_libraries(moveit_warehouse_import_from_text moveit_warehouse)
 
 add_executable(moveit_warehouse_save_as_text src/save_as_text.cpp)
-ament_target_dependencies(moveit_warehouse_save_as_text
-                          ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(moveit_warehouse_save_as_text PUBLIC
+                      ${THIS_PACKAGE_INCLUDE_DEPENDS})
 target_link_libraries(moveit_warehouse_save_as_text moveit_warehouse)
 
 add_executable(moveit_init_demo_warehouse src/initialize_demo_db.cpp)
-ament_target_dependencies(moveit_init_demo_warehouse
-                          ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(moveit_init_demo_warehouse PUBLIC
+                      ${THIS_PACKAGE_INCLUDE_DEPENDS})
 target_link_libraries(moveit_init_demo_warehouse moveit_warehouse)
 
 add_executable(moveit_warehouse_services src/warehouse_services.cpp)
-ament_target_dependencies(moveit_warehouse_services
-                          ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(moveit_warehouse_services PUBLIC
+                      ${THIS_PACKAGE_INCLUDE_DEPENDS})
 target_link_libraries(moveit_warehouse_services moveit_warehouse)
 
 install(

--- a/moveit_setup_assistant/moveit_setup_app_plugins/CMakeLists.txt
+++ b/moveit_setup_assistant/moveit_setup_app_plugins/CMakeLists.txt
@@ -33,9 +33,8 @@ target_include_directories(
   moveit_setup_app_plugins
   PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
          $<INSTALL_INTERFACE:include/moveit_setup_app_plugins>)
-ament_target_dependencies(
-  moveit_setup_app_plugins ament_index_cpp moveit_ros_visualization
-  moveit_setup_framework pluginlib rclcpp)
+target_link_libraries(moveit_setup_app_plugins PUBLIC
+    ament_index_cpp moveit_ros_visualization moveit_setup_framework pluginlib rclcpp)
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)

--- a/moveit_setup_assistant/moveit_setup_assistant/CMakeLists.txt
+++ b/moveit_setup_assistant/moveit_setup_assistant/CMakeLists.txt
@@ -41,8 +41,8 @@ target_include_directories(
   moveit_setup_assistant
   PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
          $<INSTALL_INTERFACE:include/moveit_setup_assistant>)
-ament_target_dependencies(moveit_setup_assistant
-                          ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(moveit_setup_assistant PUBLIC
+                      ${THIS_PACKAGE_INCLUDE_DEPENDS})
 target_link_libraries(moveit_setup_assistant ${Boost_LIBRARIES})
 
 add_executable(moveit_setup_assistant_updater src/collisions_updater.cpp)
@@ -51,8 +51,8 @@ target_include_directories(
   PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
          $<INSTALL_INTERFACE:include/moveit_setup_assistant>)
 
-ament_target_dependencies(moveit_setup_assistant_updater
-                          ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(moveit_setup_assistant_updater PUBLIC
+                      ${THIS_PACKAGE_INCLUDE_DEPENDS})
 
 set_target_properties(moveit_setup_assistant_updater
                       PROPERTIES OUTPUT_NAME collisions_updater PREFIX "")

--- a/moveit_setup_assistant/moveit_setup_controllers/CMakeLists.txt
+++ b/moveit_setup_assistant/moveit_setup_controllers/CMakeLists.txt
@@ -40,8 +40,8 @@ target_include_directories(
   moveit_setup_controllers
   PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
          $<INSTALL_INTERFACE:include/moveit_setup_controllers>)
-ament_target_dependencies(moveit_setup_controllers ament_index_cpp
-                          moveit_setup_framework pluginlib rclcpp)
+target_link_libraries(moveit_setup_controllers PUBLIC
+                      ament_index_cpp moveit_setup_framework pluginlib rclcpp)
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)

--- a/moveit_setup_assistant/moveit_setup_core_plugins/CMakeLists.txt
+++ b/moveit_setup_assistant/moveit_setup_core_plugins/CMakeLists.txt
@@ -36,8 +36,8 @@ add_library(
 target_include_directories(
   ${PROJECT_NAME} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
                          $<INSTALL_INTERFACE:include/moveit_setup_core_plugins>)
-ament_target_dependencies(
-  ${PROJECT_NAME}
+target_link_libraries(${PROJECT_NAME}
+  PUBLIC
   ament_index_cpp
   moveit_ros_visualization
   moveit_setup_framework

--- a/moveit_setup_assistant/moveit_setup_framework/CMakeLists.txt
+++ b/moveit_setup_assistant/moveit_setup_framework/CMakeLists.txt
@@ -47,8 +47,8 @@ target_include_directories(
   moveit_setup_framework
   PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
          $<INSTALL_INTERFACE:include/moveit_setup_framework>)
-ament_target_dependencies(
-  moveit_setup_framework
+target_link_libraries(moveit_setup_framework
+  PUBLIC
   ament_index_cpp
   moveit_core
   moveit_ros_planning

--- a/moveit_setup_assistant/moveit_setup_srdf_plugins/CMakeLists.txt
+++ b/moveit_setup_assistant/moveit_setup_srdf_plugins/CMakeLists.txt
@@ -50,8 +50,7 @@ target_include_directories(
   moveit_setup_srdf_plugins
   PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
          $<INSTALL_INTERFACE:include/moveit_setup_srdf_plugins>)
-ament_target_dependencies(moveit_setup_srdf_plugins moveit_setup_framework
-                          pluginlib)
+target_link_libraries(moveit_setup_srdf_plugins PUBLIC moveit_setup_framework pluginlib)
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)


### PR DESCRIPTION
As of the ROS 2 Kilted release [`ament_target_dependencies` is deprecated.](https://docs.ros.org/en/kilted/Releases/Release-Kilted-Kaiju.html#ament-target-dependencies-is-deprecated)

This PR updates the syntax. Caution should be used to ensure that the target branch is not used for other ROS 2 distros.

Note: This PR was generated by a bot script, but using the simple pattern matching of the [`ros_glint`](https://github.com/MetroRobots/ros_glint) library. No LLMs were used.
