### PR TITLE
Switch Tutorial job to target ROS Jazzy to improve stability

### DIFF
--- a/.github/workflows/tutorial_docker.yaml
+++ b/.github/workflows/tutorial_docker.yaml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         ROS_DISTRO: [jazzy]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       packages: write
       contents: read

--- a/.github/workflows/tutorial_docker.yaml
+++ b/.github/workflows/tutorial_docker.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ROS_DISTRO: [rolling]
+        ROS_DISTRO: [jazzy]
     runs-on: ubuntu-latest
     permissions:
       packages: write

--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ For the commercially supported version see [MoveIt Pro](http://picknik.ai/pro).
 
 See our extensive [Tutorials and Documentation](https://moveit.picknik.ai/).
 
+
+## Branch Policy
+
+| Branch | Use Case | Breaking changes | Distro scope | Bloomed to buildfarm |
+|--------|----------|------------------|--------------|----------------------|
+| main | Development | Yes | All active distros (distro-portable) | Only rolling |
+| humble / jazzy / kilted | Stable release branches | No (only backport bug fixes) | Exactly one distro | Exactly one distro |
+
 ## Install
 
 - [Binary Install](https://moveit.ros.org/install-moveit2/binary/)


### PR DESCRIPTION
From MoveIt maintainer meeting June 16, Isaac and I decided to have the Tutorial job target ROS jazzy, with a source build of `main`. The reasons are:
- Rolling for resolute does not build right now
  - Even if it was, it can be hard to keep up with breaking changes on rolling
- We do not yet have a MoveIt2 Lyrical release, the most recent LTS distro
- We enable users to use the latest features on any active distro via a source build of `main`, so new features (that might be breaking changes) featured the docs can be used on Jazzy

Add table to README describing the use cases for each branch.

### Description

Please explain the changes you made, including a reference to the related issue if applicable

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](https://moveit.ai/documentation/contributing/pullrequests/)
- [ ] Extend the tutorials / documentation [reference](https://github.com/moveit/moveit2_tutorials)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
