### PR TITLE
moveit_setup_srdf_plugins: make test_srdf fail loudly instead of segfaulting

### DIFF
--- a/moveit_setup_assistant/moveit_setup_srdf_plugins/test/test_srdf.cpp
+++ b/moveit_setup_assistant/moveit_setup_srdf_plugins/test/test_srdf.cpp
@@ -92,9 +92,10 @@ TEST_F(SRDFTest, Empty)
 
   // do nothing
 
-  generateXML();
+  ASSERT_NO_FATAL_FAILURE(generateXML());
 
   auto root = srdf_xml_.FirstChildElement("robot");
+  ASSERT_NE(root, nullptr) << "No <robot> element in generated SRDF";
   EXPECT_EQ(std::string(root->Attribute("name")), std::string("fanuc"));
   EXPECT_TRUE(root->NoChildren());
 }
@@ -111,9 +112,10 @@ TEST_F(SRDFTest, SetJoints)
   std::vector<std::string> joints = { "joint_1", "joint_2" };
   pg.setJoints(group_name, joints);
 
-  generateXML();
+  ASSERT_NO_FATAL_FAILURE(generateXML());
 
   auto root = srdf_xml_.FirstChildElement("robot");
+  ASSERT_NE(root, nullptr) << "No <robot> element in generated SRDF";
   auto group_el = root->FirstChildElement("group");
   ASSERT_NE(group_el, nullptr);
   EXPECT_EQ(std::string(group_el->Attribute("name")), group_name);
@@ -123,7 +125,7 @@ TEST_F(SRDFTest, SetJoints)
   joints.push_back("joint_4");
   pg.setJoints(group_name, joints);
 
-  generateXML();
+  ASSERT_NO_FATAL_FAILURE(generateXML());
 
   root = srdf_xml_.FirstChildElement("robot");
   group_el = root->FirstChildElement("group");
@@ -143,9 +145,10 @@ TEST_F(SRDFTest, SetLinks)
   std::vector<std::string> links = { "base_link", "link_1" };
   pg.setLinks(group_name, links);
 
-  generateXML();
+  ASSERT_NO_FATAL_FAILURE(generateXML());
 
   auto root = srdf_xml_.FirstChildElement("robot");
+  ASSERT_NE(root, nullptr) << "No <robot> element in generated SRDF";
   auto group_el = root->FirstChildElement("group");
   ASSERT_NE(group_el, nullptr);
   EXPECT_EQ(std::string(group_el->Attribute("name")), group_name);
@@ -155,7 +158,7 @@ TEST_F(SRDFTest, SetLinks)
   links.push_back("link_3");
   pg.setLinks(group_name, links);
 
-  generateXML();
+  ASSERT_NO_FATAL_FAILURE(generateXML());
 
   root = srdf_xml_.FirstChildElement("robot");
   group_el = root->FirstChildElement("group");
@@ -175,9 +178,10 @@ TEST_F(SRDFTest, SetJointsThenLinks)
   std::vector<std::string> joints = { "joint_1", "joint_2" };
   pg.setJoints(group_name, joints);
 
-  generateXML();
+  ASSERT_NO_FATAL_FAILURE(generateXML());
 
   auto root = srdf_xml_.FirstChildElement("robot");
+  ASSERT_NE(root, nullptr) << "No <robot> element in generated SRDF";
   auto group_el = root->FirstChildElement("group");
   ASSERT_NE(group_el, nullptr);
   EXPECT_EQ(std::string(group_el->Attribute("name")), group_name);
@@ -187,7 +191,7 @@ TEST_F(SRDFTest, SetJointsThenLinks)
   std::vector<std::string> links = { "base_link", "link_1" };
   pg.setLinks(group_name, links);
 
-  generateXML();
+  ASSERT_NO_FATAL_FAILURE(generateXML());
 
   root = srdf_xml_.FirstChildElement("robot");
   group_el = root->FirstChildElement("group");


### PR DESCRIPTION
### Description

`test_srdf` currently **segfaults** rather than reporting a test failure, when the fixture's generated SRDF is missing.

`SRDFTest::generateXML()` asserts the file exists:

```cpp
ASSERT_TRUE(std::filesystem::is_regular_file(srdf_path));
```

But that assert is in a **helper**, and a gtest `ASSERT_*` inside a helper aborts only the helper — not the caller. So when `generateFiles<SRDFConfig>("srdf")` doesn't write the file, the test body carries on and calls:

```cpp
srdf_xml_.FirstChildElement("robot")
```

on an `XMLDocument` that was never `LoadFile()`d. `FirstChildElement` returns `nullptr`, `root->Attribute("name")` dereferences it, and tinyxml2 11.x segfaults inside `FindAttribute` at offset `0x70`.

Net effect: **the assertion that already fired is invisible**, and you get a bare crash instead.

### Changes

- Wrap all **7** `generateXML(...)` call sites in `ASSERT_NO_FATAL_FAILURE` so the helper's fatal assert actually aborts the test body.
- Add `ASSERT_NE(root, nullptr)` after the **4** `FirstChildElement("robot")` calls, as defence in depth.

11 insertions, 7 deletions, one file.

### Scope — what this does *not* fix

This is a **test-robustness** fix. The underlying write intermittency is not addressed, and could not be reproduced deterministically: running the test binary directly always passes, both in isolation and in the full suite. Only the `colcon test` invocation path exposes it, which points at filesystem/cwd timing rather than test logic.

The value is that a future occurrence will fail with the `is_regular_file` message — pointing straight at the real problem — instead of a segfault that says nothing.

### Verification

`colcon build moveit_setup_srdf_plugins` clean; `colcon test` passes all 4 `SRDFTest` cases (`Empty`, `SetJoints`, `SetLinks`, `SetJointsThenLinks`) with no segfault.

### Checklist
- [x] **Required by CI**: Code is auto formatted — pre-commit clean
- [ ] Extend the tutorials / documentation — not applicable
- [ ] Document API changes in [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) — not applicable, test-only
- [x] Create tests, which fail without this PR — this *is* the test; the change makes an existing failure legible
- [ ] Include a screenshot if changing a GUI — not applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)