### PR TITLE
Fix severe warning from class loader in servo

### DIFF
--- a/moveit_ros/moveit_servo/include/moveit_servo/servo.hpp
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo.hpp
@@ -229,6 +229,9 @@ private:
   std::atomic<double> collision_velocity_scale_ = 1.0;
   std::unique_ptr<CollisionMonitor> collision_monitor_;
 
+  // Plugin loader
+  std::unique_ptr<pluginlib::ClassLoader<online_signal_smoothing::SmoothingBaseClass>> smoother_loader_;
+
   // Pointer to the (optional) smoothing plugin.
   pluginlib::UniquePtr<online_signal_smoothing::SmoothingBaseClass> smoother_ = nullptr;
 

--- a/moveit_ros/moveit_servo/src/servo.cpp
+++ b/moveit_ros/moveit_servo/src/servo.cpp
@@ -139,9 +139,9 @@ void Servo::setSmoothingPlugin()
   // Load the smoothing plugin
   try
   {
-    pluginlib::ClassLoader<online_signal_smoothing::SmoothingBaseClass> smoothing_loader(
-        "moveit_core", "online_signal_smoothing::SmoothingBaseClass");
-    smoother_ = smoothing_loader.createUniqueInstance(servo_params_.smoothing_filter_plugin_name);
+    smoother_loader_ = std::make_unique<pluginlib::ClassLoader<online_signal_smoothing::SmoothingBaseClass>>(
+      "moveit_core", "online_signal_smoothing::SmoothingBaseClass");
+    smoother_ = smoother_loader_->createUniqueInstance(servo_params_.smoothing_filter_plugin_name);
   }
   catch (pluginlib::PluginlibException& ex)
   {


### PR DESCRIPTION
### Description

To fix "SEVERE WARNING" from class loader in moveit_servo, created the class loader as a member variable instead of creating it on the stack.

This fixes the following error:
```
[servo_node-20] Warning: class_loader.ClassLoader: SEVERE WARNING!!! Attempting to unload library while objects created by this loader exist in the heap! You should delete your objects before attempting to unload the library or destroying the ClassLoader. The library will NOT be unloaded.
```
