### PR TITLE
Improve documentation for composeMultiArrayMessage to clarify usage

### DIFF
--- a/moveit_ros/moveit_servo/src/utils/common.cpp
+++ b/moveit_ros/moveit_servo/src/utils/common.cpp
@@ -254,7 +254,17 @@ void updateSlidingWindow(KinematicState& next_joint_state, std::deque<KinematicS
   // add next command
   joint_cmd_rolling_window.push_back(next_joint_state);
 }
-
+/**
+ * @brief Create a Float64MultiArray message from the given joint state.
+ *
+ * This function converts the joint state into a std_msgs::msg::Float64MultiArray message
+ * based on the configuration in the Servo parameters. It supports both position and
+ * velocity command modes, depending on the controller configuration.
+ *
+ * @param servo_params Configuration parameters used by Servo (e.g., command type: position or velocity).
+ * @param joint_state The current joint state to be converted into a Float64MultiArray message.
+ * @return The resulting Float64MultiArray message containing joint commands.
+ */
 std_msgs::msg::Float64MultiArray composeMultiArrayMessage(const servo::Params& servo_params,
                                                           const KinematicState& joint_state)
 {


### PR DESCRIPTION
### Description

Addresses #3243

This PR improves the documentation for the `composeMultiArrayMessage` function in `common.cpp` within the `moveit_servo` module.

- Added a Doxygen-compatible comment block to clarify the function’s purpose, parameters, return value, and usage.
- Helps developers understand how to use this function when working with controllers that accept `std_msgs::msg::Float64MultiArray` messages (rather than `trajectory_msgs::msg::JointTrajectory`).
- Enhances clarity and aligns with MoveIt 2’s commitment to being an accessible, industry-standard robotics framework.

This change is purely a documentation update and does not affect runtime behavior.
