### PR TITLE
Fix broken image link in pilz testutils README

### DIFF
--- a/moveit_planners/pilz_industrial_motion_planner_testutils/doc/README.md
+++ b/moveit_planners/pilz_industrial_motion_planner_testutils/doc/README.md
@@ -3,7 +3,7 @@
 ## General information
 - Use as little as possible test points (Reason: Reduces maintenance overhead).
 - Test points should be defined following the concept shown below.
-![TestDataConcept](../../pilz_trajectory_generation/test/test_robots/concept_testdata.png)
+![TestDataConcept](../../pilz_industrial_motion_planner/test/test_data/concept_testdata.png)
 - Test points can be defined in joint space or Cartesian space. However, one
 test point should not be defined in both spaces (data redundancy)
 - If a test point is defined in Cartesian space, then also state the


### PR DESCRIPTION
### Description

The image link in `pilz_industrial_motion_planner_testutils/doc/README.md` points at `../../pilz_trajectory_generation/test/test_robots/concept_testdata.png`, which no longer exists. The package was renamed from `pilz_trajectory_generation` to `pilz_industrial_motion_planner`, and the test directory went from `test_robots` to `test_data`, so the diagram has been broken since the rename.

The image is still there, just at `moveit_planners/pilz_industrial_motion_planner/test/test_data/concept_testdata.png`. This PR updates the relative path so it resolves again.

### Checklist
- [x] Doc-only change, no code affected
- [ ] Extend the tutorials / documentation reference
- [ ] Document API changes relevant to the user in the MIGRATION.md notes
- [ ] Create tests, which fail without this PR
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review another open pull request to support the maintainers
