### PR TITLE
Fix Servo Jacobian fallback without IK solver

### DIFF
--- a/moveit_ros/moveit_servo/include/moveit_servo/utils/common.hpp
+++ b/moveit_ros/moveit_servo/include/moveit_servo/utils/common.hpp
@@ -58,19 +58,28 @@ namespace moveit_servo
 constexpr int MIN_POINTS_FOR_TRAJ_MSG = 3;
 
 /**
- * \brief Get the base frame of the current active joint group or subgroup's IK solver.
+ * \brief Get the base frame to plan in for the current active joint group or subgroup.
+ * If an IK solver is configured, this is the IK solver's base frame. Otherwise, jointDeltaFromIK() falls back to
+ * a direct Jacobian, which only supports groups that form a kinematic chain; in that case this returns the chain's
+ * root link (the parent link of the group's first joint), matching the base link used internally by
+ * RobotState::getJacobian(). For non-chain (e.g. branched) groups without an IK solver there is no unambiguous
+ * base frame, so std::nullopt is returned.
  * @param robot_state A pointer to the current robot state.
  * @param group_name The currently active joint group name.
- * @return The IK solver base frame, if one exists, otherwise std::nullopt.
+ * @return The base frame, if one can be unambiguously determined, otherwise std::nullopt.
  */
 std::optional<std::string> getIKSolverBaseFrame(const moveit::core::RobotStatePtr& robot_state,
                                                 const std::string& group_name);
 
 /**
- * \brief Get the tip (end-effector) frame of the current active joint group or subgroup's IK solver.
+ * \brief Get the tip (end-effector) frame to plan in for the current active joint group or subgroup.
+ * If an IK solver is configured, this is the IK solver's tip frame. Otherwise, jointDeltaFromIK() falls back to
+ * a direct Jacobian, which only supports groups that form a kinematic chain; in that case this returns the
+ * chain's last link, matching the tip link used internally by RobotState::getJacobian(). For non-chain (e.g.
+ * branched) groups without an IK solver there is no unambiguous tip frame, so std::nullopt is returned.
  * @param robot_state A pointer to the current robot state.
  * @param group_name The currently active joint group name.
- * @return The IK solver tip frame, if one exists, otherwise std::nullopt.
+ * @return The tip frame, if one can be unambiguously determined, otherwise std::nullopt.
  */
 std::optional<std::string> getIKSolverTipFrame(const moveit::core::RobotStatePtr& robot_state,
                                                const std::string& group_name);

