### PR TITLE
Preserve planner-specific MoveGroup failure codes in /move_action

### DIFF
--- a/moveit_ros/move_group/src/default_capabilities/move_action_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/move_action_capability.cpp
@@ -218,7 +218,17 @@ void MoveGroupMoveAction::executeMoveCallbackPlanOnly(const std::shared_ptr<MGAc
     if (!planning_pipeline->generatePlan(scene, goal->get_goal()->request, res, context_->debug_))
     {
       RCLCPP_ERROR(getLogger(), "Generating a plan with planning pipeline failed.");
-      res.error_code.val = moveit_msgs::msg::MoveItErrorCodes::FAILURE;
+      if (res.error_code.val == moveit_msgs::msg::MoveItErrorCodes::SUCCESS ||
+          res.error_code.val == moveit_msgs::msg::MoveItErrorCodes::UNDEFINED)
+      {
+        res.error_code.val = moveit_msgs::msg::MoveItErrorCodes::FAILURE;
+      }
+      else
+      {
+        RCLCPP_ERROR(
+            getLogger(), "Preserving planner-specific failure code %d for /move_action",
+            res.error_code.val);
+      }
     }
   }
   catch (std::exception& ex)

--- a/moveit_ros/move_group/src/default_capabilities/move_action_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/move_action_capability.cpp
@@ -225,9 +225,7 @@ void MoveGroupMoveAction::executeMoveCallbackPlanOnly(const std::shared_ptr<MGAc
       }
       else
       {
-        RCLCPP_ERROR(
-            getLogger(), "Preserving planner-specific failure code %d for /move_action",
-            res.error_code.val);
+        RCLCPP_ERROR(getLogger(), "Preserving planner-specific failure code %d for /move_action", res.error_code.val);
       }
     }
   }


### PR DESCRIPTION
## Summary

Preserve planner-specific non-success `MoveItErrorCodes` in `/move_action` plan-only execution instead of always collapsing them to generic `FAILURE` (`99999`).

## Root cause

`planning_pipeline->generatePlan(...)` returns `false` for any non-success planner result. In `MoveGroupMoveAction::executeMoveCallbackPlanOnly`, that `false` return currently overwrites `res.error_code.val` with `MoveItErrorCodes::FAILURE` even when the planner already set a more specific non-success code such as:

- `INVALID_GROUP_NAME` (`-15`)
- `NO_IK_SOLUTION` (`-31`)
- other planner-specific request/kinematics failures

That destroys information that downstream action clients need for correct diagnosis and handling.

## Change

Only fall back to generic `FAILURE` when the current code is still `SUCCESS` or `UNDEFINED`. If the planner already populated a specific non-success code, preserve it and log that preservation.

## Validation

Validated downstream against `jazzy` / MoveIt `2.12.4` in a live Isaac ROS cuMotion integration harness.

Observed before this patch:

- direct planner path returned specific failure `-31`
- MoveIt-side planner client received `-31`
- `/move_action` still returned generic `99999`

Observed after this patch:

- `/move_action` preserved the original planner-specific failure code (`-31`)
- repeated requests remained stable
- no stale trajectory reuse
- no success-with-empty-trajectory regressions on the direct planner path

This also matches the user-visible symptom reported in #3667 where invalid group or unreachable goals lose their original error code and appear as generic failure.

## Related

Refs #3667
