### PR TITLE
De-flake trajectory_cache _with_move_group tests

### DIFF
--- a/moveit_ros/trajectory_cache/test/fixtures/gtest_with_move_group.py
+++ b/moveit_ros/trajectory_cache/test/fixtures/gtest_with_move_group.py
@@ -6,7 +6,13 @@ from ament_index_python.packages import get_package_share_directory
 from moveit_configs_utils import MoveItConfigsBuilder
 
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, ExecuteProcess, TimerAction
+from launch.actions import (
+    DeclareLaunchArgument,
+    ExecuteProcess,
+    RegisterEventHandler,
+    TimerAction,
+)
+from launch.event_handlers import OnProcessExit
 from launch_ros.actions import Node
 from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 from launch_testing.actions import ReadyToTest
@@ -62,7 +68,6 @@ def generate_test_description():
     for controller in [
         "panda_arm_controller",
         "panda_hand_controller",
-        "joint_state_broadcaster",
     ]:
         load_controllers += [
             ExecuteProcess(
@@ -71,6 +76,20 @@ def generate_test_description():
                 output="log",
             )
         ]
+
+    # Spawn the joint_state_broadcaster separately so the test binary can be
+    # gated on its activation. The spawner process exits 0 only once the
+    # controller is loaded, configured, and activated, at which point
+    # /joint_states is guaranteed to be publishing. Gating the test on this
+    # event (instead of a fixed wall-clock timer) avoids a startup race where
+    # the test runs before joint_states exists and
+    # MoveGroupInterface::getCurrentState() fails with
+    # "Failed to fetch current robot state".
+    joint_state_broadcaster_spawner = ExecuteProcess(
+        cmd=["ros2 run controller_manager spawner joint_state_broadcaster"],
+        shell=True,
+        output="log",
+    )
 
     gtest_node = Node(
         executable=PathJoinSubstitution(
@@ -94,8 +113,16 @@ def generate_test_description():
             robot_state_publisher,
             ros2_control_node,
             *load_controllers,
+            joint_state_broadcaster_spawner,
             TimerAction(period=1.0, actions=[run_move_group_node]),
-            TimerAction(period=3.0, actions=[gtest_node]),
+            # Launch the test binary only once joint_state_broadcaster has
+            # activated, guaranteeing /joint_states is available.
+            RegisterEventHandler(
+                OnProcessExit(
+                    target_action=joint_state_broadcaster_spawner,
+                    on_exit=[gtest_node],
+                )
+            ),
             ReadyToTest(),
         ]
     ), {


### PR DESCRIPTION
The gtest_with_move_group.py fixture launched the test binary on a fixed TimerAction(period=3.0). On slow CI runs the joint_state_broadcaster had not activated by t=3s, so /joint_states was not yet publishing and the test failed at MoveGroupInterface::getCurrentState() with "Failed to fetch current robot state". This flaked across Noble, Resolute, jazzy, and kilted for the _with_move_group test family.

Gate the test binary launch on joint_state_broadcaster activation instead: spawn the broadcaster as its own ExecuteProcess and start the gtest node from an OnProcessExit handler. The spawner exits 0 only after the controller is loaded, configured, and activated, guaranteeing /joint_states is publishing before the test runs. This removes the wall-clock race entirely.

### Description

Please explain the changes you made, including a reference to the related issue if applicable

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](https://moveit.ai/documentation/contributing/pullrequests/)
- [ ] Extend the tutorials / documentation [reference](https://github.com/moveit/moveit2_tutorials)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
