### PR TITLE
Use && in place of and keyword in action_based_controller_handle.hpp

### DIFF
--- a/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/action_based_controller_handle.hpp
+++ b/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/action_based_controller_handle.hpp
@@ -145,7 +145,7 @@ public:
         do
         {
           status = result_future.wait_for(50ms);
-          if ((status == std::future_status::timeout) and ((node_->now() - start) > timeout))
+          if ((status == std::future_status::timeout) && ((node_->now() - start) > timeout))
           {
             RCLCPP_WARN(logger_, "waitForExecution timed out");
             return false;


### PR DESCRIPTION
### Description

While compiling this package on Windows (see https://github.com/RoboStack/ros-humble/pull/241 for a similar issue), the Windows compilation was failing as depending on the compilation options `and` may not be supported in MSVC.

Anyhow, as everywhere else in the code `&&` is used, I think it make sense to be consistent and use `&&` also here.

Similar to https://github.com/moveit/moveit2/pull/3217 .

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [x] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
