### PR TITLE
Initialize the namespace property for custom iMarkers in rviz

### DIFF
--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/interactive_marker_display.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/interactive_marker_display.cpp
@@ -91,13 +91,13 @@ InteractiveMarkerDisplay::InteractiveMarkerDisplay()
 
 void InteractiveMarkerDisplay::onInitialize()
 {
-  //  auto ros_node_abstraction = context_->getRosNodeAbstraction().lock();
-  //  if (!ros_node_abstraction) {
-  //    return;
-  //  }
-  //
-  //  interactive_marker_namespace_property_->initialize(ros_node_abstraction);
-  //
+  auto ros_node_abstraction = context_->getRosNodeAbstraction().lock();
+  if (!ros_node_abstraction)
+  {
+    return;
+  }
+  interactive_marker_namespace_property_->initialize(ros_node_abstraction);
+
   rclcpp::NodeOptions options;
   options.arguments({ "--ros-args", "-r",
                       "__node:=" + std::string("interactive_marker_display_") +


### PR DESCRIPTION
### Description

MoveIt's iMarker doesn't initialize the marker namespace property, so that functionality is broken when you try to add other iMarkers alongside moveit's planning interface. Normally this just breaks the cursor, though in some cases we've seen rviz crash. I was under the impression that pluginlib might still load the default plugin for other markers, but that does not seem to be the case.

Regardless, I don't think there's a downside to providing the node abstraction to the namespace property object, so this PR just uncomments those lines.

Before (cursor gets stuck as a spinning wheel):

https://github.com/user-attachments/assets/753dc0bd-289f-47e4-8046-f22c667d8b5a

After:

https://github.com/user-attachments/assets/ccfcdb4d-5c47-47d4-a2e8-3f311f365d39


### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
