### PR TITLE
Fix missing Picknic logo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ See our extensive [Tutorials and Documentation](https://moveit.picknik.ai/).
 This open source project is maintained by supporters from around the world — see our [MoveIt Maintainers and Core Contributors](https://moveit.ros.org/about/).
 
 <a href="https://picknik.ai/">
-  <img src="https://picknik.ai/assets/images/logo.jpg" width="168">
+  <img src="https://picknik.ai/assets/images/logo/picknik-logo_dark.png" width="168">
 </a>
 
 [PickNik Inc](https://picknik.ai/) is leading the development of MoveIt.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ See our extensive [Tutorials and Documentation](https://moveit.picknik.ai/).
 This open source project is maintained by supporters from around the world — see our [MoveIt Maintainers and Core Contributors](https://moveit.ros.org/about/).
 
 <a href="https://picknik.ai/">
-  <img src="https://picknik.ai/assets/images/logo/picknik-logo_dark.png" width="168">
+  <img src="https://picknik.ai/assets/images/logo/picknik-logo-white.png" width="168">
 </a>
 
 [PickNik Inc](https://picknik.ai/) is leading the development of MoveIt.


### PR DESCRIPTION
### Description

The logo file for Picknic.ai was (re)moved on their servers at some point before January 2026, according to the [web archive](https://web.archive.org/web/20250904064745/https://picknik.ai/assets/images/logo.jpg). This seems to align with their logo redesign. I have changed the logo path to the official dark logo. There is also a [white version of the logo](https://picknik.ai/assets/images/logo/picknik-logo.png), which is invisible if the browser is in light mode. As the MoveIt logo at the top is also black, I'm prefering the black Picknic logo over the more common white one. 

### Checklist

As this is a tiny, visual fix independent of functionality, I have crossed out all non-applicable checklist items.

- [ ] ~**Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)~
- [ ] ~Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)~
- [ ] ~Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes~
- [ ] ~Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)~
- [x] Include a screenshot if changing a GUI
- [x] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"


### Screenshot

<img width="873" height="428" alt="image" src="https://github.com/user-attachments/assets/cf388604-8e28-4620-b1b1-78218e3223a8" />
