### PR TITLE
fixed moveit_servo to work with fake_hardware (fixes issue #3040)

### DIFF
--- a/moveit_ros/moveit_servo/include/moveit_servo/servo_node.hpp
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo_node.hpp
@@ -103,8 +103,16 @@ private:
   std::optional<KinematicState> processTwistCommand(const moveit::core::RobotStatePtr& robot_state);
   std::optional<KinematicState> processPoseCommand(const moveit::core::RobotStatePtr& robot_state);
 
-  // Variables
+  rclcpp::Time convertClockType(const rclcpp::Time& time, rcl_clock_type_t new_clock_type)
+  {
+    if (time.get_clock_type() != new_clock_type)
+    {
+      return rclcpp::Time(time.nanoseconds(), new_clock_type);
+    }
+    return time;
+  }
 
+  // Variables
   const rclcpp::Node::SharedPtr node_;
   std::unique_ptr<Servo> servo_;
   servo::Params servo_params_;

--- a/moveit_ros/moveit_servo/src/servo_node.cpp
+++ b/moveit_ros/moveit_servo/src/servo_node.cpp
@@ -325,10 +325,14 @@ void ServoNode::servoLoop()
   std::optional<KinematicState> next_joint_state = std::nullopt;
   rclcpp::WallRate servo_frequency(1 / servo_params_.publish_period);
 
-  // wait for first robot joint state update
   const auto servo_node_start = node_->now();
-  while (planning_scene_monitor_->getLastUpdateTime().get_clock_type() != node_->get_clock()->get_clock_type() ||
-         servo_node_start > planning_scene_monitor_->getLastUpdateTime())
+
+  while (servo_node_start >
+         convertClockType(planning_scene_monitor_->getLastUpdateTime(), servo_node_start.get_clock_type()))
+  {
+    RCLCPP_INFO(node_->get_logger(), "Waiting for planning scene monitor to receive robot state update.");
+    rclcpp::sleep_for(std::chrono::seconds(1));
+  }
   {
     RCLCPP_INFO(node_->get_logger(), "Waiting to receive robot state update.");
     rclcpp::sleep_for(std::chrono::seconds(1));


### PR DESCRIPTION
This PR resolves an initialization issue in moveit_servo when used with ros2_control mock hardware components. The robot must be manually moved at startup to trigger joint state updates, otherwise moveit_servo fails to initialize due to a mismatch in clock types between the PlanningSceneMonitor and the ServoNode.

**This fixes issue #3040** 

### Description
At startup, servo_node checks whether a recent robot_state has been received by comparing the current time with the timestamp of the latest update (`last_update_time_`). However, when using a ros2_control mock component, it may wait indefinitely—even if joint states are being published regularly. This issue stems from a mismatch in clock types between the PlanningSceneMonitor and the moveit_servo node.

Mock components typically publish ideal, noise-free joint states, which results in the robot appearing idle.
Consequently:

- The joint state doesn't change.
- PlanningSceneMonitor does not update `last_update_time_` using RCL_ROS_TIME. (it only updates when the joint states change)
  - Instead, `last_update_time_` is updated with RCL_SYSTEM_TIME.
- moveit_servo, however, performs its time comparisons using RCL_ROS_TIME.
- This discrepancy causes the freshness check to fail, preventing initialization.

### Solution:

This PR introduces a clock type conversion to ensure that time comparisons between moveit_servo and PlanningSceneMonitor are consistent, regardless of the underlying clock type.
This resolves the startup issue when using mock components that produce static, noise-free joint states and therefore do not trigger joint state updates.

There are no relevant API changes.


### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md] (https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers