### PR TITLE
fix missing boost 

### DIFF
--- a/moveit_core/CMakeLists.txt
+++ b/moveit_core/CMakeLists.txt
@@ -7,6 +7,7 @@ moveit_package()
 
 find_package(ament_cmake REQUIRED)
 find_package(angles REQUIRED)
+find_package(Boost REQUIRED COMPONENTS random filesystem)
 find_package(Bullet 2.87 REQUIRED)
 find_package(common_interfaces REQUIRED)
 find_package(eigen_stl_containers REQUIRED)

--- a/moveit_kinematics/CMakeLists.txt
+++ b/moveit_kinematics/CMakeLists.txt
@@ -6,7 +6,7 @@ find_package(moveit_common REQUIRED)
 moveit_package()
 
 find_package(ament_cmake REQUIRED)
-
+find_package(Boost REQUIRED system random)
 find_package(Eigen3 REQUIRED)
 find_package(class_loader REQUIRED)
 find_package(generate_parameter_library REQUIRED)

--- a/moveit_planners/chomp/chomp_interface/CMakeLists.txt
+++ b/moveit_planners/chomp/chomp_interface/CMakeLists.txt
@@ -7,6 +7,7 @@ moveit_package()
 
 # find dependencies
 find_package(ament_cmake REQUIRED)
+find_package(Boost REQUIRED COMPONENTS random filesystem)
 find_package(moveit_core REQUIRED)
 find_package(chomp_motion_planner REQUIRED)
 find_package(pluginlib REQUIRED)

--- a/moveit_planners/chomp/chomp_motion_planner/CMakeLists.txt
+++ b/moveit_planners/chomp/chomp_motion_planner/CMakeLists.txt
@@ -7,6 +7,7 @@ moveit_package()
 
 # find dependencies
 find_package(ament_cmake REQUIRED)
+find_package(Boost REQUIRED COMPONENTS random filesystem)
 find_package(moveit_core REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rsl REQUIRED)

--- a/moveit_planners/ompl/CMakeLists.txt
+++ b/moveit_planners/ompl/CMakeLists.txt
@@ -11,6 +11,7 @@ find_package(
   system
   filesystem
   date_time
+  random
   thread
   serialization)
 find_package(moveit_core REQUIRED)

--- a/moveit_planners/pilz_industrial_motion_planner_testutils/CMakeLists.txt
+++ b/moveit_planners/pilz_industrial_motion_planner_testutils/CMakeLists.txt
@@ -6,6 +6,7 @@ find_package(moveit_common REQUIRED)
 moveit_package()
 
 find_package(ament_cmake REQUIRED)
+find_package(Boost REQUIRED COMPONENTS random filesystem)
 find_package(rclcpp REQUIRED)
 find_package(moveit_core REQUIRED)
 find_package(moveit_msgs REQUIRED)

--- a/moveit_planners/stomp/CMakeLists.txt
+++ b/moveit_planners/stomp/CMakeLists.txt
@@ -7,6 +7,7 @@ moveit_package()
 
 # find dependencies
 find_package(ament_cmake REQUIRED)
+find_package(Boost REQUIRED COMPONENTS random filesystem)
 find_package(generate_parameter_library REQUIRED)
 find_package(moveit_core REQUIRED)
 find_package(std_msgs REQUIRED)

--- a/moveit_planners/test_configs/prbt_ikfast_manipulator_plugin/CMakeLists.txt
+++ b/moveit_planners/test_configs/prbt_ikfast_manipulator_plugin/CMakeLists.txt
@@ -18,6 +18,7 @@ if(CMAKE_COMPILER_IS_GNUCXX)
 endif()
 
 find_package(ament_cmake REQUIRED)
+find_package(Boost REQUIRED COMPONENTS random filesystem)
 find_package(moveit_core REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(rclcpp REQUIRED)

--- a/moveit_plugins/moveit_ros_control_interface/CMakeLists.txt
+++ b/moveit_plugins/moveit_ros_control_interface/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.22)
 project(moveit_ros_control_interface LANGUAGES CXX)
 
 find_package(ament_cmake REQUIRED)
+find_package(Boost REQUIRED COMPONENTS random filesystem)
 
 set(THIS_PACKAGE_INCLUDE_DEPENDS
     rclcpp_action controller_manager_msgs moveit_core

--- a/moveit_plugins/moveit_simple_controller_manager/CMakeLists.txt
+++ b/moveit_plugins/moveit_simple_controller_manager/CMakeLists.txt
@@ -6,6 +6,7 @@ find_package(moveit_common REQUIRED)
 moveit_package()
 
 find_package(ament_cmake REQUIRED)
+find_package(Boost REQUIRED COMPONENTS random filesystem)
 find_package(moveit_core REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(rclcpp REQUIRED)

--- a/moveit_ros/move_group/ConfigExtras.cmake
+++ b/moveit_ros/move_group/ConfigExtras.cmake
@@ -3,6 +3,7 @@
 find_package(
   Boost
   REQUIRED
+  random
   system
   filesystem
   date_time

--- a/moveit_ros/occupancy_map_monitor/CMakeLists.txt
+++ b/moveit_ros/occupancy_map_monitor/CMakeLists.txt
@@ -9,6 +9,7 @@ if(APPLE)
   find_package(X11 REQUIRED)
 endif()
 
+find_package(Boost REQUIRED COMPONENTS random filesystem)
 find_package(moveit_core REQUIRED)
 find_package(moveit_msgs REQUIRED)
 find_package(pluginlib REQUIRED)

--- a/moveit_ros/perception/CMakeLists.txt
+++ b/moveit_ros/perception/CMakeLists.txt
@@ -3,6 +3,7 @@ project(moveit_ros_perception LANGUAGES CXX)
 
 # Common cmake code applied to all moveit packages
 find_package(moveit_common REQUIRED)
+find_package(Boost REQUIRED COMPONENTS random filesystem)
 moveit_package()
 
 option(WITH_OPENGL "Build the parts that depend on OpenGL" ON)

--- a/moveit_ros/planning/CMakeLists.txt
+++ b/moveit_ros/planning/CMakeLists.txt
@@ -7,6 +7,7 @@ moveit_package()
 
 find_package(ament_cmake REQUIRED)
 find_package(ament_index_cpp REQUIRED)
+find_package(Boost REQUIRED COMPONENTS random filesystem)
 find_package(Eigen3 REQUIRED)
 find_package(fmt REQUIRED)
 find_package(generate_parameter_library REQUIRED)

--- a/moveit_ros/robot_interaction/CMakeLists.txt
+++ b/moveit_ros/robot_interaction/CMakeLists.txt
@@ -5,6 +5,7 @@ project(moveit_ros_robot_interaction LANGUAGES CXX)
 find_package(moveit_common REQUIRED)
 moveit_package()
 
+find_package(Boost REQUIRED COMPONENTS random filesystem)
 find_package(moveit_core REQUIRED)
 find_package(moveit_ros_planning REQUIRED)
 find_package(interactive_markers REQUIRED)

--- a/moveit_ros/warehouse/ConfigExtras.cmake
+++ b/moveit_ros/warehouse/ConfigExtras.cmake
@@ -6,6 +6,7 @@ find_package(
   thread
   system
   filesystem
+  random
   regex
   date_time
   program_options)


### PR DESCRIPTION
### Description

When compiling Moveit on Ros Rolling and Ubuntu 25.05, the compilation fails due to missing Boost.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
