### PR TITLE
resolute: fix depth_image_octomap_updater for image_transport 7.x

### DIFF
--- a/moveit_ros/perception/depth_image_octomap_updater/src/depth_image_octomap_updater.cpp
+++ b/moveit_ros/perception/depth_image_octomap_updater/src/depth_image_octomap_updater.cpp
@@ -119,10 +119,22 @@ bool DepthImageOctomapUpdater::setParams(const std::string& name_space)
 bool DepthImageOctomapUpdater::initialize(const rclcpp::Node::SharedPtr& node)
 {
   node_ = node;
+  // image_transport 7+ (rclcpp >= 30, currently Rolling only) requires a
+  // NodeInterfaces-compatible reference; earlier versions on Humble (3.x),
+  // Jazzy (5.x), and Kilted (6.x) still take a rclcpp::Node::SharedPtr.
+  // For Rolling, L-turtle, and newer
+#if RCLCPP_VERSION_GTE(30, 0, 0)
+  input_depth_transport_ = std::make_unique<image_transport::ImageTransport>(*node_);
+  model_depth_transport_ = std::make_unique<image_transport::ImageTransport>(*node_);
+  filtered_depth_transport_ = std::make_unique<image_transport::ImageTransport>(*node_);
+  filtered_label_transport_ = std::make_unique<image_transport::ImageTransport>(*node_);
+  // For Kilted and older
+#else
   input_depth_transport_ = std::make_unique<image_transport::ImageTransport>(node_);
   model_depth_transport_ = std::make_unique<image_transport::ImageTransport>(node_);
   filtered_depth_transport_ = std::make_unique<image_transport::ImageTransport>(node_);
   filtered_label_transport_ = std::make_unique<image_transport::ImageTransport>(node_);
+#endif
 
   tf_buffer_ = monitor_->getTFClient();
   free_space_updater_ = std::make_unique<LazyFreeSpaceUpdater>(tree_);


### PR DESCRIPTION
image_transport 7.0 (Rolling, available on Resolute) removed the rclcpp::Node::SharedPtr-accepting ImageTransport constructor in favor of a NodeInterfaces template. The new form requires a type that directly exposes get_node_*_interface() methods; a shared_ptr<rclcpp::Node> does not. Pass *node_ (the dereferenced rclcpp::Node) instead.

Same change applies to Humble/Jazzy because image_transport 5+ already accepts a Node& as the equivalent overload.

### Description

Please explain the changes you made, including a reference to the related issue if applicable

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
