### PR TITLE
Fix joint_limits.yaml generating integer values for double parameters

### DIFF
--- a/moveit_setup_assistant/moveit_setup_framework/src/srdf_config.cpp
+++ b/moveit_setup_assistant/moveit_setup_framework/src/srdf_config.cpp
@@ -35,6 +35,7 @@
 #include <moveit_setup_framework/data_warehouse.hpp>
 #include <moveit_setup_framework/utilities.hpp>
 #include <moveit/rdf_loader/rdf_loader.hpp>
+#include <sstream>
 
 namespace moveit_setup
 {
@@ -235,6 +236,17 @@ struct JointModelCompare
 
 bool SRDFConfig::GeneratedJointLimits::writeYaml(YAML::Emitter& emitter)
 {
+  // yaml-cpp serializes whole-number doubles (e.g. 1.0) as integers ("1"), which ROS 2 parameter
+  // loading rejects with "expected [double] got [integer]". Format them explicitly with a decimal point.
+  auto toDoubleString = [](double val) -> std::string {
+    std::ostringstream ss;
+    ss << val;
+    std::string s = ss.str();
+    if (s.find('.') == std::string::npos)
+      s += ".0";
+    return s;
+  };
+
   emitter << YAML::Comment("joint_limits.yaml allows the dynamics properties specified in the URDF "
                            "to be overwritten or augmented as needed");
   emitter << YAML::Newline;
@@ -300,7 +312,7 @@ bool SRDFConfig::GeneratedJointLimits::writeYaml(YAML::Emitter& emitter)
 
     // Output property
     emitter << YAML::Key << "max_velocity";
-    emitter << YAML::Value << static_cast<double>(std::min(fabs(b.max_velocity_), fabs(b.min_velocity_)));
+    emitter << YAML::Value << toDoubleString(std::min(fabs(b.max_velocity_), fabs(b.min_velocity_)));
 
     // Output property
     emitter << YAML::Key << "has_acceleration_limits";
@@ -315,7 +327,7 @@ bool SRDFConfig::GeneratedJointLimits::writeYaml(YAML::Emitter& emitter)
 
     // Output property
     emitter << YAML::Key << "max_acceleration";
-    emitter << YAML::Value << static_cast<double>(std::min(fabs(b.max_acceleration_), fabs(b.min_acceleration_)));
+    emitter << YAML::Value << toDoubleString(std::min(fabs(b.max_acceleration_), fabs(b.min_acceleration_)));
 
     emitter << YAML::EndMap;
   }

--- a/moveit_setup_assistant/moveit_setup_framework/src/srdf_config.cpp
+++ b/moveit_setup_assistant/moveit_setup_framework/src/srdf_config.cpp
@@ -238,6 +238,8 @@ bool SRDFConfig::GeneratedJointLimits::writeYaml(YAML::Emitter& emitter)
 {
   // yaml-cpp serializes whole-number doubles (e.g. 1.0) as integers ("1"), which ROS 2 parameter
   // loading rejects with "expected [double] got [integer]". Format them explicitly with a decimal point.
+  // TODO: remove once a yaml-cpp release includes SetEnforceFloatDot(), merged upstream but not yet
+  // in a release: https://github.com/jbeder/yaml-cpp/pull/1407
   auto toDoubleString = [](double val) -> std::string {
     std::ostringstream ss;
     ss << val;


### PR DESCRIPTION
### Description

When `moveit_setup_assistant` generates `joint_limits.yaml`, whole-number limits like `1.0` are written as `1`. This causes `move_group` to crash on startup with:
```
parameter 'robot_description_planning.joint_limits.joint1.max_velocity' has invalid type: expected [double] got [integer]
```

This was previously reported in #2776 and previous #2803 attempted to fix this with `static_cast<double>`, which doesn't affect yaml-cpp's output.

The underlying issue is that yaml-cpp saves C++'s `double` value like `1.0` as `1`, which is valid per YAML spec. It is then read as integer by  [`launch_param_builder`](https://github.com/PickNikRobotics/launch_param_builder/blob/main/launch_param_builder/utils.py#L74). So `1` would be both a `int` and `float`, it is just that it's matched as `int` first.

This fix is clearly a workaround and yaml-cpp already has a feature to enforce adding trailing zeros (jbeder/yaml-cpp#1407), but yet not available in recently released version.

An alternative solution would be to enfore the type in   `joint_limits.yaml` with `!!float` [tags](https://yaml.org/spec/1.2.2/#10214-floating-point), where `!!float 1` would be matched as `float`.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"