### PR TITLE
Fix namespaced robot descriptions in RViz

### DIFF
--- a/moveit_ros/planning/rdf_loader/src/synchronized_string_parameter.cpp
+++ b/moveit_ros/planning/rdf_loader/src/synchronized_string_parameter.cpp
@@ -36,6 +36,8 @@
 
 #include <moveit/rdf_loader/synchronized_string_parameter.hpp>
 
+#include <cctype>
+
 namespace rdf_loader
 {
 std::string SynchronizedStringParameter::loadInitialValue(const std::shared_ptr<rclcpp::Node>& node,
@@ -120,7 +122,12 @@ bool SynchronizedStringParameter::shouldPublish()
 
 bool SynchronizedStringParameter::waitForMessage(const rclcpp::Duration& timeout)
 {
-  const auto nd_name = std::string(node_->get_name()).append("_ssp_").append(name_);
+  auto nd_name = std::string(node_->get_name()).append("_ssp_").append(name_);
+  for (char& character : nd_name)
+  {
+    if (!std::isalnum(static_cast<unsigned char>(character)) && character != '_')
+      character = '_';
+  }
   const auto temp_node = std::make_shared<rclcpp::Node>(nd_name, node_->get_namespace());
   string_subscriber_ = temp_node->create_subscription<std_msgs::msg::String>(
       name_,

--- a/moveit_ros/visualization/planning_scene_rviz_plugin/include/moveit/planning_scene_rviz_plugin/planning_scene_display.hpp
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/include/moveit/planning_scene_rviz_plugin/planning_scene_display.hpp
@@ -119,6 +119,9 @@ public:
   void clearJobs();
 
   const std::string getMoveGroupNS() const;
+  /// Return the robot description name resolved against the Move Group namespace.
+  /// Absolute names are returned unchanged.
+  const std::string getRobotDescription() const;
   const moveit::core::RobotModelConstPtr& getRobotModel() const;
 
   /// wait for robot state more recent than t

--- a/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
@@ -302,6 +302,15 @@ const std::string PlanningSceneDisplay::getMoveGroupNS() const
   return move_group_ns_property_->getStdString();
 }
 
+const std::string PlanningSceneDisplay::getRobotDescription() const
+{
+  const std::string robot_description = robot_description_property_->getStdString();
+  if (getMoveGroupNS().empty() || robot_description.empty() || robot_description.front() == '/')
+    return robot_description;
+
+  return rclcpp::names::append(getMoveGroupNS(), robot_description);
+}
+
 const moveit::core::RobotModelConstPtr& PlanningSceneDisplay::getRobotModel() const
 {
   if (planning_scene_monitor_)
@@ -539,7 +548,7 @@ void PlanningSceneDisplay::unsetLinkColor(rviz_default_plugins::robot::Robot* ro
 // ******************************************************************************************
 planning_scene_monitor::PlanningSceneMonitorPtr PlanningSceneDisplay::createPlanningSceneMonitor()
 {
-  auto rml = moveit::planning_interface::getSharedRobotModelLoader(node_, robot_description_property_->getStdString());
+  auto rml = moveit::planning_interface::getSharedRobotModelLoader(node_, getRobotDescription());
   return std::make_shared<planning_scene_monitor::PlanningSceneMonitor>(node_, rml,
                                                                         getNameStd() + "_planning_scene_monitor");
 }


### PR DESCRIPTION
### Description

Fixes #3799.

The Planning Scene and Motion Planning RViz displays now resolve a relative Robot Description against the configured Move Group Namespace before creating the shared RobotModelLoader. This gives each namespaced display a distinct loader key and subscribes to the matching namespaced robot_description and robot_description_semantic topics. Explicit absolute Robot Description names remain unchanged.

The RDF synchronized-string fallback now also sanitizes its temporary ROS node name. Without this, a namespaced description containing a slash would produce an invalid temporary node name before the topic could be read.

### Validation

- clang-format 14.0.6 on all changed C++ files
- git diff --check
- static regression assertions for namespace resolution and sanitized topic-loader path
- Full ROS 2 / RViz runtime validation was not available on this macOS workspace; the draft is ready for CI compilation and maintainer feedback.

### Checklist

- [x] Required by CI: code formatted with clang-format 14
- [ ] Tutorials/documentation extension is not needed for this bug fix
- [ ] Migration note is not needed; existing non-namespaced and absolute-name behavior is preserved
- [ ] No screenshot: this changes loading behavior, not the UI
- [ ] Full integration test is not included because the existing RDF integration-test harness is currently disabled in CMake