### PR TITLE
resolute: raise octomap version pin to allow 1.10

### DIFF
--- a/moveit_core/CMakeLists.txt
+++ b/moveit_core/CMakeLists.txt
@@ -18,9 +18,7 @@ find_package(geometric_shapes REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(kdl_parser REQUIRED)
 find_package(moveit_msgs REQUIRED)
-# Enforce system version liboctomap-dev
-# https://github.com/moveit/moveit2/issues/2862
-find_package(octomap 1.9.7...<1.10.0 REQUIRED)
+find_package(octomap REQUIRED)
 find_package(octomap_msgs REQUIRED)
 find_package(osqp REQUIRED)
 find_package(pluginlib REQUIRED)

--- a/moveit_ros/occupancy_map_monitor/CMakeLists.txt
+++ b/moveit_ros/occupancy_map_monitor/CMakeLists.txt
@@ -13,9 +13,7 @@ find_package(moveit_core REQUIRED)
 find_package(moveit_msgs REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(Eigen3 REQUIRED)
-# Enforce system version liboctomap-dev
-# https://github.com/moveit/moveit2/issues/2862
-find_package(octomap 1.9.7...<1.10.0 REQUIRED)
+find_package(octomap REQUIRED)
 find_package(geometric_shapes REQUIRED)
 find_package(tf2_ros REQUIRED)
 


### PR DESCRIPTION
Drop the `1.9.7...<1.10.0` version range on `find_package(octomap)` in `moveit_core/CMakeLists.txt` and `moveit_ros/occupancy_map_monitor/CMakeLists.txt`. moveit2 already treats octomap like any other system dependency since [PR #2881](https://github.com/moveit/moveit2/pull/2881) switched both packages from `<depend>octomap</depend>` to `<depend>liboctomap-dev</depend>` — the version range was the leftover artifact of [#2862](https://github.com/moveit/moveit2/issues/2862)'s defensive workaround for an ABI skew that moveit2's own deps can no longer create.

The narrow upper cap also blocks moveit_core from configuring on Ubuntu Resolute, which ships `liboctomap-dev 1.10.0+dfsg-3`.

A plain `find_package(octomap REQUIRED)` matches the convention used by `fcl`, `Eigen3`, `pluginlib`, and every other system-installed dep in `moveit_core/CMakeLists.txt`.

### Verification

Built `moveit_core` and `moveit_ros_occupancy_map_monitor` against system `liboctomap-dev 1.10.0` on `ubuntu:resolute` and against system `liboctomap-dev 1.9.7` on a Noble container — both configure and build cleanly.

### Checklist

- [x] **Required by CI**: Code is auto formatted using clang-format (CMake only; cmake-format applied)
- [ ] Extend the tutorials / documentation — N/A
- [ ] Document API changes relevant to the user in the MIGRATION.md notes — N/A (build-system change)
- [ ] Create tests, which fail without this PR — N/A
- [ ] Include a screenshot if changing a GUI — N/A
