### PR TITLE
fix segfault when planning with differential drive planar joint

### DIFF
--- a/moveit_core/robot_model/src/planar_joint_model.cpp
+++ b/moveit_core/robot_model/src/planar_joint_model.cpp
@@ -245,6 +245,14 @@ void PlanarJointModel::interpolate(const double* from, const double* to, const d
 
     double total_d = initial_d + drive_d + final_d;
 
+    if (total_d <= std::numeric_limits<double>::epsilon())
+    {
+      state[0] = to[0];
+      state[1] = to[1];
+      state[2] = to[2];
+      return;
+    }
+
     double initial_frac = initial_d / total_d;
     double drive_frac = drive_d / total_d;
     double final_frac = final_d / total_d;

--- a/moveit_core/robot_model/src/planar_joint_model.cpp
+++ b/moveit_core/robot_model/src/planar_joint_model.cpp
@@ -236,6 +236,14 @@ void PlanarJointModel::interpolate(const double* from, const double* to, const d
   }
   else if (motion_model_ == DIFF_DRIVE)
   {
+    if (t <= 0.0)
+    {
+      state[0] = from[0];
+      state[1] = from[1];
+      state[2] = from[2];
+      return;
+    }
+
     double dx, dy, initial_turn, drive_angle, final_turn;
     computeTurnDriveTurnGeometry(from, to, min_translational_distance_, dx, dy, initial_turn, drive_angle, final_turn);
 

--- a/moveit_core/robot_model/test/test.cpp
+++ b/moveit_core/robot_model/test/test.cpp
@@ -237,11 +237,14 @@ TEST(PlanarJointTest, InterpolateDiffDriveNoNan)
   // Test interpolation for each case and check for NaN values
   for (const auto& test_case : test_cases)
   {
-    double state[3];
-    pjm.interpolate(test_case.from, test_case.to, 0.1, state);
-    EXPECT_TRUE(std::isfinite(state[0])) << "Failed at test case: " << test_case.name;
-    EXPECT_TRUE(std::isfinite(state[1])) << "Failed at test case: " << test_case.name;
-    EXPECT_TRUE(std::isfinite(state[2])) << "Failed at test case: " << test_case.name;
+    for (double t : { 0.0, 0.5, 1.0 })
+    {
+      double state[3];
+      pjm.interpolate(test_case.from, test_case.to, t, state);
+      EXPECT_TRUE(std::isfinite(state[0])) << "Failed at test case: " << test_case.name << " at t=" << t;
+      EXPECT_TRUE(std::isfinite(state[1])) << "Failed at test case: " << test_case.name << " at t=" << t;
+      EXPECT_TRUE(std::isfinite(state[2])) << "Failed at test case: " << test_case.name << " at t=" << t;
+    }
   }
 }
 

--- a/moveit_core/robot_model/test/test.cpp
+++ b/moveit_core/robot_model/test/test.cpp
@@ -34,6 +34,7 @@
 
 /* Author: Ioan Sucan */
 
+#include <limits>
 #include <moveit/robot_model/robot_model.hpp>
 #include <urdf_parser/urdf_parser.h>
 #include <fstream>
@@ -201,6 +202,46 @@ TEST(PlanarJointTest, ComputeVariablePositionsNormalizeYaw)
     while (normalized_angle < -M_PI)
       normalized_angle += 2.0 * M_PI;
     EXPECT_NEAR(joint_values[2], normalized_angle, 1e-6);
+  }
+}
+
+TEST(PlanarJointTest, InterpolateDiffDriveNoNan)
+{
+  // Create a simple planar joint model with some dummy parameters
+  moveit::core::PlanarJointModel pjm("joint", 0, 0);
+
+  // Set the motion model to DIFF_DRIVE
+  pjm.setMotionModel(moveit::core::PlanarJointModel::DIFF_DRIVE);
+
+  // Define a struct to hold test cases
+  struct FromToCase
+  {
+    std::string name;
+    double from[3];
+    double to[3];
+  };
+
+  // Define some test cases
+  const std::vector<FromToCase> test_cases = {
+    { "No movement", { 0.0, 0.0, 0.0 }, { 0.0, 0.0, 0.0 } },
+    { "Exact equal", { 0.5, -0.5, 0.2 }, { 0.5, -0.5, 0.2 } },
+    { "Small Delta", { 1.0, 1.0, 0.0 }, { 1.0 + 1e-10, 1.0 + 1e-10, 1e-10 } },
+    { "Straight line along X", { 0.0, 0.0, 0.0 }, { 0.1, 0.0, 0.0 } },
+    { "Straight line along Y", { 0.0, 0.0, M_PI / 2 }, { 0.0, 0.1, M_PI / 2 } },
+    { "180 degree turn in place", { 0.0, 0.0, 0.0 }, { 0.0, 0.0, M_PI } },
+    { "360 degree turn in place", { 0.0, 0.0, -M_PI }, { 0.0, 0.0, M_PI } },
+    { "Diagonal movement", { 0.0, 0.0, -M_PI / 4 }, { 0.1, -0.1, -M_PI / 4 } },
+    { "Complex move", { 0.5, 1.0, -M_PI / 2 }, { -0.7, -1.0, M_PI / 3 } }
+  };
+
+  // Test interpolation for each case and check for NaN values
+  for (const auto& test_case : test_cases)
+  {
+    double state[3];
+    pjm.interpolate(test_case.from, test_case.to, 0.1, state);
+    EXPECT_TRUE(std::isfinite(state[0])) << "Failed at test case: " << test_case.name;
+    EXPECT_TRUE(std::isfinite(state[1])) << "Failed at test case: " << test_case.name;
+    EXPECT_TRUE(std::isfinite(state[2])) << "Failed at test case: " << test_case.name;
   }
 }
 


### PR DESCRIPTION
### Description

* Assume and fix #3655 
* This PR is based on MoveIt1 PR (https://github.com/moveit/moveit/pull/3457) with additional test code.
* This patch is intended solely to prevent planning (with differential drive planar joint) from segfault.
* ~~CI seem to be failing because `ros-rolling-picknik-reset-fault-controller` is not found, but it looks like this was fixed in https://github.com/PickNikRobotics/picknik_controllers/issues/22. I assume this will be restored in the next rolling sync. Not sure if I should keep the PR open or convert to draft until ci issue is fixed Keeping this PR on draft until next rolling sync~~

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
