### PR TITLE
resolute: complete ament_index_cpp::get_package_share_path migration

### DIFF
--- a/moveit_core/utils/src/robot_model_test_utils.cpp
+++ b/moveit_core/utils/src/robot_model_test_utils.cpp
@@ -34,9 +34,26 @@
 
 /* Author: Bryce Willey */
 
-#include <rclcpp/version.h>
-
+// ament_index_cpp's get_package_share_directory API changed twice.
+// Guard on ament_index_cpp's own version — not rclcpp — because the
+// changes live in ament_index_cpp and its release cadence is independent
+// of rclcpp's.
+//   1.14+ (Rolling on Resolute):
+//     get_package_share_directory.hpp REMOVED, replaced with
+//     get_package_share_path.hpp exposing get_package_share_path(pkg)
+//     returning std::filesystem::path directly.
+//   1.5+ (Jazzy 1.8.4, Kilted 1.11.4, Lyrical 1.13.3, Rolling-on-Noble 1.13.1):
+//     2-arg out-param overload get_package_share_directory(pkg, path)
+//     available; the 1-arg form is deprecated starting in 1.13.
+//   Older (Humble 1.4.1):
+//     only the non-deprecated 1-arg get_package_share_directory(pkg)
+//     returning std::string is available.
+#include <ament_index_cpp/version.h>
+#if AMENT_INDEX_CPP_VERSION_GTE(1, 14, 0)
+#include <ament_index_cpp/get_package_share_path.hpp>
+#else
 #include <ament_index_cpp/get_package_share_directory.hpp>
+#endif
 #include <boost/algorithm/string_regex.hpp>
 #include <filesystem>
 #include <geometry_msgs/msg/pose.hpp>
