### PR TITLE
moveit_core: migrate AccelerationLimitedPlugin to OSQP v1.0 C A

### DIFF
--- a/moveit2_rolling.repos
+++ b/moveit2_rolling.repos
@@ -1,0 +1,21 @@
+# Rolling-only source-checkouts.
+#
+# Convention: pin dependencies by SHA (not branch), so `vcs pull` in the
+# AFTER_SETUP_UPSTREAM_WORKSPACE step cannot drift the tree under a warm ccache.
+# CI matrix entries whose IMAGE starts with "rolling-" pick up this file
+# automatically via UPSTREAM_WORKSPACE (see .github/workflows/ci.yaml).
+#
+# osqp_vendor: consume the moveit-org fork which vendors OSQP v1.0.0 and
+# therefore declares cmake_minimum_required(3.16), building cleanly on
+# CMake 4 (which resolute ships). rosdistro release of this fork is planned
+# for lyrical + rolling; humble/jazzy/kilted stay on tier4/osqp_vendor's
+# apt-shipped 0.2.0 (OSQP v0.6.x) release. Swap the SHA below for a tag
+# once moveit/osqp_vendor cuts one. Refs #3786.
+#
+# NOTE: This file may conflict with #3760 which also introduces
+# moveit2_rolling.repos; whichever PR lands second reconciles.
+repositories:
+  osqp_vendor:
+    type: git
+    url: https://github.com/moveit/osqp_vendor.git
+    version: 58a52e815ad005d1fc971dca0fdc0c0e8100444b  # Update OSQP version to v1.0.0 (#1)

--- a/moveit_core/online_signal_smoothing/CMakeLists.txt
+++ b/moveit_core/online_signal_smoothing/CMakeLists.txt
@@ -30,6 +30,35 @@ target_link_libraries(
   osqp::osqp
   srdfdom::srdfdom
   pluginlib::pluginlib)
+# OSQP shipped v1.0 in 2024 with a redesigned C API. Drive the source-code guard
+# from the include directory the osqp::osqp target actually resolved to, so that
+# a build environment with BOTH v0.6 (apt) and v1.0 (source-overlay) installed
+# sees a self-consistent compile+link (the header-probe fallback in the .hpp can
+# race the -I search order between the two installs). PUBLIC so consumers of
+# moveit_acceleration_filter (notably test_acceleration_filter) see the same
+# value — the guard controls a private member type of AccelerationLimitedPlugin,
+# so an ABI mismatch between the .so and its test would be UB.
+#
+# Not using osqp_VERSION here: on v1.0.0 the shipped `osqp-config-version.cmake`
+# sets `PACKAGE_VERSION "0.0.0"` (packaging bug), and v0.6.2 ships no
+# config-version file at all — so osqp_VERSION is unusable across both streams,
+# but for different reasons. Instead probe for a v1-only header inside the
+# include dir that osqp::osqp exposes. See #3786.
+get_target_property(_moveit_osqp_include_dirs osqp::osqp
+                    INTERFACE_INCLUDE_DIRECTORIES)
+set(_moveit_osqp_v1 0)
+foreach(_dir IN LISTS _moveit_osqp_include_dirs)
+  string(REGEX REPLACE "^\\$<BUILD_INTERFACE:(.*)>$" "\\1" _dir "${_dir}")
+  string(REGEX REPLACE "^\\$<INSTALL_INTERFACE:(.*)>$" "\\1" _dir "${_dir}")
+  if(EXISTS "${_dir}/osqp_api_types.h")
+    set(_moveit_osqp_v1 1)
+    break()
+  endif()
+endforeach()
+target_compile_definitions(moveit_acceleration_filter
+                           PUBLIC MOVEIT_OSQP_V1=${_moveit_osqp_v1})
+unset(_moveit_osqp_v1)
+unset(_moveit_osqp_include_dirs)
 
 add_library(moveit_butterworth_filter SHARED src/butterworth_filter.cpp)
 generate_export_header(moveit_butterworth_filter)

