### PR TITLE
fix(setup_assistant): use field defaults when controller params left blank

### DIFF
--- a/moveit_setup_assistant/moveit_setup_controllers/src/controller_edit_widget.cpp
+++ b/moveit_setup_assistant/moveit_setup_controllers/src/controller_edit_widget.cpp
@@ -270,11 +270,19 @@ std::string ControllerEditWidget::getControllerType()
 std::map<std::string, std::string> ControllerEditWidget::getAdditionalParameters()
 {
   std::map<std::string, std::string> parameters;
+  std::string controller_type = getControllerType();
   for (unsigned int i = 0; i < additional_fields_.size(); i++)
   {
     std::string key = additional_fields_[i]->parameter_name_;
     std::string value = additional_fields_inputs_[i]->text().trimmed().toStdString();
-    parameters[key] = value;
+    if (value.empty())
+    {
+      value = additional_fields_[i]->getDefaultValue(controller_type);
+    }
+    if (!value.empty())
+    {
+      parameters[key] = value;
+    }
   }
   return parameters;
 }


### PR DESCRIPTION
## Summary

Fixes #3434.

When a user opens the MoveIt Setup Assistant controller edit widget and leaves the **action_ns** or **default** additional-parameter fields blank (e.g. by clicking through without typing), `getAdditionalParameters()` stored the empty string directly into the parameters map. The resulting `ros2_controllers.yaml` then contained:

```yaml
- name: my_arm_controller
  type: joint_trajectory_controller/JointTrajectoryController
  action_ns: ""
  default: ""
  joints: [...]
```

These empty-string values are semantically wrong and cause downstream parsing errors when the YAML is loaded by `ros2_control`.

## Root Cause

`typeChanged()` (called on combo-box selection) already calls `getDefaultValue(controller_type)` to pre-fill the fields. But `getAdditionalParameters()` (called when the user saves) never did the same fallback — it emitted whatever was in the text box, including empty strings.

## Fix

In `getAdditionalParameters()`:
1. Call `getControllerType()` once (already a public method on the same class).
2. If a field's trimmed text is empty, fall back to `getDefaultValue(controller_type)`.
3. If the value is still empty after the fallback, skip the key entirely rather than emitting an empty-string entry.

```cpp
std::map<std::string, std::string> ControllerEditWidget::getAdditionalParameters()
{
  std::map<std::string, std::string> parameters;
  std::string controller_type = getControllerType();
  for (unsigned int i = 0; i < additional_fields_.size(); i++)
  {
    std::string key = additional_fields_[i]->parameter_name_;
    std::string value = additional_fields_inputs_[i]->text().trimmed().toStdString();
    if (value.empty())
    {
      value = additional_fields_[i]->getDefaultValue(controller_type);
    }
    if (!value.empty())
    {
      parameters[key] = value;
    }
  }
  return parameters;
}
```

## Test Plan

- [ ] Open MoveIt Setup Assistant, add a `joint_trajectory_controller/JointTrajectoryController` controller, leave action_ns and default blank, export config — verify `ros2_controllers.yaml` now contains `action_ns: follow_joint_trajectory` and `default: "true"` rather than empty strings.
- [ ] Same test with `GripperCommand` controller — verify `action_ns: gripper_cmd`.
- [ ] Add a controller, manually type a custom action_ns value — verify the explicit value is preserved.
- [ ] Load an existing YAML with populated fields — verify round-trip is lossless.