### PR TITLE
Add possibility to set use_sim_time as launch argument.

### DIFF
--- a/moveit_configs_utils/moveit_configs_utils/launches.py
+++ b/moveit_configs_utils/moveit_configs_utils/launches.py
@@ -216,6 +216,8 @@ def generate_move_group_launch(moveit_config):
     # default to false, because almost nothing in move_group relies on this information
     ld.add_action(DeclareBooleanLaunchArg("monitor_dynamics", default_value=False))
 
+    ld.add_action(DeclareBooleanLaunchArg("use_sim_time", default_value=False))
+
     should_publish = LaunchConfiguration("publish_monitored_planning_scene")
 
     move_group_configuration = {
@@ -233,7 +235,8 @@ def generate_move_group_launch(moveit_config):
         "publish_geometry_updates": should_publish,
         "publish_state_updates": should_publish,
         "publish_transforms_updates": should_publish,
-        "monitor_dynamics": False,
+        "monitor_dynamics": LaunchConfiguration("monitor_dynamics"),
+        "use_sim_time": LaunchConfiguration("use_sim_time")
     }
 
     move_group_params = [


### PR DESCRIPTION
Use LaunchArg for monitor_dynamics as well.

For reference: #1810 #1811

https://robotics.stackexchange.com/questions/104444/use-sim-time-with-moveit

Allows you to call it like:

`ros2 launch panda_moveit_config move_group.launch.py use_sim_time:=True`


### Description

Please explain the changes you made, including a reference to the related issue if applicable

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
