### PR TITLE
Fix ament_index_cpp deprecation

### DIFF
--- a/moveit_core/utils/src/robot_model_test_utils.cpp
+++ b/moveit_core/utils/src/robot_model_test_utils.cpp
@@ -35,8 +35,11 @@
 /* Author: Bryce Willey */
 
 #include <rclcpp/version.h>
-
-#include <ament_index_cpp/get_package_share_directory.hpp>
+#if RCLCPP_VERSION_GTE(30, 0, 0)
+  #include <ament_index_cpp/get_package_share_path.hpp>
+#else
+  #include <ament_index_cpp/get_package_share_directory.hpp>
+#endif
 #include <boost/algorithm/string_regex.hpp>
 #include <filesystem>
 #include <geometry_msgs/msg/pose.hpp>
@@ -68,11 +71,9 @@ moveit::core::RobotModelPtr loadTestingRobotModel(const std::string& package_nam
 {
 // For Rolling, L-turtle, and newer
 #if RCLCPP_VERSION_GTE(30, 0, 0)
-  std::filesystem::path urdf_path;
-  ament_index_cpp::get_package_share_directory(package_name, urdf_path);
+  std::filesystem::path urdf_path = ament_index_cpp::get_package_share_path(package_name);
   urdf_path /= urdf_relative_path;
-  std::filesystem::path srdf_path;
-  ament_index_cpp::get_package_share_directory(package_name, srdf_path);
+  std::filesystem::path srdf_path = ament_index_cpp::get_package_share_path(package_name);
   srdf_path /= srdf_relative_path;
 #else
   const auto urdf_path =
@@ -109,8 +110,7 @@ urdf::ModelInterfaceSharedPtr loadModelInterface(const std::string& robot_name)
   const std::string package_name = "moveit_resources_" + robot_name + "_description";
 // For Rolling, L-turtle, and newer
 #if RCLCPP_VERSION_GTE(30, 0, 0)
-  std::filesystem::path res_path;
-  ament_index_cpp::get_package_share_directory(package_name, res_path);
+  std::filesystem::path res_path = ament_index_cpp::get_package_share_path(package_name);
 #else
   std::filesystem::path res_path(ament_index_cpp::get_package_share_directory(package_name));
 #endif
@@ -143,8 +143,7 @@ srdf::ModelSharedPtr loadSRDFModel(const std::string& robot_name)
     const std::string package_name = "moveit_resources_" + robot_name + "_description";
 // For Rolling, L-turtle, and newer
 #if RCLCPP_VERSION_GTE(30, 0, 0)
-    std::filesystem::path res_path;
-    ament_index_cpp::get_package_share_directory(package_name, res_path);
+    std::filesystem::path res_path = ament_index_cpp::get_package_share_path(package_name);
 #else
     std::filesystem::path res_path(ament_index_cpp::get_package_share_directory(package_name));
 #endif
@@ -155,8 +154,7 @@ srdf::ModelSharedPtr loadSRDFModel(const std::string& robot_name)
     const std::string package_name = "moveit_resources_" + robot_name + "_moveit_config";
 // For Rolling, L-turtle, and newer
 #if RCLCPP_VERSION_GTE(30, 0, 0)
-    std::filesystem::path res_path;
-    ament_index_cpp::get_package_share_directory(package_name, res_path);
+    std::filesystem::path res_path = ament_index_cpp::get_package_share_path(package_name);
 #else
     std::filesystem::path res_path(ament_index_cpp::get_package_share_directory(package_name));
 #endif

--- a/moveit_planners/test_configs/prbt_ikfast_manipulator_plugin/src/prbt_manipulator_ikfast_moveit_plugin.cpp
+++ b/moveit_planners/test_configs/prbt_ikfast_manipulator_plugin/src/prbt_manipulator_ikfast_moveit_plugin.cpp
@@ -782,7 +782,7 @@ bool IKFastKinematicsPlugin::getPositionFK(const std::vector<std::string>& link_
     return false;
   }
 
-  KDL::Frame p_out;
+  KDL::Frame p_out = KDL::Frame::Identity();
   if (link_names.size() == 0)
   {
     RCLCPP_WARN_STREAM(LOGGER, "Link names with nothing");

--- a/moveit_plugins/moveit_ros_control_interface/src/controller_manager_plugin.cpp
+++ b/moveit_plugins/moveit_ros_control_interface/src/controller_manager_plugin.cpp
@@ -55,6 +55,8 @@
 #include <memory>
 #include <queue>
 #include <moveit/utils/logger.hpp>
+#include <unordered_set>
+
 
 static const rclcpp::Duration CONTROLLER_INFORMATION_VALIDITY_AGE = rclcpp::Duration::from_seconds(1.0);
 

--- a/moveit_plugins/moveit_ros_control_interface/test/test_controller_manager_plugin.cpp
+++ b/moveit_plugins/moveit_ros_control_interface/test/test_controller_manager_plugin.cpp
@@ -41,6 +41,8 @@
 #include <eigen3/Eigen/Eigen>
 #include <moveit/controller_manager/controller_manager.hpp>
 #include <pluginlib/class_loader.hpp>
+#include <unordered_set>
+
 
 class MockControllersManagerService final : public rclcpp::Node
 {

--- a/moveit_ros/planning/rdf_loader/src/rdf_loader.cpp
+++ b/moveit_ros/planning/rdf_loader/src/rdf_loader.cpp
@@ -40,7 +40,11 @@
 #include <moveit/rdf_loader/rdf_loader.hpp>
 #include <std_msgs/msg/string.hpp>
 #include <ament_index_cpp/get_package_prefix.hpp>
+#if RCLCPP_VERSION_GTE(30, 0, 0)
+#include <ament_index_cpp/get_package_share_path.hpp>
+#else
 #include <ament_index_cpp/get_package_share_directory.hpp>
+#endif
 #include <moveit/utils/logger.hpp>
 
 #include <rclcpp/duration.hpp>
@@ -224,7 +228,7 @@ bool RDFLoader::loadPkgFileToString(std::string& buffer, const std::string& pack
   {
 // For Rolling, L-turtle, and newer
 #if RCLCPP_VERSION_GTE(30, 0, 0)
-    ament_index_cpp::get_package_share_directory(package_name, path);
+    path = ament_index_cpp::get_package_share_path(package_name);
 #else
     path = ament_index_cpp::get_package_share_directory(package_name);
 #endif


### PR DESCRIPTION

### Description

get_package_share_directory  function is deprecated

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](https://moveit.ai/documentation/contributing/pullrequests/)
- [ ] Extend the tutorials / documentation [reference](https://github.com/moveit/moveit2_tutorials)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