@@ -66,14 +83,14 @@ moveit::core::RobotModelPtr loadTestingRobotModel(const std::string& package_nam
                                                   const std::string& urdf_relative_path,
                                                   const std::string& srdf_relative_path)
 {
-// For Rolling, L-turtle, and newer
-#if RCLCPP_VERSION_GTE(30, 0, 0)
-  std::filesystem::path urdf_path;
-  ament_index_cpp::get_package_share_directory(package_name, urdf_path);
-  urdf_path /= urdf_relative_path;
-  std::filesystem::path srdf_path;
-  ament_index_cpp::get_package_share_directory(package_name, srdf_path);
-  srdf_path /= srdf_relative_path;
+#if AMENT_INDEX_CPP_VERSION_GTE(1, 14, 0)
+  const auto urdf_path = ament_index_cpp::get_package_share_path(package_name) / urdf_relative_path;
+  const auto srdf_path = ament_index_cpp::get_package_share_path(package_name) / srdf_relative_path;
+#elif AMENT_INDEX_CPP_VERSION_GTE(1, 5, 0)
+  std::filesystem::path pkg_share;
+  ament_index_cpp::get_package_share_directory(package_name, pkg_share);
+  const auto urdf_path = pkg_share / urdf_relative_path;
+  const auto srdf_path = pkg_share / srdf_relative_path;
 #else
   const auto urdf_path =
       std::filesystem::path(ament_index_cpp::get_package_share_directory(package_name)) / urdf_relative_path;
@@ -107,8 +124,9 @@ moveit::core::RobotModelPtr loadTestingRobotModel(const std::string& robot_name)
 urdf::ModelInterfaceSharedPtr loadModelInterface(const std::string& robot_name)
 {
   const std::string package_name = "moveit_resources_" + robot_name + "_description";
-// For Rolling, L-turtle, and newer
-#if RCLCPP_VERSION_GTE(30, 0, 0)
+#if AMENT_INDEX_CPP_VERSION_GTE(1, 14, 0)
+  std::filesystem::path res_path = ament_index_cpp::get_package_share_path(package_name);
+#elif AMENT_INDEX_CPP_VERSION_GTE(1, 5, 0)
   std::filesystem::path res_path;
   ament_index_cpp::get_package_share_directory(package_name, res_path);
 #else
@@ -141,8 +159,9 @@ srdf::ModelSharedPtr loadSRDFModel(const std::string& robot_name)
   if (robot_name == "pr2")
   {
     const std::string package_name = "moveit_resources_" + robot_name + "_description";
-// For Rolling, L-turtle, and newer
-#if RCLCPP_VERSION_GTE(30, 0, 0)
+#if AMENT_INDEX_CPP_VERSION_GTE(1, 14, 0)
+    std::filesystem::path res_path = ament_index_cpp::get_package_share_path(package_name);
+#elif AMENT_INDEX_CPP_VERSION_GTE(1, 5, 0)
     std::filesystem::path res_path;
     ament_index_cpp::get_package_share_directory(package_name, res_path);
 #else
@@ -153,8 +172,9 @@ srdf::ModelSharedPtr loadSRDFModel(const std::string& robot_name)
   else
   {
     const std::string package_name = "moveit_resources_" + robot_name + "_moveit_config";
-// For Rolling, L-turtle, and newer
-#if RCLCPP_VERSION_GTE(30, 0, 0)
+#if AMENT_INDEX_CPP_VERSION_GTE(1, 14, 0)
+    std::filesystem::path res_path = ament_index_cpp::get_package_share_path(package_name);
+#elif AMENT_INDEX_CPP_VERSION_GTE(1, 5, 0)
     std::filesystem::path res_path;
     ament_index_cpp::get_package_share_directory(package_name, res_path);
 #else

--- a/moveit_ros/planning/rdf_loader/src/rdf_loader.cpp
+++ b/moveit_ros/planning/rdf_loader/src/rdf_loader.cpp
@@ -34,13 +34,30 @@
 
 /* Author: Ioan Sucan, Mathias Lüdtke, Dave Coleman */
 
-#include <rclcpp/version.h>
-
 // MoveIt
 #include <moveit/rdf_loader/rdf_loader.hpp>
 #include <std_msgs/msg/string.hpp>
 #include <ament_index_cpp/get_package_prefix.hpp>
+// ament_index_cpp's get_package_share_directory API changed twice.
+// Guard on ament_index_cpp's own version — not rclcpp — because the
+// changes live in ament_index_cpp and its release cadence is independent
+// of rclcpp's.
+//   1.14+ (Rolling on Resolute):
+//     get_package_share_directory.hpp REMOVED, replaced with
+//     get_package_share_path.hpp exposing get_package_share_path(pkg)
+//     returning std::filesystem::path directly.
+//   1.5+ (Jazzy 1.8.4, Kilted 1.11.4, Lyrical 1.13.3, Rolling-on-Noble 1.13.1):
+//     2-arg out-param overload get_package_share_directory(pkg, path)
+//     available; the 1-arg form is deprecated starting in 1.13.
+//   Older (Humble 1.4.1):
+//     only the non-deprecated 1-arg get_package_share_directory(pkg)
+//     returning std::string is available.
+#include <ament_index_cpp/version.h>
+#if AMENT_INDEX_CPP_VERSION_GTE(1, 14, 0)
+#include <ament_index_cpp/get_package_share_path.hpp>
+#else
 #include <ament_index_cpp/get_package_share_directory.hpp>
+#endif
 #include <moveit/utils/logger.hpp>
 
 #include <rclcpp/duration.hpp>
@@ -222,8 +239,9 @@ bool RDFLoader::loadPkgFileToString(std::string& buffer, const std::string& pack
   std::filesystem::path path;
   try
   {
-// For Rolling, L-turtle, and newer
-#if RCLCPP_VERSION_GTE(30, 0, 0)
+#if AMENT_INDEX_CPP_VERSION_GTE(1, 14, 0)
+    path = ament_index_cpp::get_package_share_path(package_name);
+#elif AMENT_INDEX_CPP_VERSION_GTE(1, 5, 0)
     ament_index_cpp::get_package_share_directory(package_name, path);
 #else
     path = ament_index_cpp::get_package_share_directory(package_name);

--- a/moveit_setup_assistant/moveit_setup_framework/include/moveit_setup_framework/utilities.hpp
+++ b/moveit_setup_assistant/moveit_setup_framework/include/moveit_setup_framework/utilities.hpp
@@ -36,10 +36,27 @@
 
 #pragma once
 
-#include <rclcpp/version.h>
-
 #include <ament_index_cpp/get_package_prefix.hpp>
+// ament_index_cpp's get_package_share_directory API changed twice.
+// Guard on ament_index_cpp's own version — not rclcpp — because the
+// changes live in ament_index_cpp and its release cadence is independent
+// of rclcpp's.
+//   1.14+ (Rolling on Resolute):
+//     get_package_share_directory.hpp REMOVED, replaced with
+//     get_package_share_path.hpp exposing get_package_share_path(pkg)
+//     returning std::filesystem::path directly.
+//   1.5+ (Jazzy 1.8.4, Kilted 1.11.4, Lyrical 1.13.3, Rolling-on-Noble 1.13.1):
+//     2-arg out-param overload get_package_share_directory(pkg, path)
+//     available; the 1-arg form is deprecated starting in 1.13.
+//   Older (Humble 1.4.1):
+//     only the non-deprecated 1-arg get_package_share_directory(pkg)
+//     returning std::string is available.
+#include <ament_index_cpp/version.h>
+#if AMENT_INDEX_CPP_VERSION_GTE(1, 14, 0)
+#include <ament_index_cpp/get_package_share_path.hpp>
+#else
 #include <ament_index_cpp/get_package_share_directory.hpp>
+#endif
 #include <filesystem>
 #include <string>
 #include <tinyxml2.h>
@@ -54,8 +71,9 @@ inline std::filesystem::path getSharePath(const std::string& package_name)
 {
   try
   {
-// For Rolling, L-turtle, and newer
-#if RCLCPP_VERSION_GTE(30, 0, 0)
+#if AMENT_INDEX_CPP_VERSION_GTE(1, 14, 0)
+    return ament_index_cpp::get_package_share_path(package_name);
+#elif AMENT_INDEX_CPP_VERSION_GTE(1, 5, 0)
     std::filesystem::path path;
     ament_index_cpp::get_package_share_directory(package_name, path);
     return path;


### PR DESCRIPTION
## Summary

Completes the `ament_index_cpp::get_package_share_directory` → `get_package_share_path` migration that #3703 started for Rolling. The current source has `#if RCLCPP_VERSION_GTE(30, 0, 0)` guards that hit the wrong branch on Rolling-on-Noble (deprecated call path) and outright fail to compile on Rolling-on-Resolute (missing header). Fixes both with a three-tier guard keyed on `AMENT_INDEX_CPP_VERSION_GTE` — the correct carrier package's version macro.

## Background: what ament_index_cpp did

`ament_index_cpp`'s `get_package_share_directory` API evolved in two steps:

| Version | Header | API |
|---|---|---|
| ≥ 1.14.0 (Rolling on Resolute) | `<ament_index_cpp/get_package_share_path.hpp>` | `get_package_share_path(pkg)` returns `std::filesystem::path` directly. Old header removed. |
| ≥ 1.5.x (Jazzy, Kilted, Lyrical, Rolling-on-Noble) | `<ament_index_cpp/get_package_share_directory.hpp>` | Both forms: `std::string get_package_share_directory(pkg)` (deprecated in 1.13+) **and** `void get_package_share_directory(pkg, std::filesystem::path& out)` (non-deprecated). |
| older (Humble 1.4.1) | `<ament_index_cpp/get_package_share_directory.hpp>` | Only `std::string get_package_share_directory(pkg)`. Not deprecated. |

Version snapshot for the distros moveit2 currently supports (from `apt-cache policy` against packages.ros.org):

| Distro | ament_index_cpp | Notes |
|---|---|---|
| Humble (jammy) | 1.4.1 | 1-arg only |
| Jazzy (noble) | 1.8.4 | Both forms; neither deprecated |
| Kilted (noble) | 1.11.4 | Both forms; neither deprecated |
| Lyrical (resolute) | 1.13.3 | Both forms; 1-arg deprecated |
| Rolling on Noble (frozen `moveit/moveit2:rolling-ci`) | **1.13.1** | Both forms; 1-arg deprecated |
| Rolling on Resolute (current) | **1.14.1** | Only new API |

## What went wrong in #3703

#3703 added conditional branches like:

```cpp
#if RCLCPP_VERSION_GTE(30, 0, 0)
  std::filesystem::path urdf_path;
  ament_index_cpp::get_package_share_directory(package_name, urdf_path);
  urdf_path /= urdf_relative_path;
#else
  const auto urdf_path =
      std::filesystem::path(ament_index_cpp::get_package_share_directory(package_name)) / urdf_relative_path;
#endif
```

Two problems:

1. **Wrong carrier**. `RCLCPP_VERSION_GTE(30, 0, 0)` guards on `rclcpp`'s version, but the API change lives in `ament_index_cpp`. When #3703 was written the two packages' versions happened to correlate; they've since drifted apart (see the version snapshot above).
2. **The `#if` branch's 2-arg call is real on 1.13.x but no longer exists on 1.14+**. On the current Rolling-on-Resolute container, `<ament_index_cpp/get_package_share_directory.hpp>` doesn't exist at all — the header include itself fails.

Concretely, the current code fails on rolling-resolute with:

```
fatal error: ament_index_cpp/get_package_share_path.hpp: No such file or directory
```

(from an earlier iteration of this PR that guarded on a too-permissive threshold; the current version pins the header choice on 1.14+ so this specific error is gone.)

## What this PR does

Three-tier guard, keyed on `AMENT_INDEX_CPP_VERSION_GTE`:

```cpp
#include <ament_index_cpp/version.h>
#if AMENT_INDEX_CPP_VERSION_GTE(1, 14, 0)
#include <ament_index_cpp/get_package_share_path.hpp>
#else
#include <ament_index_cpp/get_package_share_directory.hpp>
#endif

// ... in the call site:
#if AMENT_INDEX_CPP_VERSION_GTE(1, 14, 0)
  const auto path = ament_index_cpp::get_package_share_path(pkg);
#elif AMENT_INDEX_CPP_VERSION_GTE(1, 5, 0)
  std::filesystem::path path;
  ament_index_cpp::get_package_share_directory(pkg, path);
#else
  const auto path = std::filesystem::path(ament_index_cpp::get_package_share_directory(pkg));
#endif
```

Why three tiers, not two:

- **1.14+ branch** uses the new `get_package_share_path` API. Required to compile on Rolling-on-Resolute where the old header is gone.
- **1.5–1.13.x branch** uses the non-deprecated 2-arg out-param form. **This branch matters even though it's "old API"** because Rolling-on-Noble (the frozen `moveit/moveit2:rolling-ci` container, ament_index_cpp 1.13.1) treats the 1-arg form as deprecated, and the `rolling-ci + deprecation check` job runs with `-Werror=deprecated-declarations`. Using the 2-arg form keeps that job green.
- **Sub-1.5 branch** falls back to the only form Humble's 1.4.1 has.

**Why guard on `AMENT_INDEX_CPP_VERSION_GTE` instead of `RCLCPP_VERSION_GTE`**: the API rename lives in `ament_index_cpp`. Its release cadence is independent of `rclcpp`'s. Using another package's version macro as a proxy silently misfires when the two packages' versions drift — exactly what happened in #3703 → this fix. Companion policy update in [#3751](https://github.com/moveit/moveit2/pull/3751) makes "guard on the feature-carrier package's version macro" the documented rule going forward.

Also drops the now-unused `#include <rclcpp/version.h>` in each file (added by #3703 for the guard we replaced).

## Test plan

- [x] Full source-build of moveit2 + downstream on `ubuntu:resolute` + ROS Rolling (`ros2-testing` apt) — all three files' downstream packages build cleanly; the rolling-resolute build path exercises the 1.14+ branch.
- [x] `rolling-ci + ccov` (Rolling on Noble, ament_index_cpp 1.13.1, no `-Werror` on deprecations) — exercises the 1.5–1.13.x branch.
- [ ] `rolling-ci + deprecation check` (same container, `-Werror=deprecated-declarations`) — exercises the 1.5–1.13.x branch, confirms the 2-arg form doesn't trigger deprecation.
- [x] `humble-ci`, `jazzy-ci` — exercise the sub-1.5 and 1.5+ branches respectively.
