### PR TITLE
Add a value to the error_code in `getPlanningContext`

### DIFF
--- a/moveit_planners/pilz_industrial_motion_planner/src/pilz_industrial_motion_planner.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/pilz_industrial_motion_planner.cpp
@@ -142,6 +142,7 @@ CommandPlanner::getPlanningContext(const planning_scene::PlanningSceneConstPtr& 
   {
     RCLCPP_ERROR_STREAM(getLogger(), "No ContextLoader for planner_id '" << req.planner_id.c_str()
                                                                          << "' found. Planning not possible.");
+    error_code.val = moveit_msgs::msg::MoveItErrorCodes::INVALID_MOTION_PLAN;
     return nullptr;
   }
 


### PR DESCRIPTION
Set `INVALID_MOTION_PLAN` if no context loader is found for the requested planner_id before returning.

### Description

`error_code.val` will be set to a meaningful value rather than being unset in case of early return.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](https://moveit.ai/documentation/contributing/pullrequests/)
- [ ] Extend the tutorials / documentation [reference](https://github.com/moveit/moveit2_tutorials)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
