### PR TITLE
Add non-blocking Rolling-on-Resolute CI job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,6 +31,16 @@ jobs:
             ROS_DISTRO: rolling
             # Non-blocking job to surface deprecation warnings
             DEPRECATION_CHECK: true
+          # Rolling on Ubuntu Resolute. No prebuilt rolling-resolute base image exists yet
+          # (https://github.com/osrf/docker_images/issues/878), so we omit DOCKER_IMAGE and let
+          # industrial_ci build on ubuntu:resolute, installing Rolling from the ros-testing repo.
+          # Setting OS_CODE_NAME=resolute also avoids industrial_ci's default of pinning Rolling to
+          # the latest Noble-supported index. Non-blocking until all Resolute packages are released.
+          - IMAGE: rolling-resolute
+            ROS_DISTRO: rolling
+            OS_CODE_NAME: resolute
+            ROS_REPO: testing
+            SUPPRESS_DEPRECATION_ERROR: true
           - IMAGE: humble-ci
             ROS_DISTRO: humble
           - IMAGE: jazzy-ci
@@ -40,7 +50,6 @@ jobs:
       # https://stackoverflow.com/a/41673702
       CXXFLAGS: >-
         -Wall -Wextra -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls -Wno-unknown-warning-option
-      DOCKER_IMAGE: moveit/moveit2:${{ matrix.env.IMAGE }}
       UPSTREAM_WORKSPACE: >
         moveit2.repos
         $(f="moveit2_$(sed 's/-.*$//' <<< "${{ matrix.env.IMAGE }}").repos"; test -r $f && echo $f)
@@ -74,9 +83,9 @@ jobs:
       CXX: ${{ matrix.env.CLANG_TIDY && 'clang++' }}
       ADDITIONAL_DEBS: lld
 
-    name: ${{ matrix.env.IMAGE }}${{ matrix.env.CCOV && ' + ccov' || ''}}${{ matrix.env.IKFAST_TEST && ' + ikfast' || ''}}${{ matrix.env.CLANG_TIDY && (github.event_name != 'workflow_dispatch' && ' + clang-tidy (delta)' || ' + clang-tidy (all)') || '' }}${{ matrix.env.DEPRECATION_CHECK && ' + deprecation check' || '' }}
+    name: ${{ matrix.env.IMAGE }}${{ matrix.env.CCOV && ' + ccov' || ''}}${{ matrix.env.IKFAST_TEST && ' + ikfast' || ''}}${{ matrix.env.CLANG_TIDY && (github.event_name != 'workflow_dispatch' && ' + clang-tidy (delta)' || ' + clang-tidy (all)') || '' }}${{ matrix.env.DEPRECATION_CHECK && ' + deprecation check' || '' }}${{ matrix.env.OS_CODE_NAME && ' (experimental)' || '' }}
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.env.DEPRECATION_CHECK || false }}
+    continue-on-error: ${{ matrix.env.DEPRECATION_CHECK || matrix.env.OS_CODE_NAME == 'resolute' }}
     steps:
       - name: "Free up disk space"
         if: matrix.env.CCOV
@@ -148,6 +157,11 @@ jobs:
       - name: Generate ikfast packages
         if: matrix.env.IKFAST_TEST
         run: moveit_kinematics/test/test_ikfast_plugins.sh
+      - name: Set prebuilt DOCKER_IMAGE
+        # Jobs that build on a bare OS image (OS_CODE_NAME set) must leave DOCKER_IMAGE unset so
+        # industrial_ci builds the base itself. All other jobs use our prebuilt moveit/moveit2 image.
+        if: ${{ ! matrix.env.OS_CODE_NAME }}
+        run: echo "DOCKER_IMAGE=moveit/moveit2:${{ matrix.env.IMAGE }}" >> "$GITHUB_ENV"
       - id: ici
         name: Run industrial_ci
         uses: ros-industrial/industrial_ci@c553397753252d630e88e7e91aa69c6c8a478ee0


### PR DESCRIPTION
Followup to https://github.com/moveit/moveit2/pull/3734

Rolling moved to Ubuntu Resolute, but our CI in https://github.com/moveit/moveit2/pull/3734 builds it on the frozen Noble index. Setting OS_CODE_NAME=resolute alone has no effect while a custom DOCKER_IMAGE is set, since industrial_ci only honors OS_CODE_NAME when it builds the base itself.

There is no prebuilt rolling-resolute base image yet (https://github.com/osrf/docker_images/issues/878), so leave DOCKER_IMAGE unset for this job: industrial_ci then builds on ubuntu:resolute and installs Rolling from the ros-testing repo.

DOCKER_IMAGE moves to a step that sets it only for prebuilt-image jobs. The new rolling-resolute entry is non-blocking, as not all Resolute packages are released yet. Existing frozen-Noble rolling jobs stay.

### Description

Please explain the changes you made, including a reference to the related issue if applicable

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
