### PR TITLE
resolute: explicit <rclcpp/executors.hpp> include in servo_ros_fixture

### DIFF
--- a/moveit_ros/moveit_servo/tests/servo_ros_fixture.hpp
+++ b/moveit_ros/moveit_servo/tests/servo_ros_fixture.hpp
@@ -46,6 +46,7 @@
 #include <moveit_msgs/srv/servo_command_type.hpp>
 #include <moveit_servo/utils/datatypes.hpp>
 #include <rclcpp/client.hpp>
+#include <rclcpp/executors.hpp>
 #include <rclcpp/node.hpp>
 #include <rclcpp/publisher.hpp>
 #include <rclcpp/qos.hpp>


### PR DESCRIPTION
## Why

On rolling-resolute, `rclcpp/rclcpp.hpp` no longer transitively pulls `<rclcpp/executors.hpp>`. Test uses `rclcpp::executors::SingleThreadedExecutor` and fails to compile without the explicit include. On humble/jazzy/kilted the transitive still works, so this is additive-only — safe on all distros.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](https://moveit.ai/documentation/contributing/pullrequests/)
- [ ] Extend the tutorials / documentation [reference](https://github.com/moveit/moveit2_tutorials)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
