### PR TITLE
resolute: add explicit <cstdint> / <fstream> includes for GCC 15

### DIFF
--- a/moveit_core/planning_scene/test/test_planning_scene.cpp
+++ b/moveit_core/planning_scene/test/test_planning_scene.cpp
@@ -34,6 +34,7 @@
 
 /* Author: Ioan Sucan */
 
+#include <cstdint>
 #include <gtest/gtest.h>
 #include <moveit/collision_detection_fcl/collision_detector_allocator_fcl.hpp>
 #include <moveit/planning_scene/planning_scene.hpp>

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/model_based_planning_context.hpp
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/model_based_planning_context.hpp
@@ -36,6 +36,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <moveit/ompl_interface/parameterization/model_based_state_space.hpp>
 #include <moveit/constraint_samplers/constraint_sampler_manager.hpp>
 #include <moveit/planning_interface/planning_interface.hpp>

--- a/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
@@ -39,6 +39,7 @@
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/lexical_cast.hpp>
 
+#include <cstdint>
 #include <moveit/ompl_interface/model_based_planning_context.hpp>
 #include <moveit/ompl_interface/detail/state_validity_checker.hpp>
 #include <moveit/ompl_interface/detail/constrained_sampler.hpp>

--- a/moveit_planners/pilz_industrial_motion_planner/test/test_utils.hpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/test_utils.hpp
@@ -34,6 +34,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <gtest/gtest.h>
 #ifndef INSTANTIATE_TEST_SUITE_P  // prior to gtest 1.10
 #define INSTANTIATE_TEST_SUITE_P(...) INSTANTIATE_TEST_CASE_P(__VA_ARGS__)

--- a/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_trajectory_functions.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/unit_tests/src/unittest_trajectory_functions.cpp
@@ -32,6 +32,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
+#include <cstdint>
 #include <gtest/gtest.h>
 
 #include <map>

--- a/moveit_py/src/moveit/moveit_py_utils/include/moveit_py/moveit_py_utils/rclpy_time_typecaster.hpp
+++ b/moveit_py/src/moveit/moveit_py_utils/include/moveit_py/moveit_py_utils/rclpy_time_typecaster.hpp
@@ -34,6 +34,7 @@
 
 /* Author: Shobin Vinod */
 
+#include <cstdint>
 #include <pybind11/pybind11.h>
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp/serialization.hpp>

--- a/moveit_py/src/moveit/moveit_py_utils/include/moveit_py/moveit_py_utils/ros_msg_typecasters.hpp
+++ b/moveit_py/src/moveit/moveit_py_utils/include/moveit_py/moveit_py_utils/ros_msg_typecasters.hpp
@@ -36,6 +36,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <pybind11/pybind11.h>
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp/serialization.hpp>

--- a/moveit_ros/hybrid_planning/local_planner/local_planner_component/include/moveit/local_planner/local_planner_component.hpp
+++ b/moveit_ros/hybrid_planning/local_planner/local_planner_component/include/moveit/local_planner/local_planner_component.hpp
@@ -39,6 +39,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp/version.h>
 #include <rclcpp_action/rclcpp_action.hpp>

--- a/moveit_ros/moveit_servo/demos/servo_keyboard_input.cpp
+++ b/moveit_ros/moveit_servo/demos/servo_keyboard_input.cpp
@@ -40,6 +40,7 @@
 
 #include <chrono>
 #include <control_msgs/msg/joint_jog.hpp>
+#include <cstdint>
 #include <geometry_msgs/msg/twist_stamped.hpp>
 #include <moveit_msgs/srv/servo_command_type.hpp>
 #include <rclcpp/executors/single_threaded_executor.hpp>

--- a/moveit_ros/moveit_servo/include/moveit_servo/utils/datatypes.hpp
+++ b/moveit_ros/moveit_servo/include/moveit_servo/utils/datatypes.hpp
@@ -41,6 +41,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <tf2_eigen/tf2_eigen.hpp>
 #include <unordered_map>

--- a/moveit_ros/moveit_servo/src/servo_node.cpp
+++ b/moveit_ros/moveit_servo/src/servo_node.cpp
@@ -39,6 +39,7 @@
  */
 
 #if __has_include(<realtime_tools/realtime_helpers.hpp>)
+#include <cstdint>
 #include <realtime_tools/realtime_helpers.hpp>
 #else
 #include <realtime_tools/thread_priority.hpp>

--- a/moveit_ros/perception/mesh_filter/include/moveit/mesh_filter/mesh_filter_base.hpp
+++ b/moveit_ros/perception/mesh_filter/include/moveit/mesh_filter/mesh_filter_base.hpp
@@ -36,6 +36,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <map>
 #include <moveit/macros/class_forward.hpp>
 #include <moveit/mesh_filter/gl_renderer.hpp>

