### PR TITLE
De-flake servo and hybrid_planning launch fixtures

### DIFF
--- a/moveit_ros/hybrid_planning/test/launch/test_basic_integration.test.py
+++ b/moveit_ros/hybrid_planning/test/launch/test_basic_integration.test.py
@@ -5,7 +5,8 @@ import unittest
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, TimerAction
+from launch.actions import DeclareLaunchArgument, RegisterEventHandler, TimerAction
+from launch.event_handlers import OnProcessExit
 from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 from launch_ros.actions import Node
 from moveit_configs_utils import MoveItConfigsBuilder
@@ -94,7 +95,15 @@ def generate_test_description():
                 description="Binary directory of package "
                 "containing test executables",
             ),
-            TimerAction(period=2.0, actions=[hybrid_planning_gtest]),
+            # Gate the gtest launch on the last spawner exiting (== controller
+            # activated). The prior fixed TimerAction raced controller
+            # activation under load and caused this family to flake.
+            RegisterEventHandler(
+                OnProcessExit(
+                    target_action=panda_joint_group_position_controller_spawner,
+                    on_exit=[hybrid_planning_gtest],
+                )
+            ),
             launch_testing.actions.ReadyToTest(),
         ]
         + common_launch

--- a/moveit_ros/moveit_servo/tests/launch/servo_cpp_integration.test.py
+++ b/moveit_ros/moveit_servo/tests/launch/servo_cpp_integration.test.py
@@ -1,5 +1,6 @@
 import os
 import launch
+from launch.event_handlers import OnProcessExit
 import unittest
 import launch_ros
 import launch_testing
@@ -112,7 +113,14 @@ def generate_test_description():
             joint_state_broadcaster_spawner,
             panda_arm_controller_spawner,
             test_container,
-            launch.actions.TimerAction(period=5.0, actions=[servo_gtest]),
+            # Gate the gtest launch on panda_arm_controller_spawner exiting so
+            # controllers are guaranteed active before the test starts.
+            launch.actions.RegisterEventHandler(
+                OnProcessExit(
+                    target_action=panda_arm_controller_spawner,
+                    on_exit=[servo_gtest],
+                )
+            ),
             launch_testing.actions.ReadyToTest(),
         ]
     ), {

--- a/moveit_ros/moveit_servo/tests/launch/servo_ros_integration.test.py
+++ b/moveit_ros/moveit_servo/tests/launch/servo_ros_integration.test.py
@@ -1,5 +1,6 @@
 import os
 import launch
+from launch.event_handlers import OnProcessExit
 import unittest
 import launch_ros
 import launch_testing
@@ -145,7 +146,15 @@ def generate_test_description():
             launch.actions.TimerAction(
                 period=7.0, actions=[panda_arm_controller_spawner]
             ),
-            launch.actions.TimerAction(period=9.0, actions=[servo_gtest]),
+            # Gate the gtest launch on the last-in-chain spawner completing so the
+            # test does not race controller activation. Prior fixed 9s timer flaked
+            # under load (ServoRosFixture.testJointJog).
+            launch.actions.RegisterEventHandler(
+                OnProcessExit(
+                    target_action=panda_arm_controller_spawner,
+                    on_exit=[servo_gtest],
+                )
+            ),
             launch_testing.actions.ReadyToTest(),
         ]
     ), {

--- a/moveit_ros/moveit_servo/tests/launch/servo_utils.test.py
+++ b/moveit_ros/moveit_servo/tests/launch/servo_utils.test.py
@@ -1,5 +1,6 @@
 import os
 import launch
+from launch.event_handlers import OnProcessExit
 import unittest
 import launch_ros
 import launch_testing
@@ -110,7 +111,15 @@ def generate_test_description():
             joint_state_broadcaster_spawner,
             panda_arm_controller_spawner,
             test_container,
-            launch.actions.TimerAction(period=2.0, actions=[servo_gtest]),
+            # Gate the gtest launch on the last spawner exiting (== controller
+            # activated). The prior fixed TimerAction raced controller
+            # activation under load and caused this family to flake.
+            launch.actions.RegisterEventHandler(
+                OnProcessExit(
+                    target_action=panda_arm_controller_spawner,
+                    on_exit=[servo_gtest],
+                )
+            ),
             launch_testing.actions.ReadyToTest(),
         ]
     ), {


### PR DESCRIPTION
### Description

Same fix as #3777, applied to the four remaining launch fixtures with the pattern.

Each launches its gtest node on a **fixed `TimerAction`** while controller spawners run in parallel. Under load the spawner hasn't finished activating the controller when the timer fires, so the test starts against a topic with no publisher and fails intermittently:

```python
TimerAction(period=N, actions=[<gtest>])
```

Replaced with a gate on the last spawner exiting — `spawner` exits 0 only after the controller is active, so the gtest is guaranteed a live publisher:

```python
RegisterEventHandler(OnProcessExit(target_action=<last_spawner>, on_exit=[<gtest>]))
```

### Fixtures changed

| file | family |
|---|---|
| `moveit_ros/moveit_servo/tests/launch/servo_ros_integration.test.py` | `ServoRosFixture` |
| `moveit_ros/moveit_servo/tests/launch/servo_cpp_integration.test.py` | servo cpp integration |
| `moveit_ros/moveit_servo/tests/launch/servo_utils.test.py` | servo utils |
| `moveit_ros/hybrid_planning/test/launch/test_basic_integration.test.py` | hybrid_planning basic |

Verified in a Resolute container: servo **4/4** iterations green, servo_utils **3/3**, hybrid_planning **3/3**. Each previously flaked at roughly the rate the trajectory_cache family did before #3777.

`test_basic_integration.test.py` additionally needed `RegisterEventHandler` and `OnProcessExit` imported — it calls them unqualified, unlike the servo fixtures which use `launch.actions.RegisterEventHandler`. Without the import the fixture raises `NameError` at launch.

### Why this is worth landing

This family is currently costing signal on unrelated PRs. The `rolling-ci + deprecation check` and `rolling-ci + ccov` failures on #3807 were `test_get_cartesian_path_request_features_with_move_group` and `test_motion_plan_request_features_with_move_group` — same root cause, different fixture.

### Deliberately not changed

These chain `TimerAction`s across `ros2_control` and several spawners rather than gating on one terminal timer, so picking the right `target_action` needs a real reproducer of each family's failure mode:

- `moveit_ros/planning/planning_scene_monitor/test/launch/planning_scene_monitor.test.py`
- `moveit_ros/tests/launch/move_group_api.test.py`

### Checklist
- [x] **Required by CI**: Code is auto formatted — launch-file only, pre-commit clean
- [ ] Extend the tutorials / documentation — not applicable
- [ ] Document API changes in [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) — not applicable, test fixtures only
- [x] Create tests, which fail without this PR — these *are* the tests; the change makes existing ones deterministic
- [ ] Include a screenshot if changing a GUI — not applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)