### PR TITLE
Fix Servo pose joint limit halting

### DIFF
--- a/moveit_ros/moveit_servo/src/servo.cpp
+++ b/moveit_ros/moveit_servo/src/servo.cpp
@@ -349,7 +349,8 @@ KinematicState Servo::haltJoints(const std::vector<size_t>& joint_variables_to_h
 
   const bool all_joint_halt =
       (getCommandType() == CommandType::JOINT_JOG && servo_params_.halt_all_joints_in_joint_mode) ||
-      (getCommandType() == CommandType::TWIST && servo_params_.halt_all_joints_in_cartesian_mode);
+      ((getCommandType() == CommandType::TWIST || getCommandType() == CommandType::POSE) &&
+       servo_params_.halt_all_joints_in_cartesian_mode);
 
   if (all_joint_halt)
   {

--- a/moveit_ros/moveit_servo/tests/test_integration.cpp
+++ b/moveit_ros/moveit_servo/tests/test_integration.cpp
@@ -159,6 +159,39 @@ TEST_F(ServoCppFixture, PoseTest)
   ASSERT_NEAR(delta, expected_delta, tol);
 }
 
+TEST_F(ServoCppFixture, PoseHaltsAllJointsAtJointBound)
+{
+  planning_scene_monitor::LockedPlanningSceneRO locked_scene(planning_scene_monitor_);
+  auto robot_state = std::make_shared<moveit::core::RobotState>(locked_scene->getCurrentState());
+
+  const auto& joint_bounds = robot_state->getRobotModel()->getVariableBounds("panda_joint7");
+  const auto& margins = servo_params_.joint_limit_margins;
+  const double joint_margin = margins.size() == 1 ? margins.front() : margins.at(6);
+  robot_state->setVariablePosition("panda_joint7", joint_bounds.max_position_ - joint_margin - 1.0e-4);
+  robot_state->update();
+
+  moveit_servo::PoseCommand pose;
+  pose.frame_id = "panda_link0";
+  pose.pose = robot_state->getGlobalLinkTransform("panda_link8");
+  pose.pose.translation().x() += 0.01;
+  pose.pose.rotate(Eigen::AngleAxisd(M_PI / 2, Eigen::Vector3d::UnitZ()));
+
+  servo_test_instance_->setCommandType(moveit_servo::CommandType::POSE);
+  ASSERT_TRUE(servo_params_.halt_all_joints_in_cartesian_mode);
+
+  const moveit_servo::KinematicState current_state =
+      moveit_servo::extractRobotState(robot_state, servo_params_.move_group_name);
+  const moveit_servo::KinematicState next_state = servo_test_instance_->getNextJointState(robot_state, pose);
+
+  ASSERT_EQ(servo_test_instance_->getStatus(), moveit_servo::StatusCode::JOINT_BOUND);
+  ASSERT_EQ(next_state.positions.size(), current_state.positions.size());
+  for (Eigen::Index index = 0; index < current_state.positions.size(); ++index)
+  {
+    EXPECT_DOUBLE_EQ(next_state.positions[index], current_state.positions[index]);
+    EXPECT_DOUBLE_EQ(next_state.velocities[index], 0.0);
+  }
+}
+
 }  // namespace
 
 int main(int argc, char** argv)


### PR DESCRIPTION
### Description

`halt_all_joints_in_cartesian_mode` currently applies to twist commands, but not pose commands. When a pose command drives one joint into its position limit, Servo stops that joint while the remaining joints continue moving. The end effector can then move well away from the commanded Cartesian pose.

Treat pose commands as Cartesian commands in `haltJoints()`. With the default setting enabled, the whole group now stops when a joint reaches its bound and can resume when the command moves away from the bound.

I reproduced this on a Star Arm 102-FL with repeated upward pose commands. Once one joint reached its bound, the other joints kept moving and the tool orientation error grew to about 64 degrees. With this change, the group holds its pose at the bound and recovers on a command in the opposite direction.

The added integration test places Panda joint 7 just inside its limit, sends a pose command that also moves the other joints, and verifies that all positions and velocities are held. The test fails without the `POSE` case and passes with it.

### Checklist

- [x] **Required by CI**: Code is auto formatted using [clang-format](https://moveit.ai/documentation/contributing/pullrequests/)
- [ ] Extend the tutorials / documentation — no user-facing workflow change
- [ ] Document API changes in `MIGRATION.md` — no API change
- [x] Create tests, which fail without this PR
- [ ] Include a screenshot if changing a GUI — no GUI change
- [ ] Review another open pull request


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cartesian pose commands now correctly halt all joints when a joint reaches its configured limit margin.
  * Halted joints remain stationary with zero velocity and report the appropriate joint-bound state.

* **Tests**
  * Added integration coverage for stopping all joints during Cartesian pose control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
