### PR TITLE
Use use_count in LockedRobotState

### DIFF
--- a/moveit_ros/robot_interaction/src/locked_robot_state.cpp
+++ b/moveit_ros/robot_interaction/src/locked_robot_state.cpp
@@ -66,7 +66,7 @@ void robot_interaction::LockedRobotState::setState(const moveit::core::RobotStat
 
     // If someone else has a reference to the state, then make a new copy.
     // The old state is orphaned (does not change, but is now out of date).
-    if (state_.unique())
+    if (state_.use_count() == 1)
     {
       *state_ = state;
     }
@@ -87,7 +87,7 @@ void robot_interaction::LockedRobotState::modifyState(const ModifyStateFunction&
 
     // If someone else has a reference to the state, then make a copy.
     // The old state is orphaned (does not change, but is now out of date).
-    if (!state_.unique())
+    if (state_.use_count() != 1)
       state_ = std::make_shared<moveit::core::RobotState>(*state_);
 
     modify(state_.get());


### PR DESCRIPTION
This is part of an effort to contribute RoboStack downstream patches back upstream.

Origin: `patch/ros-rolling-moveit-ros-robot-interaction.patch`, authored by Daisuke Nishimatsu.

`LockedRobotState` currently uses `std::shared_ptr::unique()` to decide whether it can modify the stored state in place. That API was removed in C++20. Comparing `use_count()` with one preserves the existing copy-on-write behavior while keeping this code compatible with toolchains that build MoveIt with newer C++ standards.
