### PR TITLE
Fix trajectory execution manager shutdown segfault

### DIFF
--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -90,6 +90,15 @@ TrajectoryExecutionManager::~TrajectoryExecutionManager()
     private_executor_->cancel();
   if (private_executor_thread_.joinable())
     private_executor_thread_.join();
+
+  // Release the controller manager and its node in this order
+  // to prevent segfaults on shutdown.
+  callback_handler_.reset();
+  if (private_executor_ && controller_mgr_node_)
+    private_executor_->remove_node(controller_mgr_node_);
+  private_executor_.reset();
+  controller_manager_.reset();
+  controller_mgr_node_.reset();
 }
 
 void TrajectoryExecutionManager::initialize()


### PR DESCRIPTION
`TrajectoryExecutionManager` segfaults on destruction whenever a controller manager plugin is loaded.

The controller manager creates action clients on the node it is given in `initialize()` and the `rclcpp_action::Client` is a `Waitable`, so the node's default callback group holds a weak reference to each. Because`controller_manager_loader_` is declared after `controller_mgr_node_`, the plugin and its loader are destroyed before the node causing it to crash on shutdown.

This PR destroys the objects in the correct order so that it can shutdown cleanly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown and cleanup behavior for trajectory execution management.
  * Ensured controller-related resources are released in the correct order.
  * Reduced the risk of lingering resources or incomplete shutdowns when trajectory execution ends.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->