--- a/moveit_core/online_signal_smoothing/include/moveit/online_signal_smoothing/acceleration_filter.hpp
+++ b/moveit_core/online_signal_smoothing/include/moveit/online_signal_smoothing/acceleration_filter.hpp
@@ -84,6 +84,35 @@ c --------x--- v   |
 #include <cstddef>  // for size_t
 #include <Eigen/Sparse>
 
+// OSQP shipped v1.0 in 2024 with a redesigned C API. Neither v0.6.x nor v1.0
+// exposes a numeric version macro that's usable from a preprocessor #if
+// (v0.6's OSQP_VERSION is a string literal in constants.h; v1's numeric
+// macros live in a non-installed private/version.h), so we don't have a
+// clean OSQP-provided switch.
+//
+// Preferred signal: MOVEIT_OSQP_V1 is defined at compile time from
+// moveit_core/online_signal_smoothing/CMakeLists.txt based on the version
+// find_package(osqp) actually resolved. That keeps compile-time API selection
+// consistent with link-time library selection when a build environment has
+// BOTH v0.6 (apt) and v1.0 (source-overlay) installed.
+//
+// Fallback for tooling that doesn't run through our CMakeLists (LSP,
+// clang-tidy stand-alone, etc.): probe for a v1-only header. The osqp CMake
+// target sets INTERFACE_INCLUDE_DIRECTORIES to ${prefix}/include/osqp, so
+// headers are searched directly without an `osqp/` prefix.
+//
+// TODO(#3786): remove the v0.6.x branch once every supported distro consumes
+// an osqp_vendor >= 1.0.0. Concrete trigger: Humble EOL (2027-05) or when
+// Jazzy/Kilted release an osqp_vendor 1.0 of their own. See #3751 for the
+// distro-compat-guard policy.
+#ifndef MOVEIT_OSQP_V1
+#if __has_include(<osqp_api_types.h>)
+#define MOVEIT_OSQP_V1 1
+#else
+#define MOVEIT_OSQP_V1 0
+#endif
+#endif
+
 namespace online_signal_smoothing
 {
 MOVEIT_STRUCT_FORWARD(OSQPDataWrapper);
@@ -127,9 +156,9 @@ public:
    */
   ~AccelerationLimitedPlugin() override
   {
-    if (osqp_workspace_ != nullptr)
+    if (osqp_solver_ != nullptr)
     {
-      osqp_cleanup(osqp_workspace_);
+      osqp_cleanup(osqp_solver_);
     }
   }
 
@@ -156,7 +185,11 @@ private:
   Eigen::SparseMatrix<double> constraints_sparse_;
   /** \brief osqp types used for optimization problem */
   OSQPDataWrapperPtr osqp_data_;
-  OSQPWorkspace* osqp_workspace_ = nullptr;
+#if MOVEIT_OSQP_V1
+  OSQPSolver* osqp_solver_ = nullptr;
+#else
+  OSQPWorkspace* osqp_solver_ = nullptr;
+#endif
   OSQPSettings osqp_settings_;
 };
 }  // namespace online_signal_smoothing

