### PR TITLE
Replace raw Observer* by a shared ptr as part of world.

### DIFF
--- a/moveit_core/collision_detection/include/moveit/collision_detection/world.hpp
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/world.hpp
@@ -289,15 +289,15 @@ public:
   class ObserverHandle
   {
   public:
-    ObserverHandle() : observer_(nullptr)
+    ObserverHandle() : observer_()
     {
     }
 
   private:
-    ObserverHandle(const Observer* o) : observer_(o)
+    ObserverHandle(const std::shared_ptr<Observer>& o) : observer_(o)
     {
     }
-    const Observer* observer_;
+    std::weak_ptr<Observer> observer_;
     friend class World;
   };
 
@@ -349,6 +349,6 @@ private:
   };
 
   /// All registered observers of this world representation
-  std::vector<Observer*> observers_;
+  std::vector<std::shared_ptr<Observer>> observers_;
 };
 }  // namespace collision_detection

--- a/moveit_core/collision_detection/src/world.cpp
+++ b/moveit_core/collision_detection/src/world.cpp
@@ -402,7 +402,7 @@ void World::updateGlobalPosesInternal(ObjectPtr& obj, bool update_shape_poses, b
 
 World::ObserverHandle World::addObserver(const ObserverCallbackFn& callback)
 {
-  const auto o = new Observer(callback);
+  const auto o = std::make_shared<Observer>(callback);
   observers_.push_back(o);
   return ObserverHandle(o);
 }
@@ -411,9 +411,8 @@ void World::removeObserver(ObserverHandle observer_handle)
 {
   for (auto obs = observers_.begin(); obs != observers_.end(); ++obs)
   {
-    if (*obs == observer_handle.observer_)
+    if (obs->get() == observer_handle.observer_.lock().get())
     {
-      delete *obs;
       observers_.erase(obs);
       return;
     }
@@ -428,15 +427,15 @@ void World::notifyAll(Action action)
 
 void World::notify(const ObjectConstPtr& obj, Action action)
 {
-  for (Observer* observer : observers_)
+  for (const auto& observer : observers_)
     observer->callback_(obj, action);
 }
 
 void World::notifyObserverAllObjects(const ObserverHandle observer_handle, Action action) const
 {
-  for (auto observer : observers_)
+  for (const auto& observer : observers_)
   {
-    if (observer == observer_handle.observer_)
+    if (observer.get() == observer_handle.observer_.lock().get())
     {
       // call the callback for each object
       for (const auto& object : objects_)


### PR DESCRIPTION
### Description

As mentioned in https://github.com/moveit/moveit2/issues/860 , this aims to start removing raw pointers, and replace them by smart pointers.
In particular, this PR removes the `Observer*` ptr from `world.hpp`  and replaces it with:
- A definition as a `std::vector<std::shared_ptr<Observer>>` in the `World` object, which owns the observers.
- A definition as a `std::weak_ptr<Observer>` in the `ObserverHandle` object, which accesses the object.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