--- a/moveit_ros/perception/mesh_filter/src/depth_self_filter_nodelet.cpp
+++ b/moveit_ros/perception/mesh_filter/src/depth_self_filter_nodelet.cpp
@@ -34,6 +34,7 @@
 
 /* Author: Suat Gedikli */
 
+#include <cstdint>
 #include <moveit/mesh_filter/depth_self_filter_nodelet.hpp>
 #include <moveit/mesh_filter/stereo_camera_model.hpp>
 #include <moveit/mesh_filter/mesh_filter.hpp>

--- a/moveit_ros/planning/plan_execution/src/plan_execution.cpp
+++ b/moveit_ros/planning/plan_execution/src/plan_execution.cpp
@@ -34,6 +34,7 @@
 
 /* Author: Ioan Sucan */
 
+#include <cstdint>
 #include <moveit/plan_execution/plan_execution.hpp>
 #include <moveit/robot_state/conversions.hpp>
 #include <moveit/trajectory_processing/trajectory_tools.hpp>

--- a/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.hpp
+++ b/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.hpp
@@ -37,6 +37,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <moveit/macros/class_forward.hpp>
 #include <moveit/robot_state/robot_state.hpp>
 #include <moveit/utils/moveit_error_code.hpp>

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -36,6 +36,7 @@
 
 /* Author: Ioan Sucan, Sachin Chitta */
 
+#include <cstdint>
 #include <stdexcept>
 #include <sstream>
 #include <memory>

--- a/moveit_ros/trajectory_cache/include/moveit/trajectory_cache/trajectory_cache.hpp
+++ b/moveit_ros/trajectory_cache/include/moveit/trajectory_cache/trajectory_cache.hpp
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <chrono>
+#include <cstdint>
 #include <memory>
 #include <vector>
 

--- a/moveit_ros/trajectory_cache/src/trajectory_cache.cpp
+++ b/moveit_ros/trajectory_cache/src/trajectory_cache.cpp
@@ -18,6 +18,7 @@
  */
 
 #include <chrono>
+#include <cstdint>
 #include <memory>
 #include <vector>
 

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/mesh_shape.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/mesh_shape.cpp
@@ -27,6 +27,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <cstdint>
 #include <ogre_helpers/mesh_shape.hpp>
 
 #include <OgreMesh.h>

--- a/moveit_ros/warehouse/src/broadcast.cpp
+++ b/moveit_ros/warehouse/src/broadcast.cpp
@@ -34,6 +34,7 @@
 
 /* Author: Ioan Sucan */
 
+#include <cstdint>
 #include <moveit/warehouse/planning_scene_storage.hpp>
 #include <moveit/warehouse/constraints_storage.hpp>
 #include <moveit/warehouse/state_storage.hpp>

--- a/moveit_setup_assistant/moveit_setup_assistant/src/collisions_updater.cpp
+++ b/moveit_setup_assistant/moveit_setup_assistant/src/collisions_updater.cpp
@@ -34,6 +34,7 @@
 
 /* Author: Mathias Lüdtke */
 
+#include <cstdint>
 #include <moveit_setup_srdf_plugins/default_collisions.hpp>
 #include <moveit_setup_framework/data/package_settings_config.hpp>
 #include <moveit_setup_framework/data/srdf_config.hpp>

--- a/moveit_setup_assistant/moveit_setup_simulation/src/simulation.cpp
+++ b/moveit_setup_assistant/moveit_setup_simulation/src/simulation.cpp
@@ -34,6 +34,8 @@
 
 /* Author: David V. Lu!! */
 
+#include <fstream>
+
 #include <moveit_setup_simulation/simulation.hpp>
 
 namespace moveit_setup


### PR DESCRIPTION
GCC 15 (default on Ubuntu Resolute) stopped transitively including <cstdint> and <ostream> through other standard headers. Any translation unit that uses uint8_t / int32_t / std::endl etc. without the explicit include can fail to compile.

- Add <cstdint> to 21 files (headers + cpp) that use fixed-width integer types directly. Alphabetically ordered in each include block.
- Add <fstream> to moveit_setup_simulation/src/simulation.cpp, which uses std::ofstream / std::endl with only a single project-header include. <fstream> transitively brings in <ostream>.

This is speculative cleanup based on the GCC 15 porting guide and upstream ros2 reports of the same class of failure; the files compile fine under GCC 13 with the change since <cstdint> is a no-op when the type is already visible.

Refs:
- https://gcc.gnu.org/gcc-15/porting_to.html
- moveit/moveit2#3603 (boost::regex vs std::regex; same class of issue)

### Description

Please explain the changes you made, including a reference to the related issue if applicable

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
