### PR TITLE
CMake: remove boost system

### DIFF
--- a/moveit_core/ConfigExtras.cmake
+++ b/moveit_core/ConfigExtras.cmake
@@ -10,5 +10,4 @@ find_package(
   program_options
   regex
   serialization
-  system
   thread)

--- a/moveit_kinematics/ConfigExtras.cmake
+++ b/moveit_kinematics/ConfigExtras.cmake
@@ -1,3 +1,3 @@
 # Extras module needed for dependencies to find boost components
 
-find_package(Boost REQUIRED program_options system)
+find_package(Boost REQUIRED program_options)

--- a/moveit_planners/ompl/CMakeLists.txt
+++ b/moveit_planners/ompl/CMakeLists.txt
@@ -5,14 +5,7 @@ project(moveit_planners_ompl LANGUAGES CXX)
 find_package(moveit_common REQUIRED)
 moveit_package()
 
-find_package(
-  Boost
-  REQUIRED
-  system
-  filesystem
-  date_time
-  thread
-  serialization)
+find_package(Boost REQUIRED filesystem date_time thread serialization)
 find_package(moveit_core REQUIRED)
 find_package(moveit_msgs REQUIRED)
 find_package(moveit_ros_planning REQUIRED)

--- a/moveit_plugins/moveit_ros_control_interface/ConfigExtras.cmake
+++ b/moveit_plugins/moveit_ros_control_interface/ConfigExtras.cmake
@@ -1,3 +1,3 @@
 # Extras module needed for dependencies to find boost components
 
-find_package(Boost REQUIRED COMPONENTS system thread)
+find_package(Boost REQUIRED COMPONENTS thread)

--- a/moveit_ros/move_group/ConfigExtras.cmake
+++ b/moveit_ros/move_group/ConfigExtras.cmake
@@ -1,10 +1,3 @@
 # Extras module needed for dependencies to find boost components
 
-find_package(
-  Boost
-  REQUIRED
-  system
-  filesystem
-  date_time
-  program_options
-  thread)
+find_package(Boost REQUIRED filesystem date_time program_options thread)

--- a/moveit_ros/planning/ConfigExtras.cmake
+++ b/moveit_ros/planning/ConfigExtras.cmake
@@ -3,7 +3,6 @@
 find_package(
   Boost
   REQUIRED
-  system
   filesystem
   date_time
   program_options

--- a/moveit_ros/planning_interface/ConfigExtras.cmake
+++ b/moveit_ros/planning_interface/ConfigExtras.cmake
@@ -8,4 +8,4 @@ find_package(
   Boost REQUIRED
   COMPONENTS date_time filesystem program_options
              # ${BOOST_PYTHON_COMPONENT}
-             system thread)
+             thread)

--- a/moveit_ros/visualization/ConfigExtras.cmake
+++ b/moveit_ros/visualization/ConfigExtras.cmake
@@ -1,3 +1,3 @@
 # Extras module needed for dependencies to find boost components
 
-find_package(Boost REQUIRED thread date_time system filesystem)
+find_package(Boost REQUIRED thread date_time filesystem)

--- a/moveit_ros/warehouse/ConfigExtras.cmake
+++ b/moveit_ros/warehouse/ConfigExtras.cmake
@@ -4,7 +4,6 @@ find_package(
   Boost
   REQUIRED
   thread
-  system
   filesystem
   regex
   date_time


### PR DESCRIPTION
Hi,

This fix for boost >= 1.89:
```cmake
CMake Error at /nix/store/4qaj1kkf1p3al8z190px12ma6r8jbgqj-boost-1.89.0-dev/lib/cmake/Boost-1.89.0/BoostConfig.cmake:141 (find_package):
  Could not find a package configuration file provided by "boost_system"
  (requested version 1.89.0) with any of the following names:

    boost_systemConfig.cmake
    boost_system-config.cmake

  Add the installation prefix of "boost_system" to CMAKE_PREFIX_PATH or set
  "boost_system_DIR" to a directory containing one of the above files.  If
  "boost_system" provides a separate development package or SDK, be sure it
  has been installed.
Call Stack (most recent call first):
  /nix/store/4qaj1kkf1p3al8z190px12ma6r8jbgqj-boost-1.89.0-dev/lib/cmake/Boost-1.89.0/BoostConfig.cmake:262 (boost_find_component)
  /nix/store/v2i1hgv567g3v91im5x4g5bff52143i0-cmake-4.1.2/share/cmake-4.1/Modules/FindBoost.cmake:609 (find_package)
  ConfigExtras.cmake:3 (find_package)
  CMakeLists.txt:43 (include)
```

boost system has been header only since release 1.69 (December 5, 2018), and a useless stub was provided instead.

in 1.89 (August 6, 2025), that stub was removed, so CMake fail if we require it.

ref. https://www.boost.org/doc/libs/latest/libs/system/doc/html/system.html#changes_in_boost_1_89