--- a/moveit_ros/moveit_servo/src/servo.cpp
+++ b/moveit_ros/moveit_servo/src/servo.cpp
@@ -398,8 +398,9 @@ Eigen::VectorXd Servo::jointDeltaFromCommand(const ServoInput& command, const mo
     }
     else if (expected_type == CommandType::TWIST)
     {
-      // Transform the twist command to the planning frame, which is the base frame of the active subgroup's IK solver,
-      // before applying it. Additionally verify there is an IK solver, and that the transformation is successful.
+      // Transform the twist command to the planning frame, which is the base frame of the active subgroup's IK
+      // solver, or (if no IK solver is configured) the base link of the subgroup's kinematic chain. Additionally
+      // verify a base frame could be determined, and that the transformation is successful.
       const auto planning_frame_maybe = getIKSolverBaseFrame(robot_state, active_subgroup_name);
       if (planning_frame_maybe.has_value())
       {
@@ -420,14 +421,16 @@ Eigen::VectorXd Servo::jointDeltaFromCommand(const ServoInput& command, const mo
       else
       {
         servo_status_ = StatusCode::INVALID;
-        RCLCPP_ERROR(logger_, "No IK solver for planning group %s.", active_subgroup_name.c_str());
+        RCLCPP_ERROR(logger_, "No IK solver and no unambiguous kinematic chain base frame for planning group %s.",
+                     active_subgroup_name.c_str());
       }
     }
     else if (expected_type == CommandType::POSE)
     {
-      // Transform the pose command to the planning frame, which is the base frame of the active subgroup's IK solver,
-      // before applying it. The end effector frame is also extracted as the tip frame of the IK solver.
-      // Additionally verify there is an IK solver, and that the transformation is successful.
+      // Transform the pose command to the planning frame, which is the base frame of the active subgroup's IK
+      // solver, or (if no IK solver is configured) the base link of the subgroup's kinematic chain. The end
+      // effector frame is extracted the same way. Additionally verify these frames could be determined, and
+      // that the transformation is successful.
       const auto planning_frame_maybe = getIKSolverBaseFrame(robot_state, active_subgroup_name);
       const auto ee_frame_maybe = getIKSolverTipFrame(robot_state, active_subgroup_name);
       if (planning_frame_maybe.has_value() && ee_frame_maybe.has_value())
@@ -449,7 +452,8 @@ Eigen::VectorXd Servo::jointDeltaFromCommand(const ServoInput& command, const mo
       else
       {
         servo_status_ = StatusCode::INVALID;
-        RCLCPP_ERROR(logger_, "No IK solver for planning group %s.", active_subgroup_name.c_str());
+        RCLCPP_ERROR(logger_, "No IK solver and no unambiguous kinematic chain base/tip frame for planning group %s.",
+                     active_subgroup_name.c_str());
       }
     }
 

--- a/moveit_ros/moveit_servo/src/utils/common.cpp
+++ b/moveit_ros/moveit_servo/src/utils/common.cpp
@@ -57,31 +57,46 @@ namespace moveit_servo
 std::optional<std::string> getIKSolverBaseFrame(const moveit::core::RobotStatePtr& robot_state,
                                                 const std::string& group_name)
 {
-  const auto ik_solver = robot_state->getJointModelGroup(group_name)->getSolverInstance();
+  const moveit::core::JointModelGroup* joint_model_group = robot_state->getJointModelGroup(group_name);
+  const auto ik_solver = joint_model_group->getSolverInstance();
 
   if (ik_solver)
   {
     return ik_solver->getBaseFrame();
   }
-  else
+
+  // No IK solver is configured for this group. jointDeltaFromIK() falls back to a direct Jacobian in that case,
+  // and RobotState::getJacobian() only supports groups that form a kinematic chain. For a chain, the base frame
+  // is unambiguous: the parent link of the group's first joint (matching the root link used internally by
+  // getJacobian()). Non-chain (e.g. branched) groups have no single base frame, so fail rather than guess.
+  if (!joint_model_group->isChain() || joint_model_group->getJointModels().empty())
   {
     return std::nullopt;
   }
+
+  const moveit::core::LinkModel* base_link = joint_model_group->getJointModels().front()->getParentLinkModel();
+  return base_link ? base_link->getName() : robot_state->getRobotModel()->getModelFrame();
 }
 
 std::optional<std::string> getIKSolverTipFrame(const moveit::core::RobotStatePtr& robot_state,
                                                const std::string& group_name)
 {
-  const auto ik_solver = robot_state->getJointModelGroup(group_name)->getSolverInstance();
+  const moveit::core::JointModelGroup* joint_model_group = robot_state->getJointModelGroup(group_name);
+  const auto ik_solver = joint_model_group->getSolverInstance();
 
   if (ik_solver)
   {
     return ik_solver->getTipFrame();
   }
-  else
+
+  // See getIKSolverBaseFrame() for why the fallback only applies to chains. The tip is the chain's last link,
+  // matching the tip link used internally by RobotState::getJacobian().
+  if (!joint_model_group->isChain() || joint_model_group->getLinkModels().empty())
   {
     return std::nullopt;
   }
+
+  return joint_model_group->getLinkModels().back()->getName();
 }
 
 bool isValidCommand(const Eigen::VectorXd& command)

--- a/moveit_ros/moveit_servo/tests/test_utils.cpp
+++ b/moveit_ros/moveit_servo/tests/test_utils.cpp
@@ -49,6 +49,118 @@
 namespace
 {
 
+TEST(ServoUtilsUnitTests, ChainGroupWithoutIKSolverFallsBackToLinkFrames)
+{
+  using moveit::core::loadTestingRobotModel;
+  moveit::core::RobotModelPtr robot_model = loadTestingRobotModel("panda");
+  moveit::core::RobotStatePtr robot_state = std::make_shared<moveit::core::RobotState>(robot_model);
+  robot_state->setToDefaultValues();
+
+  // "panda_arm" is declared in the SRDF as a chain from panda_link0 to panda_link8 and, in this fixture, has no
+  // IK solver configured. getIKSolverBaseFrame()/getIKSolverTipFrame() should fall back to the chain's root and
+  // tip links, matching the base/tip that RobotState::getJacobian() uses internally.
+  const auto* joint_model_group = robot_state->getJointModelGroup("panda_arm");
+  ASSERT_TRUE(joint_model_group->getSolverInstance() == nullptr);
+  ASSERT_TRUE(joint_model_group->isChain());
+
+  const auto base_frame = moveit_servo::getIKSolverBaseFrame(robot_state, "panda_arm");
+  const auto tip_frame = moveit_servo::getIKSolverTipFrame(robot_state, "panda_arm");
+  ASSERT_TRUE(base_frame.has_value());
+  ASSERT_TRUE(tip_frame.has_value());
+  EXPECT_EQ(*base_frame, "panda_link0");
+  EXPECT_EQ(*tip_frame, "panda_link8");
+}
+
+TEST(ServoUtilsUnitTests, NonChainGroupWithoutIKSolverFailsSafely)
+{
+  using moveit::core::loadTestingRobotModel;
+  moveit::core::RobotModelPtr robot_model = loadTestingRobotModel("panda");
+  moveit::core::RobotStatePtr robot_state = std::make_shared<moveit::core::RobotState>(robot_model);
+  robot_state->setToDefaultValues();
+
+  // "panda_arm_hand" branches at the wrist (into the two finger joints), so it is not a kinematic chain and has
+  // no unambiguous base/tip frame. Without an IK solver, the frame lookups must fail safely instead of guessing.
+  const auto* joint_model_group = robot_state->getJointModelGroup("panda_arm_hand");
+  ASSERT_TRUE(joint_model_group->getSolverInstance() == nullptr);
+  ASSERT_FALSE(joint_model_group->isChain());
+
+  EXPECT_FALSE(moveit_servo::getIKSolverBaseFrame(robot_state, "panda_arm_hand").has_value());
+  EXPECT_FALSE(moveit_servo::getIKSolverTipFrame(robot_state, "panda_arm_hand").has_value());
+}
+
+TEST(ServoUtilsUnitTests, TwistCommandReachesJacobianFallbackWithoutIKSolver)
+{
+  using moveit::core::loadTestingRobotModel;
+  moveit::core::RobotModelPtr robot_model = loadTestingRobotModel("panda");
+  moveit::core::RobotStatePtr robot_state = std::make_shared<moveit::core::RobotState>(robot_model);
+
+  servo::Params servo_params;
+  servo_params.move_group_name = "panda_arm";
+  servo_params.publish_period = 0.01;
+  servo_params.command_in_type = "unitless";
+  servo_params.scale.linear = 1.0;
+  servo_params.scale.rotational = 1.0;
+
+  const auto joint_model_group = robot_state->getJointModelGroup(servo_params.move_group_name);
+  ASSERT_TRUE(joint_model_group->getSolverInstance() == nullptr);
+
+  Eigen::Vector<double, 7> state_ready{ 0.0, -0.785, 0.0, -2.356, 0.0, 1.571, 0.785 };
+  robot_state->setJointGroupActivePositions(joint_model_group, state_ready);
+
+  // Resolve the planning frame exactly as Servo::jointDeltaFromCommand() does, then drive jointDeltaFromTwist()
+  // with it. This exercises the same path a TWIST command takes, reaching the pre-existing no-solver Jacobian
+  // fallback in jointDeltaFromIK() end-to-end.
+  const auto planning_frame_maybe = moveit_servo::getIKSolverBaseFrame(robot_state, servo_params.move_group_name);
+  ASSERT_TRUE(planning_frame_maybe.has_value());
+
+  Eigen::Vector<double, 6> twist_velocities{ 0.01, 0.0, 0.0, 0.0, 0.0, 0.0 };
+  moveit_servo::TwistCommand twist{ *planning_frame_maybe, twist_velocities };
+
+  const auto delta_result =
+      moveit_servo::jointDeltaFromTwist(twist, robot_state, servo_params, *planning_frame_maybe, {});
+  EXPECT_NE(delta_result.first, moveit_servo::StatusCode::INVALID);
+  EXPECT_TRUE(delta_result.second.allFinite());
+  EXPECT_FALSE(delta_result.second.isZero());
+}
+
+TEST(ServoUtilsUnitTests, PoseCommandReachesJacobianFallbackWithoutIKSolver)
+{
+  using moveit::core::loadTestingRobotModel;
+  moveit::core::RobotModelPtr robot_model = loadTestingRobotModel("panda");
+  moveit::core::RobotStatePtr robot_state = std::make_shared<moveit::core::RobotState>(robot_model);
+
+  servo::Params servo_params;
+  servo_params.move_group_name = "panda_arm";
+  servo_params.publish_period = 0.01;
+  servo_params.scale.linear = 1.0;
+  servo_params.scale.rotational = 1.0;
+
+  const auto joint_model_group = robot_state->getJointModelGroup(servo_params.move_group_name);
+  ASSERT_TRUE(joint_model_group->getSolverInstance() == nullptr);
+
+  Eigen::Vector<double, 7> state_ready{ 0.0, -0.785, 0.0, -2.356, 0.0, 1.571, 0.785 };
+  robot_state->setJointGroupActivePositions(joint_model_group, state_ready);
+
+  // Resolve both frames exactly as Servo::jointDeltaFromCommand() does for a POSE command, then drive
+  // jointDeltaFromPose() with a target pose offset from the current one, reaching the same no-solver Jacobian
+  // fallback in jointDeltaFromIK() that the TWIST test above exercises.
+  const auto planning_frame_maybe = moveit_servo::getIKSolverBaseFrame(robot_state, servo_params.move_group_name);
+  const auto ee_frame_maybe = moveit_servo::getIKSolverTipFrame(robot_state, servo_params.move_group_name);
+  ASSERT_TRUE(planning_frame_maybe.has_value());
+  ASSERT_TRUE(ee_frame_maybe.has_value());
+
+  Eigen::Isometry3d target_pose = robot_state->getGlobalLinkTransform(*planning_frame_maybe).inverse() *
+                                  robot_state->getGlobalLinkTransform(*ee_frame_maybe);
+  target_pose.translation().x() += 0.01;
+  moveit_servo::PoseCommand pose{ *planning_frame_maybe, target_pose };
+
+  const auto delta_result =
+      moveit_servo::jointDeltaFromPose(pose, robot_state, servo_params, *planning_frame_maybe, *ee_frame_maybe, {});
+  EXPECT_NE(delta_result.first, moveit_servo::StatusCode::INVALID);
+  EXPECT_TRUE(delta_result.second.allFinite());
+  EXPECT_FALSE(delta_result.second.isZero());
+}
+
 TEST(ServoUtilsUnitTests, JointLimitVelocityScaling)
 {
   using moveit::core::loadTestingRobotModel;


### PR DESCRIPTION
### Description

Fixes #3789.

MoveIt Servo already has a direct-Jacobian fallback in `jointDeltaFromIK()` when no IK solver is configured. However, TWIST and POSE commands could not reach that path because `getIKSolverBaseFrame()` and `getIKSolverTipFrame()` returned `std::nullopt` whenever the planning group had no IK solver.

This change allows solver-less kinematic chain groups to use the same base and tip frames that `RobotState::getJacobian()` uses internally:

- base frame: parent link of the group's first joint
- tip frame: last link in the group

Groups with an IK solver retain the existing behavior and continue using the solver-provided frames.

For non-chain groups without an IK solver, the helpers continue to fail safely with `std::nullopt` rather than choosing an ambiguous frame.

Regression coverage verifies:

- solver-less chain groups resolve the expected base and tip frames;
- non-chain groups without an IK solver still fail safely;
- TWIST commands reach the existing Jacobian fallback;
- POSE commands reach the existing Jacobian fallback.

### Testing

Validated with an incremental `moveit_servo` build:

- `colcon build --packages-select moveit_servo` — passed
- targeted no-IK-solver regression tests — 4/4 passed
- complete `moveit_servo_utils_test` — 18/18 passed
- `pre-commit` on all changed files — passed
- `git diff --check` — passed

### Checklist

- [x] **Required by CI**: Code is auto formatted using clang-format
- [ ] Extend the tutorials / documentation
- [ ] Document API changes relevant to the user in MIGRATION.md
- [x] Create tests, which fail without this PR
- [ ] Include a screenshot if changing a GUI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Twist and pose commands can now operate for unambiguous kinematic-chain groups even when no IK solver is configured.
  * Servo automatically determines suitable base and tip frames from the robot’s chain structure.

* **Bug Fixes**
  * Improved handling and diagnostics when frame information cannot be determined.
  * Branched or empty groups now fail safely instead of producing invalid command results.

* **Tests**
  * Added coverage for frame fallback behavior and Jacobian-based command handling without an IK solver.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->