### PR TITLE
Remove gripper_controllers dependency

### DIFF
--- a/moveit_ros/moveit_servo/package.xml
+++ b/moveit_ros/moveit_servo/package.xml
@@ -39,7 +39,6 @@
   <depend>trajectory_msgs</depend>
 
   <exec_depend>controller_manager</exec_depend>
-  <exec_depend>gripper_controllers</exec_depend>
   <exec_depend>joint_state_broadcaster</exec_depend>
   <exec_depend>joint_trajectory_controller</exec_depend>
   <exec_depend>joy</exec_depend>


### PR DESCRIPTION
The package got removed upstream in https://github.com/ros-controls/ros2_controllers/pull/1652. Find_packageing this on Kilted or Rolling will lead to errors from the next sync on.