### PR TITLE
Clear error when an SRDF group_state names a joint that is fixed in the URDF

### DIFF
--- a/moveit_core/robot_model/src/robot_model.cpp
+++ b/moveit_core/robot_model/src/robot_model.cpp
@@ -359,11 +359,20 @@ void RobotModel::buildGroupStates(const srdf::Model& srdf_model)
             for (std::size_t j = 0; j < vn.size(); ++j)
               state[vn[j]] = jt->second[j];
           }
+          else if (vn.empty())
+          {
+            RCLCPP_ERROR(getLogger(),
+                         "Group state '%s' for group '%s' supplies %d value(s) for joint '%s', "
+                         "but that joint is fixed in the robot model and has no variables. "
+                         "Remove it from the group state, or make the joint movable in the URDF.",
+                         group_state.name_.c_str(), jmg->getName().c_str(), static_cast<int>(jt->second.size()),
+                         jt->first.c_str());
+          }
           else
           {
             RCLCPP_ERROR(getLogger(),
                          "The model for joint '%s' requires %d variable values, "
-                         "but only %d variable values were supplied in default state '%s' for group '%s'",
+                         "but %d variable values were supplied in default state '%s' for group '%s'",
                          jt->first.c_str(), static_cast<int>(vn.size()), static_cast<int>(jt->second.size()),
                          group_state.name_.c_str(), jmg->getName().c_str());
           }


### PR DESCRIPTION
### Description

Closes #3831.

When an SRDF `group_state` supplies values for a joint that is **fixed** in the URDF, `RobotModel::buildGroupStates` emitted a self-contradictory error:

```
The model for joint 'panda_finger_joint1' requires 0 variable values,
but only 1 variable values were supplied in default state 'close' for group 'hand'
```

The zero-variable case is qualitatively different from a value miscount: the joint has no degrees of freedom in the loaded URDF, so it does not belong in the `group_state` at all — typically a URDF/SRDF sync issue (e.g. gripper fingers fixed for a simulation build while the SRDF still carries their `open`/`close` states). The old wording sent users to recount SRDF numbers instead of looking at the joint type. This PR special-cases `vn.empty()`:

```
Group state 'close' for group 'hand' supplies 1 value(s) for joint 'panda_finger_joint1',
but that joint is fixed in the robot model and has no variables.
Remove it from the group state, or make the joint movable in the URDF.
```

Two notes:
- The remaining miscount message also drops the word *"only"*, which was wrong whenever too **many** values were supplied.
- Behavior is unchanged: both paths log and continue, exactly as before (verified that this path only logs and does not throw).

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](https://moveit.ai/documentation/contributing/pullrequests/) — verified clean with clang-format 14.0.6 (the version pinned in `.pre-commit-config.yaml`)
- [ ] Extend the tutorials / documentation reference — N/A, log-message wording
- [ ] Document API changes in MIGRATION.md — N/A, no API change
- [ ] Create tests, which fail without this PR — N/A: message wording only; the (unchanged) log-and-continue behavior has no public-API observable
- [ ] Include a screenshot if changing a GUI — N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages when group states provide values for fixed joints.
  * Invalid value-count errors now accurately report the number of values supplied for configurable joints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->