### PR TITLE
Fix auto-added MoveIt controller parameters

### DIFF
--- a/moveit_setup_assistant/moveit_setup_controllers/src/controllers.cpp
+++ b/moveit_setup_assistant/moveit_setup_controllers/src/controllers.cpp
@@ -51,6 +51,9 @@ bool Controllers::addDefaultControllers()
     return false;
   }
 
+  const std::string controller_type = getDefaultType();
+  FieldPointers additional_fields = getAdditionalControllerFields();
+
   // Loop through groups
   bool success = true;
   for (const std::string& group_name : group_names)
@@ -61,7 +64,17 @@ bool Controllers::addDefaultControllers()
     {
       continue;
     }
-    bool ret = controllers_config_->addController(group_name + "_controller", getDefaultType(), joint_names);
+
+    ControllerInfo controller;
+    controller.name_ = group_name + "_controller";
+    controller.type_ = controller_type;
+    controller.joints_ = joint_names;
+    for (const std::shared_ptr<AdditionalControllerField>& field : additional_fields)
+    {
+      controller.parameters_[field->parameter_name_] = field->getDefaultValue(controller_type);
+    }
+
+    bool ret = controllers_config_->addController(controller);
     success &= ret;
   }
 

--- a/moveit_setup_assistant/moveit_setup_controllers/test/test_controllers.cpp
+++ b/moveit_setup_assistant/moveit_setup_controllers/test/test_controllers.cpp
@@ -37,6 +37,7 @@
 #include <moveit_setup_controllers/ros2_controllers_config.hpp>
 #include <moveit_setup_controllers/moveit_controllers_config.hpp>
 #include <moveit_setup_controllers/ros2_controllers.hpp>
+#include <moveit_setup_controllers/moveit_controllers.hpp>
 
 using moveit_setup::expectYamlEquivalence;
 using moveit_setup::getSharePath;
@@ -173,6 +174,47 @@ TEST_F(ControllersTest, AddDefaultControllers)
 
   // Test that addDefaultControllers() did actually add a controller for the new_group
   EXPECT_EQ(ros2_controllers_config->getControllers().size(), group_count);
+}
+
+// Regression test for https://github.com/moveit/moveit2/issues/3796
+// MoveItControllers::addDefaultControllers() must populate additional
+// controller fields (e.g. action_ns, default), not just name/type/joints.
+TEST_F(ControllersTest, AddDefaultControllersMoveItAdditionalFields)
+{
+  auto config_dir = getSharePath("moveit_resources_panda_moveit_config");
+  YAML::Node settings = YAML::LoadFile(config_dir / ".setup_assistant")["moveit_setup_assistant_config"];
+  config_data_->get<moveit_setup::URDFConfig>("urdf")->loadPrevious(config_dir, settings["URDF"]);
+  auto srdf_config = config_data_->get<moveit_setup::SRDFConfig>("srdf");
+  srdf_config->loadPrevious(config_dir, settings["SRDF"]);
+
+  auto moveit_controllers_config = config_data_->get<MoveItControllersConfig>("moveit_controllers");
+
+  // Initially no controllers
+  EXPECT_EQ(moveit_controllers_config->getControllers().size(), 0u);
+
+  // Run the setup step
+  moveit_setup::controllers::MoveItControllers setup_step;
+  initializeStep(setup_step);
+
+  // Adding default controllers, a FollowJointTrajectory controller for each planning group
+  setup_step.addDefaultControllers();
+
+  size_t group_count = srdf_config->getGroups().size();
+  const std::vector<ControllerInfo>& mcontrollers = moveit_controllers_config->getControllers();
+  ASSERT_EQ(mcontrollers.size(), group_count);
+
+  for (const ControllerInfo& ci : mcontrollers)
+  {
+    EXPECT_EQ("FollowJointTrajectory", ci.type_);
+
+    const auto& action_ns = ci.parameters_.find("action_ns");
+    ASSERT_NE(action_ns, ci.parameters_.end()) << "action_ns parameter missing for " << ci.name_;
+    EXPECT_EQ("follow_joint_trajectory", action_ns->second);
+
+    const auto& default_param = ci.parameters_.find("default");
+    ASSERT_NE(default_param, ci.parameters_.end()) << "default parameter missing for " << ci.name_;
+    EXPECT_EQ("true", default_param->second);
+  }
 }
 
 int main(int argc, char** argv)


### PR DESCRIPTION
### Description

Fixes #3796.

`Controllers::addDefaultControllers()` previously used the three-argument `addController()` overload, which only populated the controller name, type, and joints. As a result, additional fields defined by `MoveItControllers`, including the required `action_ns`, were omitted from controllers created by the Setup Assistant's Auto Add path.

This change populates additional controller fields using `getAdditionalControllerFields()` and each field's `getDefaultValue()` before adding the controller. This keeps Auto Add behavior consistent with manual controller creation. Controller types without additional fields, such as `ROS2Controllers`, retain their existing behavior.

A regression test verifies that auto-added MoveIt controllers contain:

- `action_ns: follow_joint_trajectory`
- `default: true`

### Testing

Validated against ROS 2 Jazzy with an isolated `moveit_setup_controllers` build:

- `colcon build --packages-select moveit_setup_controllers` — passed
- `colcon test --packages-select moveit_setup_controllers` — passed
- 6/6 controller tests passed
- `ControllersTest.AddDefaultControllersMoveItAdditionalFields` — passed
- `ControllersTest.AddDefaultControllers` — passed
- `pre-commit` — passed
- `clang-format-14 --dry-run --Werror` — passed

### Checklist

- [x] **Required by CI**: Code is auto formatted using clang-format
- [ ] Extend the tutorials / documentation
- [ ] Document API changes relevant to the user in MIGRATION.md
- [x] Create tests, which fail without this PR
- [ ] Include a screenshot if changing a GUI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Default controllers now include all required configuration parameters, including action namespace and default values.
  * Controller setup consistently applies the configured controller type and parameters for each planning group.

* **Tests**
  * Added regression coverage to verify default controllers are created correctly for every planning group.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->