### PR TITLE
Support parallel_gripper_action_controller in Setup Assistant (#3752)

### DIFF
--- a/moveit_setup_assistant/moveit_setup_controllers/include/moveit_setup_controllers/ros2_controllers.hpp
+++ b/moveit_setup_assistant/moveit_setup_controllers/include/moveit_setup_controllers/ros2_controllers.hpp
@@ -72,7 +72,10 @@ public:
 
   std::vector<std::string> getAvailableTypes() const override
   {
-    return { "joint_trajectory_controller/JointTrajectoryController", "position_controllers/GripperActionController" };
+    // position_controllers/GripperActionController is used on Humble/Iron;
+    // parallel_gripper_action_controller/GripperActionController on Jazzy+.
+    return { "joint_trajectory_controller/JointTrajectoryController", "position_controllers/GripperActionController",
+             "parallel_gripper_action_controller/GripperActionController" };
   }
 
   std::string getDefaultType() const override

--- a/moveit_setup_assistant/moveit_setup_controllers/src/ros2_controllers_config.cpp
+++ b/moveit_setup_assistant/moveit_setup_controllers/src/ros2_controllers_config.cpp
@@ -192,12 +192,20 @@ bool ROS2ControllersConfig::GeneratedControllersConfig::writeYaml(YAML::Emitter&
       emitter << YAML::Value;
       emitter << YAML::BeginMap;
       {
-        if (ci.type_ != "position_controllers/GripperActionController")
+        // A GripperActionController commands a single joint, so it takes a
+        // `joint` parameter instead of the `joints` list. Humble/Iron ship it
+        // as position_controllers/GripperActionController; Jazzy and newer use
+        // parallel_gripper_action_controller/GripperActionController.
+        const bool is_gripper_controller = ci.type_ == "position_controllers/GripperActionController" ||
+                                           ci.type_ == "parallel_gripper_action_controller/GripperActionController";
+        if (!is_gripper_controller)
         {
           emitter << YAML::Key << "joints" << YAML::Value << ci.joints_;
         }
-        else
+        else if (!ci.joints_.empty())
         {
+          // GripperActionController controls a single joint; guard against an
+          // empty joint list so we never index joints_[0] out of bounds.
           emitter << YAML::Key << "joint" << YAML::Value << ci.joints_[0];
         }
 

--- a/moveit_setup_assistant/moveit_setup_controllers/test/test_controllers.cpp
+++ b/moveit_setup_assistant/moveit_setup_controllers/test/test_controllers.cpp
@@ -92,7 +92,12 @@ TEST_F(ControllersTest, ParsePanda)
 
   const ControllerInfo& ci2 = controllers[1 - offset];
   EXPECT_EQ("panda_hand_controller", ci2.name_);
-  EXPECT_EQ("position_controllers/GripperActionController", ci2.type_);
+  // Humble/Iron use position_controllers/GripperActionController; Jazzy and
+  // newer use parallel_gripper_action_controller/GripperActionController.
+  // Accept either so the test is distro-agnostic.
+  EXPECT_TRUE(ci2.type_ == "position_controllers/GripperActionController" ||
+              ci2.type_ == "parallel_gripper_action_controller/GripperActionController")
+      << "Unexpected gripper controller type: " << ci2.type_;
   EXPECT_EQ(1u, ci2.joints_.size());
 
   /*
@@ -120,6 +125,26 @@ TEST_F(ControllersTest, OutputFanuc)
   {
     expectYamlEquivalence(output_dir_ / relative_path, original_config / relative_path);
   }
+}
+
+// Fanuc has no gripper, so OutputFanuc doesn't exercise the gripper branch of
+// ros2_controllers.yaml generation. Panda has a GripperActionController, which
+// must be written with the singular `joint` key (not the `joints` list). A full
+// YAML equivalence check isn't possible here because the panda gripper config
+// carries extra parameters (effort/velocity interfaces) the Setup Assistant does
+// not generate, so assert on the gripper parameter shape directly.
+TEST_F(ControllersTest, OutputPandaGripperUsesSingularJoint)
+{
+  config_data_->preloadWithFullConfig("moveit_resources_panda_moveit_config");
+  config_data_->get<moveit_setup::controllers::ControlXacroConfig>("control_xacro")->loadFromDescription();
+  generateFiles<ROS2ControllersConfig>("ros2_controllers");
+
+  YAML::Node generated = YAML::LoadFile(output_dir_ / "config/ros2_controllers.yaml");
+  ASSERT_TRUE(generated["panda_hand_controller"]) << "generated config missing panda_hand_controller";
+  const YAML::Node params = generated["panda_hand_controller"]["ros__parameters"];
+  ASSERT_TRUE(params) << "panda_hand_controller missing ros__parameters";
+  EXPECT_TRUE(params["joint"]) << "gripper controller must emit the singular 'joint' parameter";
+  EXPECT_FALSE(params["joints"]) << "gripper controller must not emit the 'joints' list";
 }
 
 TEST_F(ControllersTest, AddDefaultControllers)


### PR DESCRIPTION
* Support parallel_gripper_action_controller in Setup Assistant

moveit_resources migrated the gripper from position_controllers/ GripperActionController (Humble/Iron) to parallel_gripper_action_controller/ GripperActionController (Jazzy and newer). Both are single-joint GripperActionControllers that take a `joint` parameter.

Teach moveit_setup_controllers to recognize the new type:
- ros2_controllers_config: emit the `joint` (singular) parameter for either gripper controller type, instead of only the old one (the old check misclassified the new type and emitted a `joints` list).
- ros2_controllers: offer the new type in getAvailableTypes().
- test_controllers (ParsePanda): accept either gripper type so the test is distro-agnostic (the panda config now ships the Jazzy+ type).



* Address review: guard gripper joint index, add panda gripper output test

- ros2_controllers_config: only write the singular `joint` parameter when the gripper controller actually has a joint, so joints_[0] is never indexed out of bounds for a gripper with an empty joint list.
- test_controllers: add OutputPandaGripperUsesSingularJoint, which generates the panda ros2_controllers.yaml and asserts the GripperActionController is emitted with the singular `joint` key (not the `joints` list) -- coverage the gripper-less OutputFanuc test could not provide.



---------

### Description

Please explain the changes you made, including a reference to the related issue if applicable

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](https://moveit.ai/documentation/contributing/pullrequests/)
- [ ] Extend the tutorials / documentation [reference](https://github.com/moveit/moveit2_tutorials)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