--- a/moveit_core/online_signal_smoothing/src/acceleration_filter.cpp
+++ b/moveit_core/online_signal_smoothing/src/acceleration_filter.cpp
@@ -40,6 +40,13 @@
 
 namespace online_signal_smoothing
 {
+#if !MOVEIT_OSQP_V1
+// v0.6.x doesn't expose these names; alias them to the equivalent v0.6 types so
+// the rest of the file can be written in the v1.0 naming without duplication.
+using OSQPInt = c_int;
+using OSQPCscMatrix = csc;
+#endif
+
 rclcpp::Logger getLogger()
 {
   return moveit::getLogger("moveit.core.acceleration_limited_plugin");
@@ -56,13 +63,13 @@ constexpr double ALPHA_LOWER_BOUND = 0.0;
 struct CSCWrapper
 {
   /// row indices, size nzmax starting from 0
-  std::vector<c_int> row_indices;
+  std::vector<OSQPInt> row_indices;
   /// column pointers (size n+1); col indices (size nzmax)
-  std::vector<c_int> column_pointers;
+  std::vector<OSQPInt> column_pointers;
   /// holds the non-zero values in Compressed Sparse Column (CSC) form
   std::vector<double> elements;
   /// osqp C sparse_matrix type
-  csc csc_sparse_matrix;
+  OSQPCscMatrix csc_sparse_matrix;
 
   CSCWrapper(Eigen::SparseMatrix<double>& M)
   {
@@ -103,38 +110,62 @@ struct CSCWrapper
 
 MOVEIT_STRUCT_FORWARD(OSQPDataWrapper);
 
-/** \brief Wrapper struct to make memory management easier for using osqp's C API */
+/** \brief Wrapper struct to make memory management easier for using osqp's C API.
+ * On OSQP v0.6.x, the aggregated OSQPData struct is populated in the constructor
+ * and passed as a single pointer to osqp_setup. On OSQP v1.0+, that aggregate no
+ * longer exists — matrices/vectors are passed directly to osqp_setup — but this
+ * wrapper still owns the Eigen-backed memory for P, A, q, l, u so the solver's
+ * borrowed pointers stay alive across the object's lifetime.
+ */
 struct OSQPDataWrapper
 {
   OSQPDataWrapper(Eigen::SparseMatrix<double>& objective_sparse, Eigen::SparseMatrix<double>& constraints_sparse)
-    : P{ objective_sparse }, A{ constraints_sparse }
+    : P{ objective_sparse }
+    , A{ constraints_sparse }
+    , q{ Eigen::VectorXd::Zero(objective_sparse.rows()) }
+    , l{ Eigen::VectorXd::Zero(constraints_sparse.rows()) }
+    , u{ Eigen::VectorXd::Zero(constraints_sparse.rows()) }
   {
+#if !MOVEIT_OSQP_V1
+    // v0.6.x: populate the OSQPData aggregate that osqp_setup expects.
     data.n = objective_sparse.rows();
     data.m = constraints_sparse.rows();
     data.P = &P.csc_sparse_matrix;
-    q = Eigen::VectorXd::Zero(objective_sparse.rows());
     data.q = q.data();
     data.A = &A.csc_sparse_matrix;
-    l = Eigen::VectorXd::Zero(constraints_sparse.rows());
     data.l = l.data();
-    u = Eigen::VectorXd::Zero(constraints_sparse.rows());
     data.u = u.data();
+#endif
   }
 
-  /// Update the constraint matrix A without reallocating memory
+  /// Update the constraint matrix A without reallocating memory.
+#if MOVEIT_OSQP_V1
+  void updateA(OSQPSolver* solver, Eigen::SparseMatrix<double>& constraints_sparse)
+  {
+    constraints_sparse.makeCompressed();
+    A.update(constraints_sparse);
+    // v1.0: osqp_update_data_mat covers both P and A; we pass nullptrs for the
+    // P side to say "don't update P."
+    osqp_update_data_mat(solver, nullptr, nullptr, 0, A.elements.data(), nullptr,
+                         static_cast<OSQPInt>(A.elements.size()));
+  }
+#else
   void updateA(OSQPWorkspace* work, Eigen::SparseMatrix<double>& constraints_sparse)
   {
     constraints_sparse.makeCompressed();
     A.update(constraints_sparse);
     osqp_update_A(work, A.elements.data(), OSQP_NULL, A.elements.size());
   }
+#endif
 
   CSCWrapper P;
   CSCWrapper A;
   Eigen::VectorXd q;
   Eigen::VectorXd l;
   Eigen::VectorXd u;
+#if !MOVEIT_OSQP_V1
   OSQPData data{};
+#endif
 };
 
 bool AccelerationLimitedPlugin::initialize(rclcpp::Node::SharedPtr node, moveit::core::RobotModelConstPtr robot_model,
@@ -186,19 +217,40 @@ bool AccelerationLimitedPlugin::initialize(rclcpp::Node::SharedPtr node, moveit:
   }
   constraints_sparse_.insert(num_constraints - 1, 0) = 0;
   osqp_set_default_settings(&osqp_settings_);
+#if MOVEIT_OSQP_V1
+  // v1.0 renamed OSQPSettings.warm_start -> warm_starting.
+  osqp_settings_.warm_starting = 0;
+#else
   osqp_settings_.warm_start = 0;
+#endif
   osqp_settings_.verbose = 0;
   osqp_data_ = std::make_shared<OSQPDataWrapper>(objective_sparse, constraints_sparse_);
   osqp_data_->q[0] = 0;
 
-  if (osqp_setup(&osqp_workspace_, &osqp_data_->data, &osqp_settings_) != 0)
+#if MOVEIT_OSQP_V1
+  // v1.0: no OSQPData aggregate — matrices/vectors go directly to osqp_setup.
+  if (osqp_setup(&osqp_solver_, &osqp_data_->P.csc_sparse_matrix, osqp_data_->q.data(), &osqp_data_->A.csc_sparse_matrix,
+                 osqp_data_->l.data(), osqp_data_->u.data(), static_cast<OSQPInt>(osqp_data_->A.csc_sparse_matrix.m),
+                 static_cast<OSQPInt>(osqp_data_->P.csc_sparse_matrix.n), &osqp_settings_) != 0)
   {
     osqp_settings_.verbose = 1;
-    // call setup again with verbose enables to trigger error message printing
-    osqp_setup(&osqp_workspace_, &osqp_data_->data, &osqp_settings_);
+    // call setup again with verbose enabled to trigger error message printing
+    osqp_setup(&osqp_solver_, &osqp_data_->P.csc_sparse_matrix, osqp_data_->q.data(), &osqp_data_->A.csc_sparse_matrix,
+               osqp_data_->l.data(), osqp_data_->u.data(), static_cast<OSQPInt>(osqp_data_->A.csc_sparse_matrix.m),
+               static_cast<OSQPInt>(osqp_data_->P.csc_sparse_matrix.n), &osqp_settings_);
     RCLCPP_ERROR(getLogger(), "Failed to initialize osqp problem.");
     return false;
   }
+#else
+  if (osqp_setup(&osqp_solver_, &osqp_data_->data, &osqp_settings_) != 0)
+  {
+    osqp_settings_.verbose = 1;
+    // call setup again with verbose enabled to trigger error message printing
+    osqp_setup(&osqp_solver_, &osqp_data_->data, &osqp_settings_);
+    RCLCPP_ERROR(getLogger(), "Failed to initialize osqp problem.");
+    return false;
+  }
+#endif
 
   return true;
 }
@@ -230,17 +282,28 @@ double jointLimitAccelerationScalingFactor(const Eigen::VectorXd& accelerations,
   return min_scaling_factor;
 }
 
-inline bool updateData(const OSQPDataWrapperPtr& data, OSQPWorkspace* work,
+#if MOVEIT_OSQP_V1
+inline bool updateData(const OSQPDataWrapperPtr& data, OSQPSolver* solver,
                        Eigen::SparseMatrix<double>& constraints_sparse, const Eigen::VectorXd& lower_bound,
                        const Eigen::VectorXd& upper_bound)
+#else
+inline bool updateData(const OSQPDataWrapperPtr& data, OSQPWorkspace* solver,
+                       Eigen::SparseMatrix<double>& constraints_sparse, const Eigen::VectorXd& lower_bound,
+                       const Eigen::VectorXd& upper_bound)
+#endif
 {
-  data->updateA(work, constraints_sparse);
+  data->updateA(solver, constraints_sparse);
   size_t num_constraints = constraints_sparse.rows();
   data->u.block(0, 0, num_constraints - 1, 1) = upper_bound;
   data->l.block(0, 0, num_constraints - 1, 1) = lower_bound;
   data->u[num_constraints - 1] = ALPHA_UPPER_BOUND;
   data->l[num_constraints - 1] = ALPHA_LOWER_BOUND;
-  return 0 == osqp_update_bounds(work, data->l.data(), data->u.data());
+#if MOVEIT_OSQP_V1
+  // v1.0 replaces osqp_update_bounds; nullptr for q means "do not update q."
+  return 0 == osqp_update_data_vec(solver, nullptr, data->l.data(), data->u.data());
+#else
+  return 0 == osqp_update_bounds(solver, data->l.data(), data->u.data());
+#endif
 }
 
 bool AccelerationLimitedPlugin::doSmoothing(Eigen::VectorXd& positions, Eigen::VectorXd& velocities,
@@ -294,10 +357,10 @@ bool AccelerationLimitedPlugin::doSmoothing(Eigen::VectorXd& positions, Eigen::V
   Eigen::VectorXd vel_point = last_positions_ + last_velocities_ * update_period;
   Eigen::VectorXd upper_bound = vel_point - positions + max_acceleration_limits_ * (update_period * update_period);
   Eigen::VectorXd lower_bound = vel_point - positions + min_acceleration_limits_ * (update_period * update_period);
-  if (!updateData(osqp_data_, osqp_workspace_, constraints_sparse_, lower_bound, upper_bound))
+  if (!updateData(osqp_data_, osqp_solver_, constraints_sparse_, lower_bound, upper_bound))
   {
     RCLCPP_ERROR_THROTTLE(getLogger(), *node_->get_clock(), 1000,
-                          "failed to set osqp_update_bounds. Make sure the robot's acceleration limits are valid");
+                          "failed to set osqp constraint bounds. Make sure the robot's acceleration limits are valid");
     return false;
   }
 
@@ -307,11 +370,11 @@ bool AccelerationLimitedPlugin::doSmoothing(Eigen::VectorXd& positions, Eigen::V
     positions = last_positions_;
     velocities = last_velocities_;
   }
-  else if (osqp_solve(osqp_workspace_) == 0 &&
-           osqp_workspace_->solution->x[0] >= ALPHA_LOWER_BOUND - osqp_settings_.eps_abs &&
-           osqp_workspace_->solution->x[0] <= ALPHA_UPPER_BOUND + osqp_settings_.eps_abs)
+  else if (osqp_solve(osqp_solver_) == 0 &&
+           osqp_solver_->solution->x[0] >= ALPHA_LOWER_BOUND - osqp_settings_.eps_abs &&
+           osqp_solver_->solution->x[0] <= ALPHA_UPPER_BOUND + osqp_settings_.eps_abs)
   {
-    double alpha = osqp_workspace_->solution->x[0];
+    double alpha = osqp_solver_->solution->x[0];
     positions = alpha * last_positions_ + (1.0 - alpha) * positions.eval();
     velocities = (positions - last_positions_) / update_period;
   }


### PR DESCRIPTION
Closes #3786 

OSQP v1.0 redesigned the C API:
- OSQPWorkspace* → OSQPSolver*
- OSQPData aggregate removed; matrix/vector pointers passed directly to osqp_setup(...) instead of through a data struct
- csc → OSQPCscMatrix, c_int → OSQPInt
- osqp_update_A + osqp_update_bounds → osqp_update_data_mat + osqp_update_data_vec (single call each replaces both prior functions)
- OSQPSettings.warm_start → OSQPSettings.warm_starting
- Solution access via osqp_solver_->solution->x[0] (same shape as v0.6.x)

AccelerationLimitedPlugin is the sole OSQP consumer in moveit_core; port every call site to v1.0. Behavior of the QP is unchanged — same problem formulation, same iteration/settings, same solution semantics. Regression: 100% of AccelerationFilterTest (4 tests) passes after migration.

Companion change: moveit2_rolling.repos in #3760 will point osqp_vendor at moveit/osqp_vendor (which ships OSQP v1.0.0) instead of tier4/osqp_vendor (0.6.x). A rosdistro release of moveit/osqp_vendor is planned for lyrical + rolling; humble/jazzy/kilted continue on tier4's release path.

### Description

Please explain the changes you made, including a reference to the related issue if applicable

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](https://moveit.ai/documentation/contributing/pullrequests/)
- [ ] Extend the tutorials / documentation [reference](https://github.com/moveit/moveit2_tutorials)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.picknik.ai/humble/doc/examples/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
