### PR TITLE
fix(moveit_py): RobotState.state_info

### DIFF
--- a/moveit_py/src/moveit/moveit_core/robot_state/robot_state.cpp
+++ b/moveit_py/src/moveit/moveit_core/robot_state/robot_state.cpp
@@ -314,7 +314,7 @@ void initRobotState(py::module& m)
                     str: represents the state tree of the robot state.
                     )")
 
-      .def_property_readonly_static(
+      .def_property_readonly(
           "state_info",
           [](const moveit::core::RobotState& s) {
             std::stringstream ss;


### PR DESCRIPTION
### Description

Should never been static, as `printStateInfo` is not static.

Fixes https://github.com/moveit/moveit2/issues/3511

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
