### PR TITLE
resolute: migrate moveit_hybrid_planning off removed position_controllers

### DIFF
--- a/moveit_ros/hybrid_planning/package.xml
+++ b/moveit_ros/hybrid_planning/package.xml
@@ -30,7 +30,7 @@
   <depend>trajectory_msgs</depend>
 
   <exec_depend>controller_manager</exec_depend>
-  <exec_depend>position_controllers</exec_depend>
+  <exec_depend>forward_command_controller</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>rviz2</exec_depend>
   <exec_depend>moveit_resources_panda_moveit_config</exec_depend>
@@ -41,7 +41,7 @@
   <test_depend>moveit_planners_ompl</test_depend>
   <test_depend>moveit_resources_panda_moveit_config</test_depend>
   <test_depend>moveit_simple_controller_manager</test_depend>
-  <test_depend>position_controllers</test_depend>
+  <test_depend>forward_command_controller</test_depend>
   <test_depend>robot_state_publisher</test_depend>
   <test_depend>ros_testing</test_depend>
 

--- a/moveit_ros/hybrid_planning/test/config/demo_controller.yaml
+++ b/moveit_ros/hybrid_planning/test/config/demo_controller.yaml
@@ -6,7 +6,7 @@ controller_manager:
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster
     panda_joint_group_position_controller:
-      type: position_controllers/JointGroupPositionController
+      type: forward_command_controller/ForwardCommandController
 
 panda_arm_controller:
   ros__parameters:
@@ -26,6 +26,7 @@ panda_arm_controller:
 
 panda_joint_group_position_controller:
   ros__parameters:
+    interface_name: position
     joints:
       - panda_joint1
       - panda_joint2


### PR DESCRIPTION
ros2_controllers/position_controllers was removed in ros-controls/ros2_controllers#2016 (merged 2026-04-23, released as 6.7.0). The deprecation guidance from #1913 is to replace position_controllers/JointGroupPositionController with forward_command_controller/ForwardCommandController and add interface_name: position.

- moveit_ros/hybrid_planning/test/config/demo_controller.yaml: swap controller type, add interface_name parameter.
- moveit_ros/hybrid_planning/package.xml: swap exec_depend and test_depend from position_controllers to forward_command_controller.

The two moveit_resources packages (panda_moveit_config, fanuc_moveit_config) also reference position_controllers but live in a different repo; this commit only fixes the moveit2-side hybrid_planning instance.

### Description

Please explain the changes you made, including a reference to the related issue if applicable

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
