### PR TITLE
Fix out-of-bounds SVD indexing in Servo singularity check for robots with fewer than 6 joints

### DIFF
--- a/moveit_ros/moveit_servo/src/utils/common.cpp
+++ b/moveit_ros/moveit_servo/src/utils/common.cpp
@@ -294,9 +294,6 @@ std::pair<double, StatusCode> velocityScalingFactorForSingularity(const moveit::
   const double hard_stop_singularity_threshold = servo_params.hard_stop_singularity_threshold;
   const double leaving_singularity_threshold_multiplier = servo_params.leaving_singularity_threshold_multiplier;
 
-  // Get size of total controllable dimensions.
-  const size_t dims = target_delta_x.size();
-
   // Get the current Jacobian and compute SVD
   const Eigen::JacobiSVD<Eigen::MatrixXd> current_svd = Eigen::JacobiSVD<Eigen::MatrixXd>(
       robot_state->getJacobian(joint_model_group), Eigen::ComputeThinU | Eigen::ComputeThinV);
@@ -305,15 +302,22 @@ std::pair<double, StatusCode> velocityScalingFactorForSingularity(const moveit::
   // Compute pseudo inverse
   const Eigen::MatrixXd pseudo_inverse = current_svd.matrixV() * matrix_s.inverse() * current_svd.matrixU().transpose();
 
+  // Index of the least singular value. For robots with fewer joints than task
+  // dimensions (e.g. a 4-DOF arm and a 6D twist), the thin SVD has only
+  // num_joints singular values/columns, so indexing with dims - 1 would read
+  // out of bounds and produce a garbage condition number.
+  const Eigen::Index least_sv_index = current_svd.singularValues().size() - 1;
+
   // Get the singular vector corresponding to least singular value.
   // This vector represents the least responsive dimension. By convention this is the last column of the matrix U.
   // The sign of the singular vector from result of SVD is not reliable, so we need to do extra checking to make sure of
   // the sign. See R. Bro, "Resolving the Sign Ambiguity in the Singular Value Decomposition".
-  Eigen::VectorXd vector_towards_singularity = current_svd.matrixU().col(dims - 1);
+  Eigen::VectorXd vector_towards_singularity = current_svd.matrixU().col(least_sv_index);
 
   // Compute the current condition number. The ratio of max and min singular values.
   // By convention these are the first and last element of the diagonal.
-  const double current_condition_number = current_svd.singularValues()(0) / current_svd.singularValues()(dims - 1);
+  const double current_condition_number =
+      current_svd.singularValues()(0) / current_svd.singularValues()(least_sv_index);
 
   // Take a small step in the direction of vector_towards_singularity
   const Eigen::VectorXd delta_x = vector_towards_singularity * servo_params.singularity_step_scale;
@@ -329,7 +333,8 @@ std::pair<double, StatusCode> velocityScalingFactorForSingularity(const moveit::
       robot_state->getJacobian(joint_model_group), Eigen::ComputeThinU | Eigen::ComputeThinV);
 
   // Compute condition number for the new Jacobian.
-  const double next_condition_number = next_svd.singularValues()(0) / next_svd.singularValues()(dims - 1);
+  const double next_condition_number =
+      next_svd.singularValues()(0) / next_svd.singularValues()(next_svd.singularValues().size() - 1);
 
   // If the condition number has increased, we are moving towards singularity and the direction of the
   // vector_towards_singularity is correct. If the condition number has decreased, it means the sign of

--- a/moveit_ros/moveit_servo/tests/test_utils.cpp
+++ b/moveit_ros/moveit_servo/tests/test_utils.cpp
@@ -208,6 +208,55 @@ TEST(ServoUtilsUnitTests, HaltForSingularityScaling)
   ASSERT_EQ(scaling_result.second, moveit_servo::StatusCode::HALT_FOR_SINGULARITY);
 }
 
+TEST(ServoUtilsUnitTests, SingularityScalingFewerThanSixJoints)
+{
+  // A 4-DOF arm: pan joint about z, then three pitch joints about y with
+  // vertical link offsets. Its Jacobian is 6x4, so the thin SVD has only 4
+  // singular values / U columns: indexing them with the task dimension
+  // (6) - 1 read out of bounds and computed the condition number from garbage
+  // memory, halting low-DOF robots regardless of the configured thresholds.
+  moveit::core::RobotModelBuilder builder("four_dof_bot", "base_link");
+  builder.addChain("base_link->torso", "revolute", {}, urdf::Vector3(0, 0, 1));
+  geometry_msgs::msg::Pose origin;
+  origin.orientation.w = 1.0;
+  std::vector<geometry_msgs::msg::Pose> origins(3, origin);
+  origins[0].position.z = 0.3;
+  origins[1].position.z = 0.25;
+  origins[2].position.z = 0.2;
+  builder.addChain("torso->upper_arm->lower_arm->wrist", "revolute", origins, urdf::Vector3(0, 1, 0));
+  builder.addGroupChain("base_link", "wrist", "arm");
+  ASSERT_TRUE(builder.isValid());
+  moveit::core::RobotModelPtr robot_model = builder.build();
+  moveit::core::RobotStatePtr robot_state = std::make_shared<moveit::core::RobotState>(robot_model);
+  const auto joint_model_group = robot_state->getJointModelGroup("arm");
+  robot_state->setToDefaultValues();
+
+  servo::Params servo_params;
+  servo_params.move_group_name = "arm";
+  // A 6x4 Jacobian cannot span the 6D task space, so low-DOF arms have
+  // structurally large condition numbers and need thresholds sized for their
+  // geometry; this test checks indexing correctness, not threshold policy.
+  servo_params.lower_singularity_threshold = 100.0;
+  servo_params.hard_stop_singularity_threshold = 500.0;
+
+  const Eigen::Vector<double, 6> cartesian_delta{ 0.005, 0.0, 0.0, 0.0, 0.0, 0.0 };
+
+  // Well-conditioned bent posture: condition number ~33.
+  Eigen::Vector<double, 4> bent_state{ 0.0, 0.4, -0.6, 0.4 };
+  robot_state->setJointGroupActivePositions(joint_model_group, bent_state);
+  auto scaling_result = moveit_servo::velocityScalingFactorForSingularity(robot_state, cartesian_delta, servo_params);
+  EXPECT_EQ(scaling_result.second, moveit_servo::StatusCode::NO_WARNING);
+  EXPECT_DOUBLE_EQ(scaling_result.first, 1.0);
+
+  // Nearly fully extended posture: condition number ~979, above the hard-stop
+  // threshold, so the robot must halt.
+  Eigen::Vector<double, 4> near_singular_state{ 0.0, 0.02, -0.02, 0.02 };
+  robot_state->setJointGroupActivePositions(joint_model_group, near_singular_state);
+  scaling_result = moveit_servo::velocityScalingFactorForSingularity(robot_state, cartesian_delta, servo_params);
+  EXPECT_EQ(scaling_result.second, moveit_servo::StatusCode::HALT_FOR_SINGULARITY);
+  EXPECT_DOUBLE_EQ(scaling_result.first, 0.0);
+}
+
 TEST(ServoUtilsUnitTests, LeavingSingularityScaling)
 {
   using moveit::core::loadTestingRobotModel;


### PR DESCRIPTION
### Description

`velocityScalingFactorForSingularity()` in `moveit_servo` indexes the SVD of the robot Jacobian with the Cartesian task dimension instead of the number of singular values. The Jacobian is `6 x num_joints`, and the thin SVD (`ComputeThinU`) therefore has `min(6, num_joints)` singular values and U columns, but the code reads `singularValues()(dims - 1)` and `matrixU().col(dims - 1)` with `dims = 6` always. For any move group with fewer than 6 active joints, both accesses are out of bounds. Because release builds define `NDEBUG`, Eigen's bounds assertions are compiled out and the reads silently return garbage memory: the computed "condition number" is sigma_max divided by an arbitrary value, which is almost always far above `hard_stop_singularity_threshold`, so Servo emits `HALT_FOR_SINGULARITY` ("Very close to a singularity, emergency stop") on effectively every TWIST/POSE command, independent of the configured thresholds. The corrupted last-U-column also breaks the moving-toward/away-from-singularity classification that selects the deceleration band.

This explains several reports that were closed without the root cause being found: #3411 (4-DOF arm, constant emergency stops; the reporter worked around it by adding two fake virtual joints to the URDF, which "fixes" the issue only by making the out-of-bounds index legal), #2760, and ROBOTIS-GIT/open_manipulator#192. It is related to but independent of the drift-dimensions discussion in moveit/moveit_msgs#185: even with structurally large condition numbers, users of low-DOF arms can tune thresholds — but only if the condition number is actually computed from their robot's geometry rather than from undefined behavior.

How this was found: a 4-DOF robot emergency-stopped on every POSE/TWIST command under Jazzy. The decisive symptom was that changing `lower_singularity_threshold` / `hard_stop_singularity_threshold` had *no effect whatsoever* on the behavior, which is impossible if the halting decision compares a geometry-derived condition number against those thresholds, and pointed to the comparison itself being broken. Reading `velocityScalingFactorForSingularity()` with the robot's 6x4 Jacobian in mind showed the thin SVD is indexed by the task dimension (6) rather than the number of singular values (4). With the index fixed, the computed condition numbers match an independent numerical model of the arm to four significant figures.

The fix indexes by `singularValues().size() - 1`, which is the position of sigma_min for any number of joints (singular values are sorted in decreasing order), and uses the corresponding last column of thin U as the least-responsive direction. For robots with 6 or more joints in the group this evaluates to the same index 5 as before, so behavior is unchanged for existing 6/7-DOF users.

A unit test is added that builds a 4-DOF chain with `RobotModelBuilder` and calls `velocityScalingFactorForSingularity()` directly, asserting both branches: a well-conditioned bent posture (condition number ~33, verified against an independent numerical model of the same kinematics) must return `NO_WARNING` with scale 1.0, and a near-extended posture (condition number ~979) must return `HALT_FOR_SINGULARITY` with scale 0.0, with at least 2x margin between every condition number and its threshold. The test was verified to fail against the stock, unpatched 2.12.4 release library (it spuriously halts at the well-conditioned posture) — no sanitizer needed; additionally, ASan and debug builds (`eigen_assert`) catch the out-of-bounds read itself deterministically. The existing Panda-based singularity tests pass unchanged.

Verified on real hardware: the same 4-DOF arm that previously emergency-stopped on every pose command now servos correctly with thresholds tuned to its structural condition-number range.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://contributing/code)
- [x] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/) (not applicable: bug fix, no API or behavior change for supported
configurations)
- [x] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes (not applicable: no API change)
- [x] Create tests, which fail without this PR [reference](https://moveit.pitests/tests_tutorial.html)
- [x] Include a screenshot if changing a GUI (not applicable)
- [x] While waiting for someone to review your request, please help review [tps://github.com/moveit/moveit2/pulls) to support the maintainers