### PR TITLE
Update planning_scene.cpp

### DIFF
--- a/moveit_py/src/moveit/moveit_core/planning_scene/planning_scene.cpp
+++ b/moveit_py/src/moveit/moveit_core/planning_scene/planning_scene.cpp
@@ -246,7 +246,27 @@ void initPlanningScene(py::module& m)
            Removes collision objects from the planning scene.
            This method will remove all collision object from the scene except for attached collision objects.
            )")
+	
+      .def("set_current_state",
+           py::overload_cast<const moveit_msgs::msg::RobotState&>(&planning_scene::PlanningScene::setCurrentState),
+           py::arg("robot_state"),
+           R"(
+           Set the current state using a moveit_msgs::msg::RobotState message.
 
+           Args:
+           robot_state (moveit_msgs.msg.RobotState): The robot state message to set as current state.
+           )")
+
+      .def("set_current_state",
+           py::overload_cast<const moveit::core::RobotState&>(&planning_scene::PlanningScene::setCurrentState),
+           py::arg("robot_state"),
+           R"(
+           Set the current state using a moveit::core::RobotState object.
+
+           Args:
+           robot_state (moveit_py.core.RobotState): The robot state object to set as current state.
+           )")
+	
       // checking state validity
       .def("is_state_valid",
            py::overload_cast<const moveit::core::RobotState&, const std::string&, bool>(

--- a/moveit_py/src/moveit/moveit_core/planning_scene/planning_scene.cpp
+++ b/moveit_py/src/moveit/moveit_core/planning_scene/planning_scene.cpp
@@ -246,7 +246,7 @@ void initPlanningScene(py::module& m)
            Removes collision objects from the planning scene.
            This method will remove all collision object from the scene except for attached collision objects.
            )")
-	
+
       .def("set_current_state",
            py::overload_cast<const moveit_msgs::msg::RobotState&>(&planning_scene::PlanningScene::setCurrentState),
            py::arg("robot_state"),
@@ -266,7 +266,7 @@ void initPlanningScene(py::module& m)
            Args:
            robot_state (moveit_py.core.RobotState): The robot state object to set as current state.
            )")
-	
+
       // checking state validity
       .def("is_state_valid",
            py::overload_cast<const moveit::core::RobotState&, const std::string&, bool>(


### PR DESCRIPTION
### Description

This PR adds and documents Python bindings for setting the current robot state in the PlanningScene class.
See also [Discussion  #MTC](https://github.com/moveit/moveit_task_constructor/discussions/685)

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
