### PR TITLE
Better log IK failure in pilz_industrial_motion_planner

### DIFF
--- a/moveit_planners/pilz_industrial_motion_planner/src/trajectory_functions.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/trajectory_functions.cpp
@@ -102,9 +102,21 @@ bool pilz_industrial_motion_planner::computePoseIK(const planning_scene::Plannin
   }
   else
   {
-    RCLCPP_ERROR(getLogger(), "Unable to find IK solution.");
-    // TODO(henning): Re-enable logging error
-    // RCLCPP_ERROR_STREAM(getLogger(), "Inverse kinematics for pose \n" << pose.translation() << " has no solution.");
+    std::ostringstream oss;
+    const Eigen::Quaterniond q(pose.rotation());
+    oss << "Unable to find IK solution for (" << pose.translation().transpose() << "; " << q.x() << ", " << q.y()
+        << ", " << q.z() << ", " << q.w() << ") in frame " << frame_id << " for link " << link_name << " in group '"
+        << group_name << "' with seed {";
+    for (auto pair = seed.begin(); pair != seed.end(); ++pair)
+    {
+      oss << pair->first << ": " << pair->second;
+      if (std::distance(pair, seed.end()) > 1)
+      {
+        oss << ", ";
+      }
+    }
+    oss << "}";
+    RCLCPP_ERROR_STREAM(getLogger(), oss.str());
     return false;
   }
 }


### PR DESCRIPTION
Be more explicit in the log message when no IK solution is found in `pilz_industrial_motion_planner::computePoseIK()`. 
### Description

The log message now includes the requested pose, the frame ID, the link name, the group name, and the seed values used for IK computation not just `Unable to find IK solution`.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](https://moveit.ai/documentation/contributing/pullrequests/)
- [ ] Extend the tutorials / documentation [reference](https://github.com/moveit/moveit2_tutorials). *Not required*
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes. *No API change*
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html). *No behavior change*
- [ ] Include a screenshot if changing a GUI. *No GUI change*
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
