### PR TITLE
moveit_ros_benchmarks: Require cxx_std_20 compile feature

### DIFF
--- a/moveit_ros/benchmarks/CMakeLists.txt
+++ b/moveit_ros/benchmarks/CMakeLists.txt
@@ -36,6 +36,7 @@ if(WIN32)
 endif()
 ament_target_dependencies(moveit_ros_benchmarks ${THIS_PACKAGE_INCLUDE_DEPENDS})
 target_link_libraries(moveit_ros_benchmarks ${EXTRA_LIB})
+target_compile_features(moveit_ros_benchmarks PRIVATE cxx_std_20)
 
 add_executable(moveit_run_benchmark src/RunBenchmark.cpp)
 ament_target_dependencies(moveit_run_benchmark ${THIS_PACKAGE_INCLUDE_DEPENDS})


### PR DESCRIPTION
### Description

Since https://github.com/moveit/moveit2/pull/1539 the `moveit_ros_benchmarks` library uses internally the designated initializers feature, that is only available in C++ 20 (see https://en.cppreference.com/w/cpp/language/aggregate_initialization.html#Designated_initializers). 

It seems that GCC and Clang permits to use designated initializers even in C++17 mode, but MSVC instead raise an error like:

~~~
2025-06-22T00:10:29.7938610Z  │ │ %SRC_DIR%\ros-kilted-moveit-ros-benchmarks\src\work\src\BenchmarkExecutor.cpp(811,9): error C7555: use of designated initializers requires at least '/std:c++20' [%SRC_DIR%\build\moveit_ros_benchmarks.vcxproj]
2025-06-22T00:10:29.8041863Z  │ │ %SRC_DIR%\ros-kilted-moveit-ros-benchmarks\src\work\src\BenchmarkExecutor.cpp(906,11): error C7555: use of designated initializers requires at least '/std:c++20' [%SRC_DIR%\build\moveit_ros_benchmarks.vcxproj]
~~~

see https://github.com/RoboStack/ros-kilted/actions/runs/15800837297/job/44538772389#step:6:3639 .

This PR fixes this by requesting the use at least of C++ 20 features with `target_compile_features(moveit_ros_benchmarks PRIVATE cxx_std_20)`.

### Checklist

- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [x] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
