### PR TITLE
Fix MoveItPy executor thread lifecycle (#3839)

### DIFF
--- a/moveit_py/src/moveit/moveit_ros/moveit_cpp/moveit_cpp.cpp
+++ b/moveit_py/src/moveit/moveit_ros/moveit_cpp/moveit_cpp.cpp
@@ -73,9 +73,14 @@ public:
   ExecutorThread(const ExecutorThread&) = delete;
   ExecutorThread& operator=(const ExecutorThread&) = delete;
 
+  bool isCurrentThread() const noexcept
+  {
+    return execution_thread_.joinable() && execution_thread_.get_id() == std::this_thread::get_id();
+  }
+
   void stop() noexcept
   {
-    if (!execution_thread_.joinable())
+    if (!execution_thread_.joinable() || isCurrentThread())
       return;
 
     stop_requested_->store(true);
@@ -175,6 +180,18 @@ void initMoveitPy(py::module& m)
              auto executor_thread = std::make_shared<ExecutorThread>(node);
 
              auto custom_deleter = [executor_thread](moveit_cpp::MoveItCpp* moveit_cpp) {
+               if (executor_thread->isCurrentThread())
+               {
+                 // A node callback may release the final MoveItCpp holder. Defer cleanup so the executor thread is
+                 // joined externally and MoveItCpp remains alive until the callback has returned.
+                 std::thread cleanup_thread([executor_thread, moveit_cpp]() {
+                   executor_thread->stop();
+                   delete moveit_cpp;
+                 });
+                 cleanup_thread.detach();
+                 return;
+               }
+
                executor_thread->stop();
                delete moveit_cpp;
              };

--- a/moveit_py/src/moveit/moveit_ros/moveit_cpp/moveit_cpp.cpp
+++ b/moveit_py/src/moveit/moveit_ros/moveit_cpp/moveit_cpp.cpp
@@ -35,9 +35,12 @@
 /* Author: Peter David Fagan */
 
 #include "moveit_cpp.hpp"
+#include <atomic>
+#include <chrono>
 #include <pybind11/pytypes.h>
 #include <moveit/utils/logger.hpp>
 #include <string>
+#include <thread>
 
 namespace moveit_py
 {
@@ -47,6 +50,51 @@ rclcpp::Logger getLogger()
 {
   return moveit::getLogger("moveit.py.cpp_initializer");
 }
+
+class ExecutorThread
+{
+public:
+  explicit ExecutorThread(const rclcpp::Node::SharedPtr& node)
+    : executor_(std::make_shared<rclcpp::executors::SingleThreadedExecutor>())
+    , stop_requested_(std::make_shared<std::atomic_bool>(false))
+    , execution_thread_([node, executor = executor_, stop_requested = stop_requested_]() {
+      executor->add_node(node);
+      while (!stop_requested->load())
+        executor->spin_once(std::chrono::milliseconds(100));
+    })
+  {
+  }
+
+  ~ExecutorThread()
+  {
+    stop();
+  }
+
+  ExecutorThread(const ExecutorThread&) = delete;
+  ExecutorThread& operator=(const ExecutorThread&) = delete;
+
+  void stop() noexcept
+  {
+    if (!execution_thread_.joinable())
+      return;
+
+    stop_requested_->store(true);
+    try
+    {
+      executor_->cancel();
+    }
+    catch (...)
+    {
+      // spin_once has a bounded wait, so the thread can still exit cleanly.
+    }
+    execution_thread_.join();
+  }
+
+private:
+  std::shared_ptr<rclcpp::executors::SingleThreadedExecutor> executor_;
+  std::shared_ptr<std::atomic_bool> stop_requested_;
+  std::thread execution_thread_;
+};
 
 std::shared_ptr<moveit_cpp::PlanningComponent>
 getPlanningComponent(std::shared_ptr<moveit_cpp::MoveItCpp>& moveit_cpp_ptr, const std::string& planning_component)
@@ -122,20 +170,12 @@ void initMoveitPy(py::module& m)
 
              RCLCPP_INFO(getLogger(), "Initialize node and executor");
              rclcpp::Node::SharedPtr node = rclcpp::Node::make_shared(node_name, name_space, node_options);
-             std::shared_ptr<rclcpp::executors::SingleThreadedExecutor> executor =
-                 std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
 
              RCLCPP_INFO(getLogger(), "Spin separate thread");
-             auto spin_node = [node, executor]() {
-               executor->add_node(node);
-               executor->spin();
-             };
-             std::thread execution_thread(spin_node);
-             execution_thread.detach();
+             auto executor_thread = std::make_shared<ExecutorThread>(node);
 
-             auto custom_deleter = [executor](moveit_cpp::MoveItCpp* moveit_cpp) {
-               executor->cancel();
-               rclcpp::shutdown();
+             auto custom_deleter = [executor_thread](moveit_cpp::MoveItCpp* moveit_cpp) {
+               executor_thread->stop();
                delete moveit_cpp;
              };
 


### PR DESCRIPTION
### Description

Fixes #3839.

`MoveItPy` currently detaches its executor thread before constructing `MoveItCpp`. That leaves the worker without a lifetime owner: construction failure can leave it running, while normal destruction cannot wait for active callbacks before deleting `MoveItCpp`. The instance deleter also shuts down the process-wide default ROS context.

This change gives the executor worker an RAII owner. Cleanup now:

* requests the worker to stop;
* cancels any bounded `spin_once()` wait;
* joins the worker before deleting `MoveItCpp`;
* performs the same stop-and-join cleanup if `MoveItCpp` construction throws; and
* leaves process-wide ROS shutdown to the existing explicit `shutdown()` method.

The bounded `spin_once()` loop also covers the race where destruction starts before the new thread reaches its first spin call.

### Validation

* Local patch application check against upstream commit `8fcb5d2327767af3c764b1348a69a9b74c5efd18` — passed
* Standalone RAII lifecycle probe compiled with `-Wall -Wextra -Werror -pedantic -fsanitize=address,undefined` — passed
* Probe verified constructor-exception cleanup leaves no worker thread behind
* Probe verified cleanup waits for an active callback before dependent destruction
* Full MoveIt/ROS build, repository test suite, and repository clang-format check — **not run in the current environment**

This is opened as a draft so CI and maintainer feedback can validate the integration and determine the preferred in-repository regression test.

### Checklist

* [ ] **Required by CI**: Code is auto formatted using [[clang-format](https://moveit.ai/documentation/contributing/pullrequests/)](https://moveit.ai/documentation/contributing/pullrequests/)
* [ ] Extend the tutorials/documentation — not applicable
* [ ] Document API changes in `MIGRATION.md` — maintainer decision requested
* [ ] Create tests that fail without this PR — isolated lifecycle proof completed; integrated test still required
* [ ] Include a screenshot if changing a GUI — not applicable
* [ ] Review another open pull request while waiting for review

### AI-assisted verification disclosure

This patch and its evidence package were prepared with AI assistance and reviewed and approved by Tim. The exact base revision, validation performed, and untested boundaries are disclosed above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MoveIt C++ integration shutdown and cleanup behavior.
  * Reduced the risk of lingering background processing after MoveIt components are released.
  * Improved responsiveness during executor shutdown through bounded wait intervals.
  * Prevented potential hangs during cleanup when shutdown is initiated from an active processing callback.

* **Stability**
  * Improved lifecycle management for background processing, supporting more predictable application behavior during startup, runtime, and shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->