### PR TITLE
Use modern --frame-id/--child-frame-id args for test static_transform_publisher

### DIFF
--- a/moveit_planners/test_configs/prbt_moveit_config/launch/demo.launch.py
+++ b/moveit_planners/test_configs/prbt_moveit_config/launch/demo.launch.py
@@ -168,7 +168,7 @@ def generate_launch_description():
         executable="static_transform_publisher",
         name="static_transform_publisher",
         output="log",
-        arguments=["0.0", "0.0", "0.0", "0.0", "0.0", "0.0", "world", "prbt_link0"],
+        arguments=["--frame-id", "world", "--child-frame-id", "prbt_link0"],
     )
 
     # Publish TF

--- a/moveit_ros/hybrid_planning/test/launch/test_basic_integration.test.py
+++ b/moveit_ros/hybrid_planning/test/launch/test_basic_integration.test.py
@@ -42,7 +42,7 @@ def generate_test_description():
         executable="static_transform_publisher",
         name="static_transform_publisher",
         output="log",
-        arguments=["0.0", "0.0", "0.0", "0.0", "0.0", "0.0", "world", "panda_link0"],
+        arguments=["--frame-id", "world", "--child-frame-id", "panda_link0"],
     )
 
     # Publish TF

--- a/moveit_ros/planning_interface/test/launch/move_group_launch_test_common.py
+++ b/moveit_ros/planning_interface/test/launch/move_group_launch_test_common.py
@@ -39,7 +39,7 @@ def generate_move_group_test_description(*args, gtest_name: SomeSubstitutionsTyp
         executable="static_transform_publisher",
         name="static_transform_publisher",
         output="log",
-        arguments=["0.0", "0.0", "0.0", "0.0", "0.0", "0.0", "world", "panda_link0"],
+        arguments=["--frame-id", "world", "--child-frame-id", "panda_link0"],
     )
 
     # Publish TF

--- a/moveit_ros/tests/launch/move_group_api.test.py
+++ b/moveit_ros/tests/launch/move_group_api.test.py
@@ -78,7 +78,7 @@ def generate_test_description():
         executable="static_transform_publisher",
         name="static_transform_publisher",
         output="log",
-        arguments=["0.0", "0.0", "0.0", "0.0", "0.0", "0.0", "world", "panda_link0"],
+        arguments=["--frame-id", "world", "--child-frame-id", "panda_link0"],
     )
 
     # Publish TF

--- a/moveit_ros/trajectory_cache/test/fixtures/gtest_with_move_group.py
+++ b/moveit_ros/trajectory_cache/test/fixtures/gtest_with_move_group.py
@@ -34,7 +34,7 @@ def generate_test_description():
         package="tf2_ros",
         executable="static_transform_publisher",
         output="log",
-        arguments=["0.0", "0.0", "0.0", "0.0", "0.0", "0.0", "world", "panda_link0"],
+        arguments=["--frame-id", "world", "--child-frame-id", "panda_link0"],
     )
 
     robot_state_publisher = Node(

--- a/moveit_ros/trajectory_cache/test/test_trajectory_cache.py
+++ b/moveit_ros/trajectory_cache/test/test_trajectory_cache.py
@@ -56,7 +56,7 @@ def robot_fixture(moveit_config):
         package="tf2_ros",
         executable="static_transform_publisher",
         output="log",
-        arguments=["0.0", "0.0", "0.0", "0.0", "0.0", "0.0", "world", "panda_link0"],
+        arguments=["--frame-id", "world", "--child-frame-id", "panda_link0"],
     )
 
     robot_state_publisher = Node(


### PR DESCRIPTION
tf2_ros 0.46.0 (Rolling) removed the positional-argument form of static_transform_publisher; only the named-arg form remains:

`static_transform_publisher --frame-id FRAME_ID --child-frame-id CHILD`

Six test fixtures still passed positional args; static_transform_publisher exited immediately every launch with `error parsing command line arguments: Frame id must not be empty`. The move_group node still started, but the world→<robot_base> TF never published. Tests that needed that transform failed; tests that didn't passed — which read as "different test failure per run, package unrelated to the PR's changes", i.e. classic flake.

Switch all six fixtures to the named-arg form already used in moveit_configs_utils/launches.py. Translation and rotation values were all zero in the legacy invocations, so the identity-transform default preserves behavior.

This resolves the recurring rolling-ci flakes:
- test_motion_plan_request_features_with_move_group
- test_get_cartesian_path_request_features_with_move_group and any other test in these fixtures that latently depended on the TF.

### Description

Please explain the changes you made, including a reference to the related issue if applicable

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](https://moveit.ai/documentation/contributing/pullrequests/)
- [ ] Extend the tutorials / documentation [reference](https://github.com/moveit/moveit2_tutorials)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
