### PR TITLE
Fix missing yaw normalization in PlanarJointModel DIFF_DRIVE interpolate

### DIFF
--- a/moveit_core/robot_model/src/planar_joint_model.cpp
+++ b/moveit_core/robot_model/src/planar_joint_model.cpp
@@ -271,6 +271,7 @@ void PlanarJointModel::interpolate(const double* from, const double* to, const d
       state[1] = to[1];
       state[2] = drive_angle + final_turn * percent;
     }
+    normalizeRotation(state);
   }
 }
 

--- a/moveit_core/robot_model/test/test.cpp
+++ b/moveit_core/robot_model/test/test.cpp
@@ -204,6 +204,18 @@ TEST(PlanarJointTest, ComputeVariablePositionsNormalizeYaw)
   }
 }
 
+TEST(PlanarJointTest, InterpolateDiffDriveNormalizesYaw)
+{
+  moveit::core::PlanarJointModel pjm("joint", 0, 0);
+  pjm.setMotionModel(moveit::core::PlanarJointModel::DIFF_DRIVE);
+  const double from[3] = { 0.0, 0.0, -2.9 };
+  const double to[3] = { 0.0, 0.0, 3.0 };
+  double state[3];
+  pjm.interpolate(from, to, 1.0, state);
+  EXPECT_GE(state[2], -M_PI) << "theta=" << state[2];
+  EXPECT_LE(state[2], M_PI) << "theta=" << state[2];
+}
+
 int main(int argc, char** argv)
 {
   testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
## Summary

Fixes #3665.

`PlanarJointModel::interpolate()` normalizes `state[2]` (yaw) back to `[-π, π]` in the `HOLONOMIC` branch, but the `DIFF_DRIVE` branch was missing this step. As a result, interpolated states could carry non-canonical yaw values, which violates the joint's canonical representation and can cause downstream planning issues.

**Fix:** call the existing `normalizeRotation(state)` helper at the end of the `DIFF_DRIVE` branch — one line added.

## Changes

- `moveit_core/robot_model/src/planar_joint_model.cpp` — add `normalizeRotation(state)` after the `DIFF_DRIVE` interpolation block
- `moveit_core/robot_model/test/test.cpp` — add regression test `InterpolateDiffDriveNormalizesYaw` (reproducer from the issue)

## Test plan

- [ ] New test `PlanarJointTest.InterpolateDiffDriveNormalizesYaw` covers the exact reproducer from the issue
- [ ] Existing `PlanarJointTest.ComputeVariablePositionsNormalizeYaw` continues to pass