### PR TITLE
Fix use-after-free in CollisionEnvFCL when a moved world object is copy-on-write cloned

### DIFF
--- a/moveit_core/collision_detection_fcl/src/collision_env_fcl.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_env_fcl.cpp
@@ -470,6 +470,12 @@ void CollisionEnvFCL::notifyObjectChange(const ObjectConstPtr& obj, World::Actio
 
     for (std::size_t i = 0; i < it->second.collision_objects_.size(); ++i)
     {
+      // World::ensureUnique() may have copy-on-write cloned `obj` into a new World::Object
+      // since these FCL objects were built, freeing the old one. CollisionGeometryData only
+      // stores a raw World::Object*, so refresh it here or getID() reads freed memory.
+      const_cast<FCLGeometry*>(it->second.collision_geometry_[i].get())
+          ->updateCollisionGeometryData(obj.get(), static_cast<int>(i), false);
+
       it->second.collision_objects_[i]->setTransform(transform2fcl(obj->global_shape_poses_[i]));
 
       // compute AABB, order matters

--- a/moveit_core/collision_detection_fcl/test/test_fcl_env.cpp
+++ b/moveit_core/collision_detection_fcl/test/test_fcl_env.cpp
@@ -322,6 +322,73 @@ TEST_F(CollisionDetectionEnvTest, DISABLED_ContinuousCollisionWorld)
   res.clear();
 }
 
+namespace
+{
+/** \brief Test-only subclass exposing CollisionEnvFCL's protected fcl_objs_ cache, so a test can
+ *  check that the World::Object pointer cached inside a collision geometry stays in sync with the
+ *  live World after the object is moved. */
+class TestableCollisionEnvFCL : public collision_detection::CollisionEnvFCL
+{
+public:
+  using CollisionEnvFCL::CollisionEnvFCL;
+
+  const void* getCachedWorldObjectPtr(const std::string& id) const
+  {
+    const auto it = fcl_objs_.find(id);
+    if (it == fcl_objs_.end() || it->second.collision_geometry_.empty())
+      return nullptr;
+    return it->second.collision_geometry_.front()->collision_geometry_data_->ptr.raw;
+  }
+};
+}  // namespace
+
+/** \brief Regression test for a use-after-free in CollisionEnvFCL::notifyObjectChange().
+ *
+ *  World::ensureUnique() copy-on-write clones a World::Object whenever it is modified while an
+ *  external shared_ptr to it is still alive (e.g. RViz's MotionPlanningDisplay briefly holding a
+ *  reference while it live-checks collisions for the interactive goal state). The MOVE_SHAPE fast
+ *  path in notifyObjectChange() updated the FCL collision object's transform in place but never
+ *  refreshed CollisionGeometryData::ptr.obj, so once the pre-move Object was destroyed, the
+ *  collision environment was left holding a dangling pointer. Reading it back out (e.g. via
+ *  getID(), called from AllowedCollisionMatrix::getEntry() during a collision check) is a
+ *  use-after-free, which is what crashed RViz. */
+TEST_F(CollisionDetectionEnvTest, MovedWorldObjectKeepsValidGeometryPointer)
+{
+  auto testable_env = std::make_shared<TestableCollisionEnvFCL>(robot_model_);
+
+  shapes::Shape* shape = new shapes::Box(.1, .1, .1);
+  shapes::ShapeConstPtr shape_ptr(shape);
+
+  Eigen::Isometry3d pos = Eigen::Isometry3d::Identity();
+  pos.translation().z() = 0.3;
+  testable_env->getWorld()->addToObject("box", shape_ptr, pos);
+
+  {
+    // Hold an extra reference to the current Object so the upcoming move is forced through
+    // World::ensureUnique()'s copy-on-write path, mirroring how RViz can end up holding a
+    // reference while a move happens.
+    const collision_detection::World::ObjectConstPtr held = testable_env->getWorld()->getObject("box");
+    ASSERT_TRUE(held);
+
+    pos.translation().z() = 0.32;
+    testable_env->getWorld()->moveObject("box", pos);
+    // `held` is released at the end of this scope, dropping the last external reference to the
+    // pre-move Object. Pre-fix, the cache checked below still points at that now-freed memory.
+  }
+
+  const void* cached_ptr = testable_env->getCachedWorldObjectPtr("box");
+  const void* current_ptr = testable_env->getWorld()->getObject("box").get();
+  EXPECT_EQ(cached_ptr, current_ptr)
+      << "CollisionGeometryData still references a stale World::Object after a copy-on-write move";
+
+  // Pre-fix, this dereferences the dangling pointer while reading the collision object's name -
+  // reproducing the RViz crash reported inside AllowedCollisionMatrix::getEntry().
+  collision_detection::CollisionRequest req;
+  collision_detection::CollisionResult res;
+  testable_env->checkRobotCollision(req, res, *robot_state_, *acm_);
+  EXPECT_TRUE(res.collision);
+}
+
 int main(int argc, char** argv)
 {
   testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
I was experiencing some rviz crashes while playing around with the moveit_resources_panda_moveit_config demo. I decided to throw Claude at it and uncovered a use-after-free bug in moveit_core. Rviz would crash if I introduced a simple box collision object, moved it so that it was in collision with the manipulator arm, and then tried to move the arm using the . 

World::ensureUnique() copy-on-write clones a World::Object when it is mutated while an external shared_ptr to it is still alive (e.g. RViz's MotionPlanningDisplay briefly holding a reference while it live-checks collisions for the goal/start state). CollisionEnvFCL::notifyObjectChange()'s MOVE_SHAPE fast path (#3601) updated the cached FCL collision object's transform in place but never refreshed CollisionGeometryData::ptr.obj, a raw non-owning pointer into the World::Object. Once the pre-move object was destroyed, that pointer was left dangling, and the next collision check reading the object's id through it (CollisionGeometryData::getID()) was a use-after-free - reproducibly crashing RViz.

This PR:

- Refreshes the cached pointer via the existing FCLGeometry::updateCollisionGeometryData() helper, the same mechanism createCollisionGeometry() already uses for this exact copy-on-write scenario, before applying the transform update.
- Adds a regression test that forces the copy-on-write path and checks the cached World::Object pointer stays in sync via direct pointer comparison, so it fails deterministically without the fix rather than relying on the process actually crashing.

### Description

Please explain the changes you made, including a reference to the related issue if applicable

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](https://moveit.ai/documentation/contributing/pullrequests/)
- [ ] Extend the tutorials / documentation [reference](https://github.com/moveit/moveit2_tutorials)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [x] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
