### PR TITLE
Solve the IK velocity step via JJ^T eigendecomposition, not JacobiSVD

### DIFF
--- a/moveit_kinematics/kdl_kinematics_plugin/CMakeLists.txt
+++ b/moveit_kinematics/kdl_kinematics_plugin/CMakeLists.txt
@@ -29,4 +29,11 @@ target_compile_definitions(moveit_kdl_kinematics_plugin
 target_compile_definitions(moveit_kdl_kinematics_plugin
                            PRIVATE "MOVEIT_KDL_KINEMATICS_PLUGIN_BUILDING_DLL")
 
+if(BUILD_TESTING)
+  find_package(ament_cmake_gtest REQUIRED)
+  ament_add_gtest(test_kdl_pseudoinverse test/test_pseudoinverse.cpp)
+  target_include_directories(test_kdl_pseudoinverse PRIVATE src)
+  target_link_libraries(test_kdl_pseudoinverse Eigen3::Eigen)
+endif()
+
 install(DIRECTORY include/ DESTINATION include/moveit_kinematics)

--- a/moveit_kinematics/kdl_kinematics_plugin/include/moveit/kdl_kinematics_plugin/chainiksolver_vel_mimic_svd.hpp
+++ b/moveit_kinematics/kdl_kinematics_plugin/include/moveit/kdl_kinematics_plugin/chainiksolver_vel_mimic_svd.hpp
@@ -31,6 +31,7 @@
 
 #include <moveit/kdl_kinematics_plugin/joint_mimic.hpp>
 #include <Eigen/SVD>
+#include <Eigen/Eigenvalues>
 
 namespace KDL
 {

--- a/moveit_kinematics/kdl_kinematics_plugin/include/moveit/kdl_kinematics_plugin/chainiksolver_vel_mimic_svd.hpp
+++ b/moveit_kinematics/kdl_kinematics_plugin/include/moveit/kdl_kinematics_plugin/chainiksolver_vel_mimic_svd.hpp
@@ -31,7 +31,6 @@
 
 #include <moveit/kdl_kinematics_plugin/joint_mimic.hpp>
 #include <Eigen/SVD>
-#include <Eigen/Eigenvalues>
 
 namespace KDL
 {

--- a/moveit_kinematics/kdl_kinematics_plugin/src/chainiksolver_vel_mimic_svd.cpp
+++ b/moveit_kinematics/kdl_kinematics_plugin/src/chainiksolver_vel_mimic_svd.cpp
@@ -25,6 +25,8 @@
 
 #include <moveit/kdl_kinematics_plugin/chainiksolver_vel_mimic_svd.hpp>
 
+#include "pseudoinverse.hpp"
+
 namespace
 {
 unsigned int countMimicJoints(const std::vector<kdl_kinematics_plugin::JointMimic>& mimic_joints)
@@ -109,23 +111,9 @@ int ChainIkSolverVelMimicSVD::CartToJnt(const JntArray& q_in, const Twist& v_in,
   vin.topRows<3>() = Eigen::Map<const Eigen::Array3d>(v_in.vel.data, 3) * cartesian_weights.topRows<3>().array();
   vin.bottomRows<3>() = Eigen::Map<const Eigen::Array3d>(v_in.rot.data, 3) * cartesian_weights.bottomRows<3>().array();
 
-  // x = J^T (JJ^T)^# vin via a small (rows x rows) self-adjoint eigendecomposition of JJ^T -- the
-  // same thresholded min-norm pseudo-inverse solution as svd_.solve, but far cheaper than a
-  // JacobiSVD of the 6xN Jacobian.
-  const auto Jp = jac.topRows(rows);
-  Eigen::MatrixXd A = Jp * Jp.transpose();
-  Eigen::SelfAdjointEigenSolver<Eigen::MatrixXd> es(A);
-  const Eigen::VectorXd& ev = es.eigenvalues();
-  const Eigen::MatrixXd& V = es.eigenvectors();
-  const double sv_max = std::sqrt(std::max(0.0, ev.maxCoeff()));
-  const double abs_thr = svd_.threshold() * sv_max;  // same relative threshold as JacobiSVD
-  Eigen::VectorXd y = V.transpose() * vin.topRows(rows);
-  for (Eigen::Index k = 0; k < ev.size(); ++k)
-  {
-    const double sv = std::sqrt(std::max(0.0, ev(k)));
-    y(k) = (sv > abs_thr) ? y(k) / ev(k) : 0.0;
-  }
-  const Eigen::VectorXd x_sol = Jp.transpose() * (V * y);
+  const auto jacobian = jac.topRows(rows);
+  const Eigen::VectorXd x_sol =
+      kdl_kinematics_plugin::internal::solvePseudoinverse(jacobian, vin.topRows(rows), svd_.threshold());
 
   if (num_mimic_joints_ > 0)
   {

--- a/moveit_kinematics/kdl_kinematics_plugin/src/chainiksolver_vel_mimic_svd.cpp
+++ b/moveit_kinematics/kdl_kinematics_plugin/src/chainiksolver_vel_mimic_svd.cpp
@@ -109,19 +109,34 @@ int ChainIkSolverVelMimicSVD::CartToJnt(const JntArray& q_in, const Twist& v_in,
   vin.topRows<3>() = Eigen::Map<const Eigen::Array3d>(v_in.vel.data, 3) * cartesian_weights.topRows<3>().array();
   vin.bottomRows<3>() = Eigen::Map<const Eigen::Array3d>(v_in.rot.data, 3) * cartesian_weights.bottomRows<3>().array();
 
-  // Do a singular value decomposition: J = U*S*V^t
-  svd_.compute(jac.topRows(rows));
+  // x = J^T (JJ^T)^# vin via a small (rows x rows) self-adjoint eigendecomposition of JJ^T -- the
+  // same thresholded min-norm pseudo-inverse solution as svd_.solve, but far cheaper than a
+  // JacobiSVD of the 6xN Jacobian.
+  const auto Jp = jac.topRows(rows);
+  Eigen::MatrixXd A = Jp * Jp.transpose();
+  Eigen::SelfAdjointEigenSolver<Eigen::MatrixXd> es(A);
+  const Eigen::VectorXd& ev = es.eigenvalues();
+  const Eigen::MatrixXd& V = es.eigenvectors();
+  const double sv_max = std::sqrt(std::max(0.0, ev.maxCoeff()));
+  const double abs_thr = svd_.threshold() * sv_max;  // same relative threshold as JacobiSVD
+  Eigen::VectorXd y = V.transpose() * vin.topRows(rows);
+  for (Eigen::Index k = 0; k < ev.size(); ++k)
+  {
+    const double sv = std::sqrt(std::max(0.0, ev(k)));
+    y(k) = (sv > abs_thr) ? y(k) / ev(k) : 0.0;
+  }
+  const Eigen::VectorXd x_sol = Jp.transpose() * (V * y);
 
   if (num_mimic_joints_ > 0)
   {
-    qdot_out_reduced_.noalias() = svd_.solve(vin.topRows(rows));
+    qdot_out_reduced_.noalias() = x_sol;
     qdot_out_reduced_.array() *= joint_weights.array();
     for (unsigned int i = 0; i < chain_.getNrOfJoints(); ++i)
       qdot_out(i) = qdot_out_reduced_[mimic_joints_[i].map_index] * mimic_joints_[i].multiplier;
   }
   else
   {
-    qdot_out.data.noalias() = svd_.solve(vin.topRows(rows));
+    qdot_out.data.noalias() = x_sol;
     qdot_out.data.array() *= joint_weights.array();
   }
 

--- a/moveit_kinematics/kdl_kinematics_plugin/src/pseudoinverse.hpp
+++ b/moveit_kinematics/kdl_kinematics_plugin/src/pseudoinverse.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <Eigen/Eigenvalues>
+
+#include <algorithm>
+#include <cmath>
+
+namespace kdl_kinematics_plugin::internal
+{
+inline Eigen::VectorXd solvePseudoinverse(const Eigen::Ref<const Eigen::MatrixXd>& jacobian,
+                                          const Eigen::Ref<const Eigen::VectorXd>& input, double threshold)
+{
+  const Eigen::MatrixXd normal = jacobian * jacobian.transpose();
+  const Eigen::SelfAdjointEigenSolver<Eigen::MatrixXd> solver(normal);
+  const Eigen::VectorXd& eigenvalues = solver.eigenvalues();
+  const Eigen::MatrixXd& eigenvectors = solver.eigenvectors();
+  const double singular_max = std::sqrt(std::max(0.0, eigenvalues.maxCoeff()));
+  const double absolute_threshold = threshold * singular_max;
+  Eigen::VectorXd projected = eigenvectors.transpose() * input;
+  for (Eigen::Index index = 0; index < eigenvalues.size(); ++index)
+  {
+    const double singular = std::sqrt(std::max(0.0, eigenvalues(index)));
+    projected(index) = singular > absolute_threshold ? projected(index) / eigenvalues(index) : 0.0;
+  }
+  return jacobian.transpose() * (eigenvectors * projected);
+}
+}  // namespace kdl_kinematics_plugin::internal

--- a/moveit_kinematics/kdl_kinematics_plugin/test/test_pseudoinverse.cpp
+++ b/moveit_kinematics/kdl_kinematics_plugin/test/test_pseudoinverse.cpp
@@ -1,0 +1,71 @@
+#include "pseudoinverse.hpp"
+
+#include <Eigen/QR>
+#include <Eigen/SVD>
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cmath>
+#include <vector>
+
+namespace
+{
+Eigen::MatrixXd matrixWithSingularValues(const std::vector<double>& values, Eigen::Index columns)
+{
+  const Eigen::Index rows = values.size();
+  Eigen::MatrixXd left(rows, rows);
+  Eigen::MatrixXd right(columns, rows);
+  for (Eigen::Index row = 0; row < rows; ++row)
+  {
+    for (Eigen::Index column = 0; column < rows; ++column)
+      left(row, column) = std::sin((row + 1) * (column + 2));
+    for (Eigen::Index column = 0; column < columns; ++column)
+      right(column, row) = std::cos((row + 2) * (column + 1));
+  }
+  const Eigen::MatrixXd u = left.householderQr().householderQ() * Eigen::MatrixXd::Identity(rows, rows);
+  const Eigen::MatrixXd v = right.householderQr().householderQ() * Eigen::MatrixXd::Identity(columns, rows);
+  return u * Eigen::Map<const Eigen::VectorXd>(values.data(), rows).asDiagonal() * v.transpose();
+}
+
+void expectSameSolution(const std::vector<double>& singular_values)
+{
+  constexpr double threshold = 0.001;
+  constexpr Eigen::Index columns = 7;
+  const Eigen::MatrixXd jacobian = matrixWithSingularValues(singular_values, columns);
+  const Eigen::VectorXd input = Eigen::VectorXd::LinSpaced(jacobian.rows(), -0.7, 0.9);
+  Eigen::JacobiSVD<Eigen::MatrixXd> svd(jacobian.rows(), jacobian.cols(), Eigen::ComputeThinU | Eigen::ComputeThinV);
+  svd.setThreshold(threshold);
+  svd.compute(jacobian);
+  const Eigen::VectorXd expected = svd.solve(input);
+  Eigen::MatrixXd jacobian_storage = Eigen::MatrixXd::Zero(jacobian.rows() + 1, jacobian.cols());
+  Eigen::VectorXd input_storage = Eigen::VectorXd::Zero(input.size() + 1);
+  jacobian_storage.topRows(jacobian.rows()) = jacobian;
+  input_storage.topRows(input.size()) = input;
+  const Eigen::VectorXd actual = kdl_kinematics_plugin::internal::solvePseudoinverse(
+      jacobian_storage.topRows(jacobian.rows()), input_storage.topRows(input.size()), threshold);
+  EXPECT_LT((expected - actual).norm(), 1e-8 * std::max(1.0, expected.norm()));
+  EXPECT_NEAR((jacobian * expected - input).norm(), (jacobian * actual - input).norm(), 1e-9);
+}
+}  // namespace
+
+TEST(Pseudoinverse, FullRank)
+{
+  expectSameSolution({ 1.0, 0.7, 0.4, 0.2, 0.1, 0.02 });
+  expectSameSolution({ 1.0, 0.3, 0.02 });
+}
+
+TEST(Pseudoinverse, RankDeficient)
+{
+  expectSameSolution({ 1.0, 0.4, 0.1, 0.0, 0.0, 0.0 });
+}
+
+TEST(Pseudoinverse, ThresholdBoundary)
+{
+  expectSameSolution({ 1.0, 0.4, 0.1, 0.01, 0.001001, 0.0005 });
+  expectSameSolution({ 1.0, 0.4, 0.1, 0.01, 0.000999, 0.0005 });
+}
+
+TEST(Pseudoinverse, IllConditioned)
+{
+  expectSameSolution({ 1.0, 0.01, 0.0001, 1e-6, 1e-8, 0.0 });
+}


### PR DESCRIPTION
### Description

`ChainIkSolverVelMimicSVD::CartToJnt()` runs once per Newton iteration, and profiling showed that most of its runtime was spent computing a thin `JacobiSVD` of the 6xN Jacobian.

This replaces that decomposition with the equivalent minimum-norm solve

```text
x = J^T (JJ^T)^# vin
```

using a self-adjoint eigendecomposition of the smaller `rows x rows` matrix `JJ^T`. The helper applies the same relative singular-value threshold as the existing SVD solve.

### Results

Measured on a 7-DOF Panda chain:

| workload | current | this change | speedup |
|---|---:|---:|---:|
| decomposition, 6x7 | 5.33–5.38 us | 1.85 us | ~2.9x |
| decomposition, 3x7 | 1.24–1.27 us | 0.76 us | ~1.6x |
| full IK solve, original perturbation | 1774.9 us | 1446.4 us | 1.23x |
| full IK solve, 6-DOF targets | 2173.2 us | 1654.0 us | 1.31x |

### Validation

Added tests comparing the helper against Eigen's thin `JacobiSVD` for 6x7 and 3x7 Jacobians. They cover full-rank, rank-deficient, ill-conditioned, and threshold-boundary cases.

- `clang-format` run on all changed C++ files
- 4 pseudoinverse tests pass in the MoveIt Humble CI image with `-Wall -Wextra -Werror`

### Checklist

- [x] Code is formatted using `clang-format`
- [x] No tutorial or documentation changes are needed
- [x] No user-facing API change; no `MIGRATION.md` entry is needed
- [x] Added tests that compare the new solve with the existing thin-SVD result
- [x] No GUI changes
- [ ] Review another open pull request while waiting for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inverse kinematics solving for weighted and mimic-joint configurations, including rank-deficient and ill-conditioned systems.
  * Added threshold-based handling for near-zero singular values to improve numerical stability.

* **Tests**
  * Added automated coverage for full-rank, rank-deficient, threshold-boundary, and ill-conditioned pseudoinverse calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->