### PR TITLE
Include mutex header for usage of scoped_lock

### DIFF
--- a/moveit_ros/visualization/planning_scene_rviz_plugin/src/background_processing.cpp
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/src/background_processing.cpp
@@ -34,6 +34,8 @@
 
 /* Author: Ioan Sucan */
 
+#include <mutex>
+
 #include <moveit/planning_scene_rviz_plugin/background_processing.hpp>
 #include <rclcpp/logger.hpp>
 #include <rclcpp/logging.hpp>


### PR DESCRIPTION
Since std::scoped_lock is used in the implementations, [the header defining this ](https://en.cppreference.com/w/cpp/header/mutex.html)should be included.

Otherwise this can lead to build errors such as in https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/runs/16434641652/job/46442308076#step:6:9912

Could also reproduce this when building moveit2 locally. Adding the changes from this PR fixed it.
