### PR TITLE
Remove CLANG_TIDY_ARGS to support run-clang-tidy (backport of #3640)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,6 @@ jobs:
       # https://stackoverflow.com/a/41673702
       CXXFLAGS: >-
         -Wall -Wextra -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls -Wno-unknown-warning-option
-      CLANG_TIDY_ARGS: --fix --fix-errors --format-style=file
       DOCKER_IMAGE: moveit/moveit2:${{ matrix.env.IMAGE }}
       UPSTREAM_WORKSPACE: >
         moveit2.repos


### PR DESCRIPTION
Same fix as #3640 (main) and the equivalent humble/jazzy backports. The run-clang-tidy script shipped in current kilted-ci Docker images no longer accepts the `--fix --fix-errors --format-style=file` flags, so any kilted PR that touches a file clang-tidy actually checks (like PR #3774 touching moveit_setup_controllers) fails with:

    run-clang-tidy: error: unrecognized arguments:
      --fix --fix-errors --format-style=file
    'clang_tidy_check_moveit_setup_controllers' returned with code '123'

Drop the env var so run-clang-tidy gets invoked with its defaults.

### Description

Please explain the changes you made, including a reference to the related issue if applicable

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](https://moveit.ai/documentation/contributing/pullrequests/)
- [ ] Extend the tutorials / documentation [reference](https://github.com/moveit/moveit2_tutorials)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
