### PR TITLE
Fix RViz Cartesian execute crash under sim-time mismatch

### DIFF
--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
@@ -151,7 +151,7 @@ bool MotionPlanningFrame::computeCartesianPlan()
     // Compute time parameterization to also provide velocities
     // https://groups.google.com/forum/#!topic/moveit-users/MOoFxy2exT4
     robot_trajectory::RobotTrajectory rt(move_group_->getRobotModel(), move_group_->getName());
-    rt.setRobotTrajectoryMsg(*move_group_->getCurrentState(), trajectory);
+    rt.setRobotTrajectoryMsg(planning_display_->getPlanningSceneRO()->getCurrentState(), trajectory);
     trajectory_processing::TimeOptimalTrajectoryGeneration time_parameterization;
     bool success = time_parameterization.computeTimeStamps(rt, ui_->velocity_scaling_factor->value(),
                                                            ui_->acceleration_scaling_factor->value());


### PR DESCRIPTION
Fix null pointer dereference in computeCartesianPlan() under sim_time

**Problem**

In simulation setups where `/joint_states` carries sim_time stamps and
RViz uses wall time, `move_group_->getCurrentState()` always times out and
returns nullptr (wall time ~1.78×10⁹ s vs sim time ~tens of seconds, so
the 1-second wait in `waitForCurrentState(node->now(), 1s)` never succeeds).
Dereferencing the returned pointer crashes the RViz process with SIGSEGV.

**Fix**

Replace the blocking call with the PlanningSceneMonitor's already-tracked
state, consistent with all five other current-state accesses in this file:

-rt.setRobotTrajectoryMsg(*move_group_->getCurrentState(), trajectory);
+rt.setRobotTrajectoryMsg(planning_display_->getPlanningSceneRO()->getCurrentState(), trajectory);

**Why this is correct**
- PlanningSceneMonitor maintains the current robot state continuously and  does not block on timestamp matching.
- Every other call site in `motion_planning_frame_planning.cpp` already uses `getPlanningSceneRO()->getCurrentState()`.
  This was the only exception.
- Behavior is identical in non-sim setups.

**Reproduction**

1. Launch MoveIt with Gazebo + ros2_control (use_sim_time=true), RViz with use_sim_time=false (default).
2. Compute a Cartesian path in the MotionPlanning panel.
3. Click Execute → RViz crashes with SIGSEGV before this patch.


