### PR TITLE
Fix state-only planning scene diff classification

### DIFF
--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -505,6 +505,8 @@ void PlanningSceneMonitor::scenePublishingThread()
             {
               msg.robot_state.attached_collision_objects.clear();
               msg.robot_state.is_diff = true;
+              msg.link_padding.clear();
+              msg.link_scale.clear();
             }
           }
           std::scoped_lock prevent_shape_cache_updates(shape_handles_lock_);  // we don't want the

--- a/moveit_ros/planning/planning_scene_monitor/test/planning_scene_monitor_test.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/test/planning_scene_monitor_test.cpp
@@ -42,6 +42,11 @@
 // Testing
 #include <gtest/gtest.h>
 
+#include <condition_variable>
+#include <mutex>
+#include <optional>
+#include <thread>
+
 // Main class
 #include <moveit/planning_scene_monitor/planning_scene_monitor.hpp>
 #include <moveit/robot_state/conversions.hpp>
@@ -145,6 +150,85 @@ TEST_F(PlanningSceneMonitorTest, UpdateTypes)
   msg.is_diff = false;
 
   TRIGGERS_UPDATE(msg, UpdateType::UPDATE_SCENE);
+}
+
+TEST_F(PlanningSceneMonitorTest, StateUpdatePublishesStateOnlyDiff)
+{
+  std::mutex message_mutex;
+  std::condition_variable message_condition;
+  std::optional<moveit_msgs::msg::PlanningScene> full_scene_msg;
+  std::optional<moveit_msgs::msg::PlanningScene> scene_diff_msg;
+
+  auto planning_scene_subscription = test_node_->create_subscription<moveit_msgs::msg::PlanningScene>(
+      "state_only_planning_scene", rclcpp::QoS(10), [&](const moveit_msgs::msg::PlanningScene::ConstSharedPtr& msg) {
+        std::scoped_lock lock(message_mutex);
+        if (msg->is_diff)
+        {
+          scene_diff_msg = *msg;
+        }
+        else
+        {
+          full_scene_msg = *msg;
+        }
+        message_condition.notify_all();
+      });
+
+  planning_scene_monitor_->startPublishingPlanningScene(UpdateType::UPDATE_STATE, "state_only_planning_scene");
+
+  const auto discovery_deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+  while (planning_scene_subscription->get_publisher_count() == 0 &&
+         std::chrono::steady_clock::now() < discovery_deadline)
+  {
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+  const bool publisher_discovered = planning_scene_subscription->get_publisher_count() > 0;
+
+  bool full_scene_received = false;
+  bool scene_diff_received = false;
+  if (publisher_discovered)
+  {
+    planning_scene_monitor_->triggerSceneUpdateEvent(UpdateType::UPDATE_SCENE);
+    {
+      std::unique_lock lock(message_mutex);
+      full_scene_received =
+          message_condition.wait_for(lock, std::chrono::seconds(5), [&] { return full_scene_msg.has_value(); });
+    }
+
+    planning_scene_monitor_->getPlanningScene()->getCurrentStateNonConst();
+    planning_scene_monitor_->triggerSceneUpdateEvent(UpdateType::UPDATE_STATE);
+    {
+      std::unique_lock lock(message_mutex);
+      scene_diff_received =
+          message_condition.wait_for(lock, std::chrono::seconds(5), [&] { return scene_diff_msg.has_value(); });
+    }
+  }
+  planning_scene_monitor_->stopPublishingPlanningScene();
+
+  ASSERT_TRUE(publisher_discovered);
+  ASSERT_TRUE(full_scene_received);
+  ASSERT_TRUE(scene_diff_received);
+  ASSERT_TRUE(full_scene_msg.has_value());
+  ASSERT_TRUE(scene_diff_msg.has_value());
+
+  EXPECT_FALSE(full_scene_msg->is_diff);
+  EXPECT_FALSE(full_scene_msg->link_padding.empty());
+  EXPECT_FALSE(full_scene_msg->link_scale.empty());
+
+  EXPECT_TRUE(scene_diff_msg->is_diff);
+  EXPECT_TRUE(scene_diff_msg->robot_state.is_diff);
+  EXPECT_TRUE(scene_diff_msg->robot_state.attached_collision_objects.empty());
+  EXPECT_TRUE(scene_diff_msg->link_padding.empty());
+  EXPECT_TRUE(scene_diff_msg->link_scale.empty());
+
+  auto receiving_monitor = std::make_unique<planning_scene_monitor::PlanningSceneMonitor>(
+      test_node_, planning_scene_monitor_->getRobotModelLoader(), "state_only_diff_receiver");
+  receiving_monitor->stopPublishingPlanningScene();
+  ASSERT_TRUE(receiving_monitor->newPlanningSceneMessage(*full_scene_msg));
+
+  auto received_update_type{ UpdateType::UPDATE_NONE };
+  receiving_monitor->addUpdateCallback([&](auto type) { received_update_type = type; });
+  ASSERT_TRUE(receiving_monitor->newPlanningSceneMessage(*scene_diff_msg));
+  EXPECT_EQ(received_update_type, UpdateType::UPDATE_STATE);
 }
 
 int main(int argc, char** argv)


### PR DESCRIPTION
### Description

`PlanningScene::getPlanningSceneDiffMsg()` includes the current link padding
and scale even when the pending monitor update contains only robot state. On
the receiving side, either field prevents `PlanningSceneMonitor` from
classifying the message as a state-only update.

This clears `link_padding` and `link_scale` in the exact `UPDATE_STATE`
publication branch, alongside the attached collision objects that are already
removed there. The initial full-scene message still carries padding and scale,
and updates that include another update bit do not enter this branch.

The regression test captures the actual published full scene and state diff,
then applies both messages to another monitor and verifies that the diff is
classified as `UPDATE_STATE`.

This addresses the padding/scale cause identified in #3794. As noted in the
issue comments, other causes such as world/OctoMap updates and RViz rendering
behavior can still produce broader updates, so this PR does not claim to fix
every source of the reported RViz slowdown.

### Testing

- Verified the regression fails on the base revision because padding/scale are
  present and the receiving monitor reports update type `15` instead of
  `UPDATE_STATE` (`1`).
- `ctest -R "^planning_scene_monitor_test_" --output-on-failure` (10/10
  consecutive runs)
- `ctest --output-on-failure` in `moveit_ros_planning` (6/6 passed)
- `clang-format-14 --dry-run --Werror` on both changed files
- `clang-tidy` on both changed files
- `git diff --check`

### Checklist

- [x] **Required by CI**: Code is auto formatted using clang-format
- [x] Create tests which fail without this PR
- [x] No API, migration note, tutorial, or GUI screenshot is required

AI assistance disclosure: OpenAI Codex was used to inspect the relevant code
paths, help draft the regression test, and review the patch. The behavior and
scope were checked against the current source, and the reported tests were run
before submission.
