### PR TITLE
remove unused boost-filesystem

### DIFF
--- a/moveit_core/ConfigExtras.cmake
+++ b/moveit_core/ConfigExtras.cmake
@@ -5,7 +5,6 @@ find_package(
   REQUIRED
   chrono
   date_time
-  filesystem
   iostreams
   program_options
   regex

--- a/moveit_planners/ompl/CMakeLists.txt
+++ b/moveit_planners/ompl/CMakeLists.txt
@@ -9,7 +9,6 @@ find_package(
   Boost
   REQUIRED
   system
-  filesystem
   date_time
   thread
   serialization)

--- a/moveit_ros/benchmarks/ConfigExtras.cmake
+++ b/moveit_ros/benchmarks/ConfigExtras.cmake
@@ -1,3 +1,3 @@
 # Extras module needed for dependencies to find boost components
 
-find_package(Boost REQUIRED date_time filesystem)
+find_package(Boost REQUIRED date_time)

--- a/moveit_ros/benchmarks/package.xml
+++ b/moveit_ros/benchmarks/package.xml
@@ -22,7 +22,6 @@
 
   <build_depend>libboost-dev</build_depend>
   <build_depend>libboost-date-time-dev</build_depend>
-  <build_depend>libboost-filesystem-dev</build_depend>
 
   <depend>moveit_ros_planning</depend>
   <depend>moveit_ros_warehouse</depend>
@@ -31,7 +30,6 @@
   <depend version_gte="1.11.2">pluginlib</depend>
 
   <exec_depend>libboost-date-time</exec_depend>
-  <exec_depend>libboost-filesystem</exec_depend>
   <exec_depend>moveit_configs_utils</exec_depend>
   <exec_depend>launch_param_builder</exec_depend>
 

--- a/moveit_ros/benchmarks/src/BenchmarkExecutor.cpp
+++ b/moveit_ros/benchmarks/src/BenchmarkExecutor.cpp
@@ -58,7 +58,6 @@ using boost_progress_display = boost::progress_display;
 #endif
 
 #include <boost/math/constants/constants.hpp>
-#include <boost/filesystem.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <math.h>
 #include <limits>

--- a/moveit_ros/hybrid_planning/test/CMakeLists.txt
+++ b/moveit_ros/hybrid_planning/test/CMakeLists.txt
@@ -4,7 +4,7 @@ ament_target_dependencies(cancel_action PUBLIC ${THIS_PACKAGE_INCLUDE_DEPENDS})
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
   find_package(ros_testing REQUIRED)
-  find_package(Boost REQUIRED COMPONENTS filesystem)
+  find_package(Boost REQUIRED COMPONENTS)
 
   # TODO (vatanaksoytezer / andyze: Flaky behaviour, investigate and re-enable
   # this test asap) Basic integration tests

--- a/moveit_ros/move_group/ConfigExtras.cmake
+++ b/moveit_ros/move_group/ConfigExtras.cmake
@@ -4,7 +4,6 @@ find_package(
   Boost
   REQUIRED
   system
-  filesystem
   date_time
   program_options
   thread)

--- a/moveit_ros/planning/ConfigExtras.cmake
+++ b/moveit_ros/planning/ConfigExtras.cmake
@@ -4,7 +4,6 @@ find_package(
   Boost
   REQUIRED
   system
-  filesystem
   date_time
   program_options
   thread

--- a/moveit_ros/planning_interface/ConfigExtras.cmake
+++ b/moveit_ros/planning_interface/ConfigExtras.cmake
@@ -6,6 +6,6 @@
 
 find_package(
   Boost REQUIRED
-  COMPONENTS date_time filesystem program_options
+  COMPONENTS date_time program_options
              # ${BOOST_PYTHON_COMPONENT}
              system thread)

--- a/moveit_ros/visualization/ConfigExtras.cmake
+++ b/moveit_ros/visualization/ConfigExtras.cmake
@@ -1,3 +1,3 @@
 # Extras module needed for dependencies to find boost components
 
-find_package(Boost REQUIRED thread date_time system filesystem)
+find_package(Boost REQUIRED thread date_time system)

--- a/moveit_ros/warehouse/ConfigExtras.cmake
+++ b/moveit_ros/warehouse/ConfigExtras.cmake
@@ -5,7 +5,6 @@ find_package(
   REQUIRED
   thread
   system
-  filesystem
   regex
   date_time
   program_options)


### PR DESCRIPTION
### Description

Removed boost filesystem. Not actually being used anymore and already replaced with std::filesystem throughout.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [x] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [x] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [x] Include a screenshot if changing a GUI
- [x] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
