### PR TITLE
Replace rclcpp::Rate with rclcpp::WallRate

### DIFF
--- a/moveit_core/robot_state/test/test_aabb.cpp
+++ b/moveit_core/robot_state/test/test_aabb.cpp
@@ -160,7 +160,7 @@ TEST_F(TestAABB, TestPR2)
   auto pub_aabb =
       node->create_publisher<visualization_msgs::msg::Marker>("/visualization_aabb", rmw_qos_profile_default);
   auto pub_obb = node->create_publisher<visualization_msgs::msg::Marker>("/visualization_obb", rmw_qos_profile_default);
-  rclcpp::Rate loop_rate(10);
+  rclcpp::WallRate loop_rate(10);
 
   // Wait for the publishers to establish connections
   sleep(5);

--- a/moveit_ros/hybrid_planning/test/test_basic_integration.cpp
+++ b/moveit_ros/hybrid_planning/test/test_basic_integration.cpp
@@ -224,7 +224,7 @@ TEST_F(HybridPlanningFixture, ActionCompletion)
     auto goal_handle_future = hp_action_client_->async_send_goal(goal_action_request_, send_goal_options_);
   });
 
-  rclcpp::Rate rate(10);
+  rclcpp::WallRate rate(10);
   while (!action_complete_)
   {
     executor_.spin_once();
@@ -245,7 +245,7 @@ TEST_F(HybridPlanningFixture, ActionAbortion)
     hp_action_client_->async_cancel_all_goals();
   });
 
-  rclcpp::Rate rate(10);
+  rclcpp::WallRate rate(10);
   while (!action_complete_)
   {
     executor_.spin_once();

--- a/moveit_ros/move_group/src/default_capabilities/tf_publisher_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/tf_publisher_capability.cpp
@@ -79,7 +79,7 @@ void TfPublisher::publishPlanningSceneFrames()
 {
   tf2_ros::TransformBroadcaster broadcaster(context_->moveit_cpp_->getNode());
   geometry_msgs::msg::TransformStamped transform;
-  rclcpp::Rate rate(rate_);
+  rclcpp::WallRate rate(rate_);
 
   while (keep_running_)
   {

--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/trajectory_monitor_middleware_handle.hpp
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/trajectory_monitor_middleware_handle.hpp
@@ -66,6 +66,6 @@ public:
   void sleep() override;
 
 private:
-  std::unique_ptr<rclcpp::Rate> rate_;
+  std::unique_ptr<rclcpp::WallRate> rate_;
 };
 }  // namespace planning_scene_monitor

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -430,7 +430,7 @@ void PlanningSceneMonitor::scenePublishingThread()
     moveit_msgs::msg::PlanningScene msg;
     bool publish_msg = false;
     bool is_full = false;
-    rclcpp::Rate rate(publish_planning_scene_frequency_);
+    rclcpp::WallRate rate(publish_planning_scene_frequency_);
     {
       std::unique_lock<std::shared_mutex> ulock(scene_update_mutex_);
       while (new_scene_update_ == UPDATE_NONE && publish_planning_scene_)

--- a/moveit_ros/planning/planning_scene_monitor/src/trajectory_monitor_middleware_handle.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/trajectory_monitor_middleware_handle.cpp
@@ -48,7 +48,7 @@ void planning_scene_monitor::TrajectoryMonitorMiddlewareHandle::setRate(double s
 {
   if (sampling_frequency > std::numeric_limits<double>::epsilon())
   {
-    rate_ = std::make_unique<rclcpp::Rate>(sampling_frequency);
+    rate_ = std::make_unique<rclcpp::WallRate>(sampling_frequency);
   }
 }
 

--- a/moveit_ros/warehouse/src/broadcast.cpp
+++ b/moveit_ros/warehouse/src/broadcast.cpp
@@ -115,7 +115,7 @@ int main(int argc, char** argv)
   rclcpp::executors::StaticSingleThreadedExecutor executor;
   executor.add_node(node);
 
-  rclcpp::Rate rate((int64_t)delay * 1000ms);
+  rclcpp::WallRate rate((int64_t)delay * 1000ms);
 
   // publish the scene
   if (vm.count("scene"))


### PR DESCRIPTION
### Description
rclcpp::WallRate is preferable to rclcpp::Rate, because with rclcpp::WallRate `rate.sleep()` won’t stall due to backward system clock adjustments (e.g., a one-day rollback).