### PR TITLE
Fix MotionPlanning combo box signals for Qt6

### DIFF
--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -119,10 +119,19 @@ MotionPlanningFrame::MotionPlanningFrame(MotionPlanningDisplay* pdisplay, rviz_c
   connect(ui_->execute_button, SIGNAL(clicked()), this, SLOT(executeButtonClicked()));
   connect(ui_->plan_and_execute_button, SIGNAL(clicked()), this, SLOT(planAndExecuteButtonClicked()));
   connect(ui_->stop_button, SIGNAL(clicked()), this, SLOT(stopButtonClicked()));
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+  connect(ui_->start_state_combo_box, &QComboBox::textActivated, this,
+          &MotionPlanningFrame::startStateTextChanged);
+  connect(ui_->goal_state_combo_box, &QComboBox::textActivated, this,
+          &MotionPlanningFrame::goalStateTextChanged);
+  connect(ui_->planning_group_combo_box, &QComboBox::currentTextChanged, this,
+          &MotionPlanningFrame::planningGroupTextChanged);
+#else
   connect(ui_->start_state_combo_box, SIGNAL(activated(QString)), this, SLOT(startStateTextChanged(QString)));
   connect(ui_->goal_state_combo_box, SIGNAL(activated(QString)), this, SLOT(goalStateTextChanged(QString)));
   connect(ui_->planning_group_combo_box, SIGNAL(currentIndexChanged(QString)), this,
           SLOT(planningGroupTextChanged(QString)));
+#endif
   connect(ui_->database_connect_button, SIGNAL(clicked()), this, SLOT(databaseConnectButtonClicked()));
   connect(ui_->save_scene_button, SIGNAL(clicked()), this, SLOT(saveSceneButtonClicked()));
   connect(ui_->save_query_button, SIGNAL(clicked()), this, SLOT(saveQueryButtonClicked()));


### PR DESCRIPTION
## Summary

Fix the MotionPlanning RViz plugin's named-state combo box connections when built against Qt6.

Qt6 no longer exposes the old text-carrying `QComboBox` signal names used by the plugin's string-based connections:

- `activated(QString)`
- `currentIndexChanged(QString)`

In a Qt6 RViz environment this produces runtime warnings such as:

```text
QObject::connect: No such signal QComboBox::activated(QString)
QObject::connect: No such signal QComboBox::currentIndexChanged(QString)
```

When those connections fail, selecting a named Start State or Goal State in the MotionPlanning panel does not invoke the corresponding handler, so selecting a named goal such as `home` does not update the query goal state.

For more details check #3744 

## Changes

- Use `QComboBox::textActivated` for Start State and Goal State under Qt6.
- Use `QComboBox::currentTextChanged` for Planning Group under Qt6.
- Keep the existing Qt5 string-signal connections for Qt5 builds.

## Testing

Tested downstream in a RoboStack Lyrical Qt6 RViz environment by rebuilding `moveit_ros_visualization` with this patch and verifying that the MotionPlanning panel no longer logs the missing `QComboBox` signal warnings and named goal-state selection works again.
