### PR TITLE
ci: fix kilted branch CI to actually test against kilted

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,17 +17,13 @@ jobs:
       fail-fast: false
       matrix:
         env:
-          - IMAGE: rolling-ci
+          - IMAGE: kilted-ci
             CCOV: true
-            ROS_DISTRO: rolling
-          - IMAGE: rolling-ci
-            ROS_DISTRO: rolling
+            ROS_DISTRO: kilted
+          - IMAGE: kilted-ci
+            ROS_DISTRO: kilted
             IKFAST_TEST: true
             CLANG_TIDY: pedantic
-          - IMAGE: humble-ci
-            ROS_DISTRO: humble
-          - IMAGE: jazzy-ci
-            ROS_DISTRO: jazzy
     env:
       # TODO(andyz): When this clang-tidy issue is fixed, remove -Wno-unknown-warning-option
       # https://stackoverflow.com/a/41673702

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - main
+      - kilted
   pull_request:
     paths:
       - .docker/**
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ROS_DISTRO: [rolling]
+        ROS_DISTRO: [kilted]
     runs-on: ubuntu-latest
     permissions:
       packages: write
@@ -72,7 +72,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ROS_DISTRO: [rolling]
+        ROS_DISTRO: [kilted]
     runs-on: ubuntu-latest
     permissions:
       packages: write
@@ -128,7 +128,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ROS_DISTRO: [rolling]
+        ROS_DISTRO: [kilted]
     runs-on: ubuntu-latest
     permissions:
       packages: write


### PR DESCRIPTION
When the kilted branch was forked from main, two workflow files were overlooked and still target rolling/humble/jazzy:

1. .github/workflows/ci.yaml's matrix was testing kilted-branch code against rolling-ci/humble-ci/jazzy-ci images. PR CI thus failed for reasons unrelated to the PR (e.g. mergify-backported #3768 failed all 6 jobs because they ran on rolling+humble+jazzy infrastructure that doesn't match kilted's expected toolchain).

2. .github/workflows/docker.yaml's matrix kept ROS_DISTRO=[rolling], so the kilted branch never built its own moveit/moveit2:kilted-ci / kilted-release / kilted-source images. The push trigger also still pointed at branches: [main].

Match the jazzy branch's pattern: ci.yaml uses kilted-ci for both ccov and ikfast+clang-tidy jobs; docker.yaml builds kilted images and triggers on pushes to kilted.

Followup work after this lands:
- Trigger docker.yaml manually (workflow_dispatch on kilted) to build the first set of kilted-ci/release/source Docker images, OR push any commit to kilted to trigger automatically.
- Once moveit/moveit2:kilted-ci exists, re-run CI on PR #3768 (and any other open kilted backports) so they have a real toolchain to test against.

### Description

Please explain the changes you made, including a reference to the related issue if applicable

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](https://moveit.ai/documentation/contributing/pullrequests/)
- [ ] Extend the tutorials / documentation [reference](https://github.com/moveit/moveit2_tutorials)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
