### PR TITLE
ci: skip the tutorial rebuild on unrelated PRs, and unfreeze its ccache

### DIFF
--- a/.github/workflows/tutorial_docker.yaml
+++ b/.github/workflows/tutorial_docker.yaml
@@ -6,6 +6,20 @@ on:
     - cron:  '0 17 * * 6'
   workflow_dispatch:
   pull_request:
+    # This job rebuilds moveit2 + moveit2_tutorials + upstream deps from source
+    # and takes 45-60 min, so skip PRs that cannot affect the tutorial image.
+    # `paths` with `!` rather than `paths-ignore`, because negation is only
+    # supported in `paths` and the two cannot be combined for one event.
+    # Order matters: later patterns override earlier ones.
+    paths:
+      - '**'
+      - '!**/test/**'
+      - '!**/*.test.py'
+      - '!**.md'
+      - '!.github/**'
+      - '.github/workflows/tutorial_docker.yaml'
+      - '!.docker/**'
+      - '.docker/tutorial-source/**'
   merge_group:
   push:
     branches:
@@ -49,7 +63,15 @@ jobs:
         uses: actions/cache@v5
         with:
           path: .ccache
-          key: docker-tutorial-ccache-${{ matrix.ROS_DISTRO }}-${{ hashFiles( '.docker/tutorial-source/Dockerfile' ) }}
+          # actions/cache skips its save step on an exact-key hit, so a static key
+          # is written once and never refreshed -- every later build reuses a
+          # frozen ccache. Make the key unique per run and fall back to the
+          # stable prefix, so each run restores the newest entry and saves an
+          # updated one.
+          key: docker-tutorial-ccache-${{ matrix.ROS_DISTRO }}-${{ hashFiles( '.docker/tutorial-source/Dockerfile' ) }}-${{ github.run_id }}
+          restore-keys: |
+            docker-tutorial-ccache-${{ matrix.ROS_DISTRO }}-${{ hashFiles( '.docker/tutorial-source/Dockerfile' ) }}-
+            docker-tutorial-ccache-${{ matrix.ROS_DISTRO }}-
       - name: inject ccache into docker
         uses: reproducible-containers/buildkit-cache-dance@v3.3.0
         with:


### PR DESCRIPTION
### Description

`tutorial-source` is the long pole on every moveit2 PR. Measured across **eight consecutive runs**:

```
43m33s  53m32s  56m41s  54m22s  60m58s  51m10s  54m01s  57m40s
```

It ran the full ~55 min on #3809 — a PR touching **four launch `.test.py` files**.

Two independent causes, both small fixes.

---

### 1. It runs on every `pull_request` with no path filter

The job rebuilds moveit2 + moveit2_tutorials + all upstream deps from source. Changes to test fixtures, markdown, or other workflows can't affect the tutorial image, but still trigger a full rebuild.

Uses **`paths` with `!`** rather than `paths-ignore` — [negation is only supported in `paths`](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#onpushpull_requestpull_request_targetpathspaths-ignore), and the two filters can't be combined for one event:

> You cannot use `paths` and `paths-ignore` to filter the same event in a single workflow. If you want to both include and exclude path patterns for a single event, use the `paths` filter prefixed with the `!` character.

The filter still runs the job when this workflow or `.docker/tutorial-source/**` changes.

**Verified safe to skip.** `tutorial-source (jazzy)` is **not** a required status check on `main` — the required set is `Format`, `humble-ci`, `jazzy-ci`, `rolling-ci + ikfast + clang-tidy (delta)`, `rolling-ci + ccov`. And `.github/mergify.yml` contains only label-driven backport rules with **no `check-success` conditions**. So a skipped run can't block a merge, and no no-op fallback job is needed.

### 2. The ccache was frozen after its first save

```yaml
key: docker-tutorial-ccache-${{ matrix.ROS_DISTRO }}-${{ hashFiles( '.docker/tutorial-source/Dockerfile' ) }}
```

A static key with **no `restore-keys`**. `actions/cache` skips its save step on an exact-key hit, so the entry is written **once** and never refreshed — every build after the first restores a stale ccache and recompiles whatever changed since, indefinitely. The key only rotates when the Dockerfile changes, which is rare.

Switched to the rolling-key pattern used elsewhere in this repo: unique per run, falling back to the stable prefixes, so each run restores the newest entry and saves an updated one.

---

### Not addressed here

Worth follow-up, but larger and Dockerfile-structural:

- `COPY . src/moveit2` sits **above** the expensive `RUN`, with `.dockerignore` deliberately removed (`"enforce full source context"`) — so any source change busts the layer and forces a full workspace rebuild.
- Gazebo install, the tutorials clone, `vcs import`, `rosdep install` and `colcon build` share **one monolithic `RUN`**, so the slow-and-stable parts can never cache separately from the fast-changing build.
- The `moveit2_tutorials` clone is not shallow (`--depth 1`).

### Checklist
- [x] **Required by CI**: Code is auto formatted — CI config only
- [ ] Extend the tutorials / documentation — not applicable
- [ ] Document API changes in [MIGRATION.md](https://github.com/moveit/moveit2/blob/main/MIGRATION.md) — not applicable
- [ ] Create tests, which fail without this PR — not applicable
- [ ] Include a screenshot if changing a GUI — not applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)