### PR TITLE
Removed unused funcion

### DIFF
--- a/moveit_setup_assistant/moveit_setup_srdf_plugins/include/moveit_setup_srdf_plugins/collision_linear_model.hpp
+++ b/moveit_setup_assistant/moveit_setup_srdf_plugins/include/moveit_setup_srdf_plugins/collision_linear_model.hpp
@@ -92,7 +92,6 @@ public:
   void setEnabled(const QItemSelection& selection, bool value);
 
 protected:
-  bool filterAcceptsRow(int source_row, const QModelIndex& source_parent) const override;
   bool lessThan(const QModelIndex& src_left, const QModelIndex& src_right) const override;
 
 private Q_SLOTS:

--- a/moveit_setup_assistant/moveit_setup_srdf_plugins/src/collision_linear_model.cpp
+++ b/moveit_setup_assistant/moveit_setup_srdf_plugins/src/collision_linear_model.cpp
@@ -257,20 +257,6 @@ void SortFilterProxyModel::setShowAll(bool show_all)
   invalidateFilter();
 }
 
-bool SortFilterProxyModel::filterAcceptsRow(int source_row, const QModelIndex& source_parent) const
-{
-  CollisionLinearModel* m = qobject_cast<CollisionLinearModel*>(sourceModel());
-  if (!show_all_ && m->reason(source_row) > ALWAYS &&
-      m->data(m->index(source_row, 2), Qt::CheckStateRole) != Qt::Checked)
-    return false;  // not accepted due to check state
-
-  const QRegExp regexp = filterRegExp();
-  if (regexp.isEmpty())
-    return true;
-
-  return m->data(m->index(source_row, 0, source_parent), Qt::DisplayRole).toString().contains(regexp) ||
-         m->data(m->index(source_row, 1, source_parent), Qt::DisplayRole).toString().contains(regexp);
-}
 
 // define a fallback comparison operator for QVariants
 bool compareVariants(const QVariant& left, const QVariant& right)


### PR DESCRIPTION

### Description

filteracceptRos is never used, QregExp is used inside and is deprecated in QT6

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
