### PR TITLE
Fix rviz Qt6 threshold: 15.1 → 15.1.14

### DIFF
--- a/moveit_ros/visualization/CMakeLists.txt
+++ b/moveit_ros/visualization/CMakeLists.txt
@@ -31,8 +31,10 @@ find_package(rviz2 REQUIRED)
 find_package(tf2_eigen REQUIRED)
 find_package(Eigen3 REQUIRED)
 
-# rviz switched to Qt6 in version 15.1: https://github.com/ros2/rviz/pull/1635
-if(rviz2_VERSION VERSION_GREATER_EQUAL 15.1)
+# rviz switched to Qt6 in 15.1.14: https://github.com/ros2/rviz/pull/1635
+# (merged 2025-12-08, first released in the 15.1.14 tag on 2025-12-17 -- 15.1.0
+# through 15.1.13 are still Qt5)
+if(rviz2_VERSION VERSION_GREATER_EQUAL 15.1.14)
   find_package(Qt6 REQUIRED COMPONENTS Widgets)
   set(QT_VERSION_MAJOR 6)
   # Hint for transitive deps that use find_package(QT NAMES Qt6 Qt5 ...) which

--- a/moveit_setup_assistant/moveit_setup_app_plugins/CMakeLists.txt
+++ b/moveit_setup_assistant/moveit_setup_app_plugins/CMakeLists.txt
@@ -8,9 +8,11 @@ moveit_package()
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_ros REQUIRED)
 find_package(ament_index_cpp REQUIRED)
-# rviz switched to Qt6 in version 15.1: https://github.com/ros2/rviz/pull/1635
+# rviz switched to Qt6 in 15.1.14: https://github.com/ros2/rviz/pull/1635
+# (merged 2025-12-08, first released in the 15.1.14 tag on 2025-12-17 -- 15.1.0
+# through 15.1.13 are still Qt5)
 find_package(rviz2 QUIET)
-if(rviz2_VERSION VERSION_GREATER_EQUAL 15.1)
+if(rviz2_VERSION VERSION_GREATER_EQUAL 15.1.14)
   find_package(Qt6 REQUIRED COMPONENTS Core Widgets)
   set(QT_VERSION_MAJOR 6)
   # Hint for transitive deps that use find_package(QT NAMES Qt6 Qt5 ...) which

--- a/moveit_setup_assistant/moveit_setup_assistant/CMakeLists.txt
+++ b/moveit_setup_assistant/moveit_setup_assistant/CMakeLists.txt
@@ -9,9 +9,11 @@ moveit_package()
 find_package(ament_cmake REQUIRED)
 find_package(ament_index_cpp REQUIRED)
 find_package(Boost REQUIRED program_options)
-# rviz switched to Qt6 in version 15.1: https://github.com/ros2/rviz/pull/1635
+# rviz switched to Qt6 in 15.1.14: https://github.com/ros2/rviz/pull/1635
+# (merged 2025-12-08, first released in the 15.1.14 tag on 2025-12-17 -- 15.1.0
+# through 15.1.13 are still Qt5)
 find_package(rviz2 QUIET)
-if(rviz2_VERSION VERSION_GREATER_EQUAL 15.1)
+if(rviz2_VERSION VERSION_GREATER_EQUAL 15.1.14)
   find_package(Qt6 REQUIRED COMPONENTS Core Widgets)
   set(QT_VERSION_MAJOR 6)
   # Hint for transitive deps that use find_package(QT NAMES Qt6 Qt5 ...) which

--- a/moveit_setup_assistant/moveit_setup_controllers/CMakeLists.txt
+++ b/moveit_setup_assistant/moveit_setup_controllers/CMakeLists.txt
@@ -8,9 +8,11 @@ moveit_package()
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_ros REQUIRED)
 find_package(ament_index_cpp REQUIRED)
-# rviz switched to Qt6 in version 15.1: https://github.com/ros2/rviz/pull/1635
+# rviz switched to Qt6 in 15.1.14: https://github.com/ros2/rviz/pull/1635
+# (merged 2025-12-08, first released in the 15.1.14 tag on 2025-12-17 -- 15.1.0
+# through 15.1.13 are still Qt5)
 find_package(rviz2 QUIET)
-if(rviz2_VERSION VERSION_GREATER_EQUAL 15.1)
+if(rviz2_VERSION VERSION_GREATER_EQUAL 15.1.14)
   find_package(Qt6 REQUIRED COMPONENTS Core Widgets)
   set(QT_VERSION_MAJOR 6)
   # Hint for transitive deps that use find_package(QT NAMES Qt6 Qt5 ...) which

--- a/moveit_setup_assistant/moveit_setup_core_plugins/CMakeLists.txt
+++ b/moveit_setup_assistant/moveit_setup_core_plugins/CMakeLists.txt
@@ -8,9 +8,11 @@ moveit_package()
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_ros REQUIRED)
 find_package(ament_index_cpp REQUIRED)
-# rviz switched to Qt6 in version 15.1: https://github.com/ros2/rviz/pull/1635
+# rviz switched to Qt6 in 15.1.14: https://github.com/ros2/rviz/pull/1635
+# (merged 2025-12-08, first released in the 15.1.14 tag on 2025-12-17 -- 15.1.0
+# through 15.1.13 are still Qt5)
 find_package(rviz2 QUIET)
-if(rviz2_VERSION VERSION_GREATER_EQUAL 15.1)
+if(rviz2_VERSION VERSION_GREATER_EQUAL 15.1.14)
   find_package(Qt6 REQUIRED COMPONENTS Core Widgets)
   set(QT_VERSION_MAJOR 6)
   # Hint for transitive deps that use find_package(QT NAMES Qt6 Qt5 ...) which

--- a/moveit_setup_assistant/moveit_setup_framework/CMakeLists.txt
+++ b/moveit_setup_assistant/moveit_setup_framework/CMakeLists.txt
@@ -9,9 +9,11 @@ find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_ros REQUIRED)
 find_package(ament_index_cpp REQUIRED)
 find_package(fmt REQUIRED)
-# rviz switched to Qt6 in version 15.1: https://github.com/ros2/rviz/pull/1635
+# rviz switched to Qt6 in 15.1.14: https://github.com/ros2/rviz/pull/1635
+# (merged 2025-12-08, first released in the 15.1.14 tag on 2025-12-17 -- 15.1.0
+# through 15.1.13 are still Qt5)
 find_package(rviz2 QUIET)
-if(rviz2_VERSION VERSION_GREATER_EQUAL 15.1)
+if(rviz2_VERSION VERSION_GREATER_EQUAL 15.1.14)
   find_package(Qt6 REQUIRED COMPONENTS Core Widgets)
   set(QT_VERSION_MAJOR 6)
   # Hint for transitive deps that use find_package(QT NAMES Qt6 Qt5 ...) which

--- a/moveit_setup_assistant/moveit_setup_simulation/CMakeLists.txt
+++ b/moveit_setup_assistant/moveit_setup_simulation/CMakeLists.txt
@@ -8,9 +8,11 @@ moveit_package()
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_ros REQUIRED)
 find_package(ament_index_cpp REQUIRED)
-# rviz switched to Qt6 in version 15.1: https://github.com/ros2/rviz/pull/1635
+# rviz switched to Qt6 in 15.1.14: https://github.com/ros2/rviz/pull/1635
+# (merged 2025-12-08, first released in the 15.1.14 tag on 2025-12-17 -- 15.1.0
+# through 15.1.13 are still Qt5)
 find_package(rviz2 QUIET)
-if(rviz2_VERSION VERSION_GREATER_EQUAL 15.1)
+if(rviz2_VERSION VERSION_GREATER_EQUAL 15.1.14)
   find_package(Qt6 REQUIRED COMPONENTS Core Widgets)
   set(QT_VERSION_MAJOR 6)
   # Hint for transitive deps that use find_package(QT NAMES Qt6 Qt5 ...) which

