### PR TITLE
Document panda_simulated_config.yaml's loading contract (ParameterBuilder namespace + update_period)

### DIFF
--- a/moveit_ros/moveit_servo/config/panda_simulated_config.yaml
+++ b/moveit_ros/moveit_servo/config/panda_simulated_config.yaml
@@ -1,6 +1,20 @@
 ###############################################
 # Modify all parameters related to servoing here
 ###############################################
+# NOTE: this is not a standalone ROS 2 parameter file (there is no node name /
+# ros__parameters wrapper). The demo launch files load it through
+# launch_param_builder's ParameterBuilder("moveit_servo"), which nests every key
+# under the "moveit_servo" namespace that servo's parameter listener expects
+# (servo_node.cpp: ParamListener(node_, "moveit_servo")). Passing this file
+# directly via `parameters=[...]` / --params-file will not work.
+#
+# NOTE: `smoothing_filter_plugin_name` below selects
+# online_signal_smoothing::AccelerationLimitedPlugin, which additionally
+# requires an `update_period` parameter. That parameter cannot live in this
+# file: the plugin reads it from the node's root namespace
+# (acceleration_filter.cpp: ParamListener(node_), no prefix), while everything
+# in this file lands under `moveit_servo.`. Supply it as a separate node-level
+# parameter, as every demo launch file does:  {"update_period": 0.01}
 
 # Optionally override Servo's internal velocity scaling when near singularity or collision (0.0 = use internal velocity scaling)
 # override_velocity_scaling_factor = 0.0 # valid range [0.0:1.0]


### PR DESCRIPTION
### Description

Closes #3830.

`panda_simulated_config.yaml` reads like a ROS 2 parameter file but cannot be loaded as one, and the smoothing plugin it enables requires a parameter that lives only in the demo launch files. This PR documents both constraints in a header comment, so a user starting from this config finds the contract in the file itself instead of reverse-engineering it from the demos.

#3830 offered maintainers two options: (a) make the file self-contained, or (b) document the loading contract. This implements **(b)**, because while preparing (a) I found it is not actually achievable without breaking changes — which itself seems worth recording:

- **A `/**: ros__parameters:` wrapper would break every existing consumer.** The demo launch files (and downstream users following them) load this file through `ParameterBuilder("moveit_servo").yaml(...)`, which reads the whole document and nests it under the `moveit_servo` namespace expected by servo's listener ([`servo_node.cpp` L105-106](https://github.com/moveit/moveit2/blob/main/moveit_ros/moveit_servo/src/servo_node.cpp#L105-L106)). With a wrapper, those keys would land under `moveit_servo./**.ros__parameters.*` — garbage.
- **`update_period` cannot be moved into this file at all.** `AccelerationLimitedPlugin` constructs its listener without a prefix ([`acceleration_filter.cpp` L181](https://github.com/moveit/moveit2/blob/main/moveit_core/online_signal_smoothing/src/acceleration_filter.cpp#L181)) and therefore reads `update_period` from the node's **root** namespace, while every key in this yaml lands under `moveit_servo.`. That is why all four demo launch files (`demo_twist`, `demo_pose`, `demo_joint_jog`, `demo_ros_api`) each pass `{"update_period": 0.01}` as a separate node-level parameter.

Comment-only change: no behavior, API, or formatting impact. Happy to reword or trim if maintainers prefer a shorter note.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](https://moveit.ai/documentation/contributing/pullrequests/) (comment-only YAML change; no C++ touched)
- [ ] Extend the tutorials / documentation reference — N/A, the documentation IS the change
- [ ] Document API changes in MIGRATION.md — N/A, no API change
- [ ] Create tests, which fail without this PR — N/A, comment-only
- [ ] Include a screenshot if changing a GUI — N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how to load the simulated configuration.
  * Documented the separately required `update_period` setting for acceleration-limited operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->