--- a/moveit_setup_assistant/moveit_setup_srdf_plugins/CMakeLists.txt
+++ b/moveit_setup_assistant/moveit_setup_srdf_plugins/CMakeLists.txt
@@ -7,9 +7,11 @@ moveit_package()
 
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_ros REQUIRED)
-# rviz switched to Qt6 in version 15.1: https://github.com/ros2/rviz/pull/1635
+# rviz switched to Qt6 in 15.1.14: https://github.com/ros2/rviz/pull/1635
+# (merged 2025-12-08, first released in the 15.1.14 tag on 2025-12-17 -- 15.1.0
+# through 15.1.13 are still Qt5)
 find_package(rviz2 QUIET)
-if(rviz2_VERSION VERSION_GREATER_EQUAL 15.1)
+if(rviz2_VERSION VERSION_GREATER_EQUAL 15.1.14)
   find_package(Qt6 REQUIRED COMPONENTS Core Widgets)
   set(QT_VERSION_MAJOR 6)
   # Hint for transitive deps that use find_package(QT NAMES Qt6 Qt5 ...) which


### PR DESCRIPTION
### Description

Follow-up to #3707. The Qt6 gates it added test `rviz2_VERSION VERSION_GREATER_EQUAL 15.1`, but rviz didn't switch to Qt6 at 15.1.0.

[ros2/rviz#1635](https://github.com/ros2/rviz/pull/1635) — "Use qt6 as the default dependency from rosdep" (ahcorde, merged 2025-12-08, [`4784c8cd`](https://github.com/ros2/rviz/commit/4784c8cda3f83f7107de581d90986a6edfd2fc20)) — first shipped in the [**15.1.14**](https://github.com/ros2/rviz/tree/15.1.14) tag on 2025-12-17.

Bisecting `rviz_common/package.xml` upstream:

| 15.1.11 | 15.1.12 | 15.1.13 | **15.1.14** |
|---|---|---|---|
| `qtbase5-dev` | `qtbase5-dev` | `qtbase5-dev` | **`qt6-base-dev`** |

So **15.1.0 – 15.1.13 are Qt5 but currently classify as Qt6.** Building against an rviz in that window selects Qt6 while rviz itself is Qt5.

### Impact

Latent, not currently breaking — no active distro is in the bad window:

| distro | `rviz2_VERSION` | actual Qt |
|---|---|---|
| humble | 11.2.26 | Qt5 |
| jazzy | 14.1.22 | Qt5 |
| kilted | 15.0.13 | Qt5 |
| lyrical | 15.2.4 | Qt6 |
| rolling | 16.0.1 | Qt6 |

Worth fixing anyway: **kilted is at 15.0.13, one patch series below the bad range.**

Note the failure mode is not a silent ABI mismatch — where Qt5 and Qt6 are both installed, `find_package(Qt6)` after rviz's Qt5 has defined the versionless `Qt::Core` target aborts the configure with `Some (but not all) targets in this export set were already defined`.

### Changes

`15.1` → `15.1.14` in all 8 `CMakeLists.txt` carrying the gate (`moveit_ros/visualization` + the 7 `moveit_setup_assistant` packages), and the comment now records which release introduced the switch.

### Validation

Probed `osrf/ros:<distro>-desktop` containers: confirmed `rviz2_VERSION` and `rviz_common_VERSION` agree, and the corrected gate still resolves correctly — kilted 15.0.13 → Qt5, lyrical 15.2.4 → Qt6, rolling 16.0.1 → Qt6.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](https://moveit.ai/documentation/contributing/pullrequests/) — CMake-only, no C++ changed
- [ ] Extend the tutorials / documentation — not applicable
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) notes — not applicable, build-system-internal
- [ ] Create tests, which fail without this PR — not applicable
- [ ] Include a screenshot if changing a GUI — not applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)
