### PR TITLE
Own MotionPlanningFrame execution workers

### DIFF
--- a/moveit_ros/visualization/motion_planning_rviz_plugin/CMakeLists.txt
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(HEADERS
+    include/moveit/motion_planning_rviz_plugin/execution_job.hpp
     include/moveit/motion_planning_rviz_plugin/motion_planning_display.hpp
     include/moveit/motion_planning_rviz_plugin/motion_planning_frame.hpp
     include/moveit/motion_planning_rviz_plugin/motion_planning_frame_joints_widget.hpp
@@ -55,5 +56,12 @@ target_link_libraries(
   rviz_ogre_vendor::OgreOverlay)
 target_include_directories(moveit_motion_planning_rviz_plugin
                            PRIVATE "${OGRE_PREFIX_DIR}/include")
+
+if(BUILD_TESTING)
+  find_package(ament_cmake_gtest REQUIRED)
+  ament_add_gtest(test_execution_job test/execution_job_test.cpp)
+  target_include_directories(test_execution_job
+                             PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+endif()
 
 install(DIRECTORY include/ DESTINATION include/moveit_ros_visualization)

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/execution_job.hpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/execution_job.hpp
@@ -1,0 +1,141 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2026, MoveIt Contributors
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <functional>
+#include <mutex>
+#include <thread>
+#include <utility>
+
+namespace moveit_rviz_plugin
+{
+/** Owns one cancelable worker and always joins it before destruction. */
+class ExecutionJob
+{
+public:
+  using Generation = std::uint64_t;
+  using Job = std::function<void(Generation)>;
+  using CancelJob = std::function<void()>;
+
+  ExecutionJob() = default;
+  ExecutionJob(const ExecutionJob&) = delete;
+  ExecutionJob& operator=(const ExecutionJob&) = delete;
+
+  ~ExecutionJob()
+  {
+    cancelAndWait();
+  }
+
+  /** Start a job unless another job is still active. */
+  bool start(Job job, CancelJob cancel_job)
+  {
+    std::scoped_lock lock(mutex_);
+    if (active_)
+      return false;
+
+    if (thread_.joinable())
+      thread_.join();
+    const Generation generation = generation_.fetch_add(1) + 1;
+    active_ = true;
+    cancel_job_ = std::move(cancel_job);
+    try
+    {
+      thread_ = std::thread([this, job = std::move(job), generation]() mutable {
+        job(generation);
+        active_ = false;
+      });
+    }
+    catch (...)
+    {
+      generation_.fetch_add(1);
+      active_ = false;
+      cancel_job_ = {};
+      throw;
+    }
+    return true;
+  }
+
+  void cancel()
+  {
+    CancelJob cancel_job;
+    {
+      std::scoped_lock lock(mutex_);
+      if (active_)
+        cancel_job = cancel_job_;
+    }
+    if (cancel_job)
+      cancel_job();
+  }
+
+  void wait()
+  {
+    std::scoped_lock lock(mutex_);
+    if (thread_.joinable())
+      thread_.join();
+    active_ = false;
+    cancel_job_ = {};
+  }
+
+  void cancelAndWait()
+  {
+    std::scoped_lock lock(mutex_);
+    generation_.fetch_add(1);
+    if (active_ && cancel_job_)
+      cancel_job_();
+    if (thread_.joinable())
+      thread_.join();
+    active_ = false;
+    cancel_job_ = {};
+  }
+
+  bool active() const
+  {
+    return active_;
+  }
+
+  bool isCurrent(Generation generation) const
+  {
+    return generation_.load() == generation;
+  }
+
+private:
+  std::mutex mutex_;
+  std::thread thread_;
+  std::atomic_bool active_{ false };
+  std::atomic<Generation> generation_{ 0 };
+  CancelJob cancel_job_;
+};
+}  // namespace moveit_rviz_plugin

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/execution_job.hpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/execution_job.hpp
@@ -35,6 +35,7 @@
 
 #include <atomic>
 #include <cstdint>
+#include <exception>
 #include <functional>
 #include <mutex>
 #include <thread>
@@ -49,6 +50,7 @@ public:
   using Generation = std::uint64_t;
   using Job = std::function<void(Generation)>;
   using CancelJob = std::function<void()>;
+  using ExceptionHandler = std::function<void(Generation, std::exception_ptr)>;
 
   ExecutionJob() = default;
   ExecutionJob(const ExecutionJob&) = delete;
@@ -60,7 +62,7 @@ public:
   }
 
   /** Start a job unless another job is still active. */
-  bool start(Job job, CancelJob cancel_job)
+  bool start(Job job, CancelJob cancel_job, ExceptionHandler exception_handler)
   {
     std::scoped_lock lock(mutex_);
     if (active_)
@@ -73,10 +75,30 @@ public:
     cancel_job_ = std::move(cancel_job);
     try
     {
-      thread_ = std::thread([this, job = std::move(job), generation]() mutable {
-        job(generation);
-        active_ = false;
-      });
+      thread_ = std::thread(
+          [this, job = std::move(job), exception_handler = std::move(exception_handler), generation]() mutable {
+            std::exception_ptr exception;
+            try
+            {
+              job(generation);
+            }
+            catch (...)
+            {
+              exception = std::current_exception();
+            }
+            active_ = false;
+            if (exception && exception_handler)
+            {
+              try
+              {
+                exception_handler(generation, exception);
+              }
+              catch (...)
+              {
+                // Exception reporting must not escape the worker boundary either.
+              }
+            }
+          });
     }
     catch (...)
     {

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.hpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.hpp
@@ -265,6 +265,7 @@ private:
                                           ExecutionJob::Generation execution_generation);
   void queueFinishedExecution(bool success, ExecutionJob::Generation execution_generation,
                               const moveit::planning_interface::MoveGroupInterface::PlanPtr& plan = {});
+  void queueFailedExecution(ExecutionJob::Generation execution_generation, std::exception_ptr exception);
   void onFinishedExecution(bool success);
   void populateConstraintsList();
   void populateConstraintsList(const std::vector<std::string>& constr);

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.hpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame.hpp
@@ -42,6 +42,8 @@
 #include <QTreeWidgetItem>
 #include <QListWidgetItem>
 
+#include <moveit/motion_planning_rviz_plugin/execution_job.hpp>
+
 #ifndef Q_MOC_RUN
 #include <moveit/macros/class_forward.hpp>
 #include <moveit/move_group_interface/move_group_interface.hpp>
@@ -142,6 +144,7 @@ protected:
   MotionPlanningFrameJointsWidget* joints_tab_;
 
   moveit::planning_interface::MoveGroupInterfacePtr move_group_;
+  ExecutionJob execution_job_;
   // TODO (ddengster): Enable when moveit_ros_perception is ported
   //  moveit::semantic_world::SemanticWorldPtr semantic_world_;
 
@@ -248,10 +251,20 @@ private:
 
   // Planning tab
   void computePlanButtonClicked();
-  void computeExecuteButtonClicked();
-  void computePlanAndExecuteButtonClicked();
-  void computePlanAndExecuteButtonClickedDisplayHelper();
-  void computeStopButtonClicked();
+  moveit::planning_interface::MoveGroupInterface::PlanPtr
+  computeCartesianPlan(const moveit::planning_interface::MoveGroupInterfacePtr& move_group,
+                       const moveit::core::RobotState& goal, double velocity_scaling_factor,
+                       double acceleration_scaling_factor);
+  void computeExecuteButtonClicked(const moveit::planning_interface::MoveGroupInterfacePtr& move_group,
+                                   const moveit::planning_interface::MoveGroupInterface::PlanPtr& plan,
+                                   ExecutionJob::Generation execution_generation);
+  void computePlanAndExecuteButtonClicked(const moveit::planning_interface::MoveGroupInterfacePtr& move_group,
+                                          bool use_cartesian_path,
+                                          const moveit::core::RobotStateConstPtr& cartesian_goal,
+                                          double velocity_scaling_factor, double acceleration_scaling_factor,
+                                          ExecutionJob::Generation execution_generation);
+  void queueFinishedExecution(bool success, ExecutionJob::Generation execution_generation,
+                              const moveit::planning_interface::MoveGroupInterface::PlanPtr& plan = {});
   void onFinishedExecution(bool success);
   void populateConstraintsList();
   void populateConstraintsList(const std::vector<std::string>& constr);

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -287,6 +287,7 @@ MotionPlanningFrame::MotionPlanningFrame(MotionPlanningDisplay* pdisplay, rviz_c
 
 MotionPlanningFrame::~MotionPlanningFrame()
 {
+  execution_job_.cancelAndWait();
   delete ui_;
 }
 
@@ -484,6 +485,7 @@ void MotionPlanningFrame::changePlanningGroupHelper()
 
 void MotionPlanningFrame::clearRobotModel()
 {
+  execution_job_.cancelAndWait();
   ui_->planner_param_treeview->setMoveGroup(moveit::planning_interface::MoveGroupInterfacePtr());
   joints_tab_->clearRobotModel();
   move_group_.reset();

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
@@ -59,24 +59,57 @@ void MotionPlanningFrame::planButtonClicked()
 
 void MotionPlanningFrame::executeButtonClicked()
 {
+  if (!move_group_ || !current_plan_ || execution_job_.active())
+    return;
+
   ui_->execute_button->setEnabled(false);
-  // execution is done in a separate thread, to not block other background jobs by blocking for synchronous execution
-  planning_display_->spawnBackgroundJob([this] { computeExecuteButtonClicked(); });
+  ui_->stop_button->setEnabled(true);
+  auto move_group = move_group_;
+  auto plan = current_plan_;
+  execution_job_.start(
+      [this, move_group, plan](ExecutionJob::Generation execution_generation) {
+        computeExecuteButtonClicked(move_group, plan, execution_generation);
+      },
+      [move_group] { move_group->stop(); });
 }
 
 void MotionPlanningFrame::planAndExecuteButtonClicked()
 {
+  if (!move_group_ || execution_job_.active())
+    return;
+
   publishSceneIfNeeded();
   ui_->plan_and_execute_button->setEnabled(false);
   ui_->execute_button->setEnabled(false);
-  // execution is done in a separate thread, to not block other background jobs by blocking for synchronous execution
-  planning_display_->spawnBackgroundJob([this] { computePlanAndExecuteButtonClicked(); });
+  ui_->stop_button->setEnabled(true);
+
+  configureForPlanning();
+  planning_display_->rememberPreviousStartState();
+  move_group_->setStartStateToCurrentState();
+
+  auto move_group = move_group_;
+  bool use_cartesian_path = ui_->use_cartesian_path->isEnabled() && ui_->use_cartesian_path->checkState();
+  moveit::core::RobotStateConstPtr cartesian_goal;
+  if (use_cartesian_path)
+    cartesian_goal = std::make_shared<moveit::core::RobotState>(*planning_display_->getQueryGoalState());
+  double velocity_scaling_factor = ui_->velocity_scaling_factor->value();
+  double acceleration_scaling_factor = ui_->acceleration_scaling_factor->value();
+
+  execution_job_.start(
+      [this, move_group, use_cartesian_path, cartesian_goal, velocity_scaling_factor,
+       acceleration_scaling_factor](ExecutionJob::Generation execution_generation) {
+        computePlanAndExecuteButtonClicked(move_group, use_cartesian_path, cartesian_goal, velocity_scaling_factor,
+                                           acceleration_scaling_factor, execution_generation);
+      },
+      [move_group] { move_group->stop(); });
 }
 
 void MotionPlanningFrame::stopButtonClicked()
 {
   ui_->stop_button->setEnabled(false);  // avoid clicking again
-  planning_display_->addBackgroundJob([this] { computeStopButtonClicked(); }, "stop");
+  auto move_group = move_group_;
+  if (move_group)
+    planning_display_->addBackgroundJob([move_group] { move_group->stop(); }, "stop");
 }
 
 void MotionPlanningFrame::allowReplanningToggled(bool checked)
@@ -120,16 +153,25 @@ void MotionPlanningFrame::onClearOctomapClicked()
 
 bool MotionPlanningFrame::computeCartesianPlan()
 {
+  current_plan_ =
+      computeCartesianPlan(move_group_, *planning_display_->getQueryGoalState(), ui_->velocity_scaling_factor->value(),
+                           ui_->acceleration_scaling_factor->value());
+  return static_cast<bool>(current_plan_);
+}
+
+moveit::planning_interface::MoveGroupInterface::PlanPtr
+MotionPlanningFrame::computeCartesianPlan(const moveit::planning_interface::MoveGroupInterfacePtr& move_group,
+                                          const moveit::core::RobotState& goal, double velocity_scaling_factor,
+                                          double acceleration_scaling_factor)
+{
   rclcpp::Time start = rclcpp::Clock().now();
-  // get goal pose
-  moveit::core::RobotState goal = *planning_display_->getQueryGoalState();
   std::vector<geometry_msgs::msg::Pose> waypoints;
-  const std::string& link_name = move_group_->getEndEffectorLink();
-  const moveit::core::LinkModel* link = move_group_->getRobotModel()->getLinkModel(link_name);
+  const std::string& link_name = move_group->getEndEffectorLink();
+  const moveit::core::LinkModel* link = move_group->getRobotModel()->getLinkModel(link_name);
   if (!link)
   {
     RCLCPP_ERROR_STREAM(logger_, "Failed to determine unique end-effector link: " << link_name);
-    return false;
+    return {};
   }
   waypoints.push_back(tf2::toMsg(goal.getGlobalLinkTransform(link)));
 
@@ -139,7 +181,7 @@ bool MotionPlanningFrame::computeCartesianPlan()
 
   // compute trajectory
   moveit_msgs::msg::RobotTrajectory trajectory;
-  double fraction = move_group_->computeCartesianPath(waypoints, cart_step_size, trajectory, avoid_collisions);
+  double fraction = move_group->computeCartesianPath(waypoints, cart_step_size, trajectory, avoid_collisions);
 
   if (fraction >= 1.0)
   {
@@ -147,20 +189,21 @@ bool MotionPlanningFrame::computeCartesianPlan()
 
     // Compute time parameterization to also provide velocities
     // https://groups.google.com/forum/#!topic/moveit-users/MOoFxy2exT4
-    robot_trajectory::RobotTrajectory rt(move_group_->getRobotModel(), move_group_->getName());
-    rt.setRobotTrajectoryMsg(*move_group_->getCurrentState(), trajectory);
+    robot_trajectory::RobotTrajectory rt(move_group->getRobotModel(), move_group->getName());
+    rt.setRobotTrajectoryMsg(*move_group->getCurrentState(), trajectory);
     trajectory_processing::TimeOptimalTrajectoryGeneration time_parameterization;
-    bool success = time_parameterization.computeTimeStamps(rt, ui_->velocity_scaling_factor->value(),
-                                                           ui_->acceleration_scaling_factor->value());
+    bool success = time_parameterization.computeTimeStamps(rt, velocity_scaling_factor, acceleration_scaling_factor);
     RCLCPP_INFO(logger_, "Computing time stamps %s", success ? "SUCCEEDED" : "FAILED");
 
-    // Store trajectory in current_plan_
-    current_plan_ = std::make_shared<moveit::planning_interface::MoveGroupInterface::Plan>();
-    rt.getRobotTrajectoryMsg(current_plan_->trajectory);
-    current_plan_->planning_time = (rclcpp::Clock().now() - start).seconds();
-    return success;
+    if (success)
+    {
+      auto plan = std::make_shared<moveit::planning_interface::MoveGroupInterface::Plan>();
+      rt.getRobotTrajectoryMsg(plan->trajectory);
+      plan->planning_time = (rclcpp::Clock().now() - start).seconds();
+      return plan;
+    }
   }
-  return false;
+  return {};
 }
 
 bool MotionPlanningFrame::computeJointSpacePlan()
@@ -196,51 +239,52 @@ void MotionPlanningFrame::computePlanButtonClicked()
   Q_EMIT planningFinished();
 }
 
-void MotionPlanningFrame::computeExecuteButtonClicked()
+void MotionPlanningFrame::computeExecuteButtonClicked(
+    const moveit::planning_interface::MoveGroupInterfacePtr& move_group,
+    const moveit::planning_interface::MoveGroupInterface::PlanPtr& plan, ExecutionJob::Generation execution_generation)
 {
-  // ensures the MoveGroupInterface is not destroyed while executing
-  moveit::planning_interface::MoveGroupInterfacePtr mgi(move_group_);
-  if (mgi && current_plan_)
-  {
-    ui_->stop_button->setEnabled(true);  // enable stopping
-    bool success = mgi->execute(*current_plan_) == moveit::core::MoveItErrorCode::SUCCESS;
-    onFinishedExecution(success);
-  }
+  bool success = move_group->execute(*plan) == moveit::core::MoveItErrorCode::SUCCESS;
+  queueFinishedExecution(success, execution_generation);
 }
 
-void MotionPlanningFrame::computePlanAndExecuteButtonClicked()
+void MotionPlanningFrame::computePlanAndExecuteButtonClicked(
+    const moveit::planning_interface::MoveGroupInterfacePtr& move_group, bool use_cartesian_path,
+    const moveit::core::RobotStateConstPtr& cartesian_goal, double velocity_scaling_factor,
+    double acceleration_scaling_factor, ExecutionJob::Generation execution_generation)
 {
-  // ensures the MoveGroupInterface is not destroyed while executing
-  moveit::planning_interface::MoveGroupInterfacePtr mgi(move_group_);
-  if (!mgi)
-    return;
-  configureForPlanning();
-  planning_display_->rememberPreviousStartState();
-  // move_group::move() on the server side, will always start from the current state
-  // to suppress a warning, we pass an empty state (which encodes "start from current state")
-  mgi->setStartStateToCurrentState();
-  ui_->stop_button->setEnabled(true);
-  if (ui_->use_cartesian_path->isEnabled() && ui_->use_cartesian_path->checkState())
+  bool success = false;
+  moveit::planning_interface::MoveGroupInterface::PlanPtr plan;
+  if (use_cartesian_path)
   {
-    if (computeCartesianPlan())
-      computeExecuteButtonClicked();
+    plan = computeCartesianPlan(move_group, *cartesian_goal, velocity_scaling_factor, acceleration_scaling_factor);
+    if (plan)
+      success = move_group->execute(*plan) == moveit::core::MoveItErrorCode::SUCCESS;
   }
   else
   {
-    bool success = mgi->move() == moveit::core::MoveItErrorCode::SUCCESS;
-    onFinishedExecution(success);
+    success = move_group->move() == moveit::core::MoveItErrorCode::SUCCESS;
   }
-  ui_->plan_and_execute_button->setEnabled(true);
+  queueFinishedExecution(success, execution_generation, plan);
 }
 
-void MotionPlanningFrame::computeStopButtonClicked()
+void MotionPlanningFrame::queueFinishedExecution(bool success, ExecutionJob::Generation execution_generation,
+                                                 const moveit::planning_interface::MoveGroupInterface::PlanPtr& plan)
 {
-  if (move_group_)
-    move_group_->stop();
+  QMetaObject::invokeMethod(
+      this,
+      [this, success, execution_generation, plan] {
+        if (!execution_job_.isCurrent(execution_generation))
+          return;
+        if (plan)
+          current_plan_ = plan;
+        onFinishedExecution(success);
+      },
+      Qt::QueuedConnection);
 }
 
 void MotionPlanningFrame::onFinishedExecution(bool success)
 {
+  ui_->plan_and_execute_button->setEnabled(true);
   // visualize result of execution
   if (success)
   {
@@ -562,17 +606,20 @@ void MotionPlanningFrame::configureForPlanning()
 
 void MotionPlanningFrame::remotePlanCallback(const std_msgs::msg::Empty::ConstSharedPtr& /*msg*/)
 {
-  planButtonClicked();
+  QMetaObject::invokeMethod(
+      this, [this] { planButtonClicked(); }, Qt::QueuedConnection);
 }
 
 void MotionPlanningFrame::remoteExecuteCallback(const std_msgs::msg::Empty::ConstSharedPtr& /*msg*/)
 {
-  executeButtonClicked();
+  QMetaObject::invokeMethod(
+      this, [this] { executeButtonClicked(); }, Qt::QueuedConnection);
 }
 
 void MotionPlanningFrame::remoteStopCallback(const std_msgs::msg::Empty::ConstSharedPtr& /*msg*/)
 {
-  stopButtonClicked();
+  QMetaObject::invokeMethod(
+      this, [this] { stopButtonClicked(); }, Qt::QueuedConnection);
 }
 
 void MotionPlanningFrame::remoteUpdateStartStateCallback(const std_msgs::msg::Empty::ConstSharedPtr& /*msg*/)

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
@@ -70,7 +70,10 @@ void MotionPlanningFrame::executeButtonClicked()
       [this, move_group, plan](ExecutionJob::Generation execution_generation) {
         computeExecuteButtonClicked(move_group, plan, execution_generation);
       },
-      [move_group] { move_group->stop(); });
+      [move_group] { move_group->stop(); },
+      [this](ExecutionJob::Generation execution_generation, std::exception_ptr exception) {
+        queueFailedExecution(execution_generation, exception);
+      });
 }
 
 void MotionPlanningFrame::planAndExecuteButtonClicked()
@@ -101,7 +104,10 @@ void MotionPlanningFrame::planAndExecuteButtonClicked()
         computePlanAndExecuteButtonClicked(move_group, use_cartesian_path, cartesian_goal, velocity_scaling_factor,
                                            acceleration_scaling_factor, execution_generation);
       },
-      [move_group] { move_group->stop(); });
+      [move_group] { move_group->stop(); },
+      [this](ExecutionJob::Generation execution_generation, std::exception_ptr exception) {
+        queueFailedExecution(execution_generation, exception);
+      });
 }
 
 void MotionPlanningFrame::stopButtonClicked()
@@ -280,6 +286,24 @@ void MotionPlanningFrame::queueFinishedExecution(bool success, ExecutionJob::Gen
         onFinishedExecution(success);
       },
       Qt::QueuedConnection);
+}
+
+void MotionPlanningFrame::queueFailedExecution(ExecutionJob::Generation execution_generation,
+                                               std::exception_ptr exception)
+{
+  try
+  {
+    std::rethrow_exception(exception);
+  }
+  catch (const std::exception& error)
+  {
+    RCLCPP_ERROR(logger_, "Execution job failed: %s", error.what());
+  }
+  catch (...)
+  {
+    RCLCPP_ERROR(logger_, "Execution job failed with an unknown exception");
+  }
+  queueFinishedExecution(false, execution_generation);
 }
 
 void MotionPlanningFrame::onFinishedExecution(bool success)

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/test/execution_job_test.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/test/execution_job_test.cpp
@@ -1,0 +1,125 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2026, MoveIt Contributors
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#include <moveit/motion_planning_rviz_plugin/execution_job.hpp>
+
+#include <gtest/gtest.h>
+
+#include <condition_variable>
+#include <mutex>
+
+namespace moveit_rviz_plugin
+{
+TEST(ExecutionJob, RejectsConcurrentJob)
+{
+  std::mutex mutex;
+  std::condition_variable condition;
+  bool release = false;
+  bool second_job_ran = false;
+
+  ExecutionJob execution;
+  ASSERT_TRUE(execution.start(
+      [&](ExecutionJob::Generation) {
+        std::unique_lock<std::mutex> lock(mutex);
+        condition.wait(lock, [&] { return release; });
+      },
+      [&] {
+        {
+          std::scoped_lock lock(mutex);
+          release = true;
+        }
+        condition.notify_one();
+      }));
+
+  EXPECT_FALSE(execution.start([&](ExecutionJob::Generation) { second_job_ran = true; }, [] {}));
+  execution.cancelAndWait();
+  EXPECT_FALSE(second_job_ran);
+  EXPECT_FALSE(execution.active());
+}
+
+TEST(ExecutionJob, DestructionCancelsBeforeJoining)
+{
+  std::mutex mutex;
+  std::condition_variable condition;
+  bool canceled = false;
+  bool worker_completed = false;
+
+  {
+    ExecutionJob execution;
+    ASSERT_TRUE(execution.start(
+        [&](ExecutionJob::Generation) {
+          std::unique_lock<std::mutex> lock(mutex);
+          condition.wait(lock, [&] { return canceled; });
+          worker_completed = true;
+        },
+        [&] {
+          {
+            std::scoped_lock lock(mutex);
+            canceled = true;
+          }
+          condition.notify_one();
+        }));
+  }
+
+  EXPECT_TRUE(canceled);
+  EXPECT_TRUE(worker_completed);
+}
+
+TEST(ExecutionJob, CancelAndWaitInvalidatesCompletion)
+{
+  ExecutionJob execution;
+  ExecutionJob::Generation generation = 0;
+  ASSERT_TRUE(execution.start([&](ExecutionJob::Generation value) { generation = value; }, [] {}));
+
+  execution.wait();
+  ASSERT_TRUE(execution.isCurrent(generation));
+  execution.cancelAndWait();
+  EXPECT_FALSE(execution.isCurrent(generation));
+}
+
+TEST(ExecutionJob, NewJobInvalidatesPreviousCompletion)
+{
+  ExecutionJob execution;
+  ExecutionJob::Generation first_generation = 0;
+  ExecutionJob::Generation second_generation = 0;
+  ASSERT_TRUE(execution.start([&](ExecutionJob::Generation value) { first_generation = value; }, [] {}));
+  execution.wait();
+  ASSERT_TRUE(execution.isCurrent(first_generation));
+
+  ASSERT_TRUE(execution.start([&](ExecutionJob::Generation value) { second_generation = value; }, [] {}));
+  execution.wait();
+
+  EXPECT_FALSE(execution.isCurrent(first_generation));
+  EXPECT_TRUE(execution.isCurrent(second_generation));
+}
+}  // namespace moveit_rviz_plugin

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/test/execution_job_test.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/test/execution_job_test.cpp
@@ -37,6 +37,7 @@
 
 #include <condition_variable>
 #include <mutex>
+#include <stdexcept>
 
 namespace moveit_rviz_plugin
 {
@@ -59,9 +60,11 @@ TEST(ExecutionJob, RejectsConcurrentJob)
           release = true;
         }
         condition.notify_one();
-      }));
+      },
+      [](ExecutionJob::Generation, std::exception_ptr) {}));
 
-  EXPECT_FALSE(execution.start([&](ExecutionJob::Generation) { second_job_ran = true; }, [] {}));
+  EXPECT_FALSE(execution.start([&](ExecutionJob::Generation) { second_job_ran = true; }, [] {},
+                               [](ExecutionJob::Generation, std::exception_ptr) {}));
   execution.cancelAndWait();
   EXPECT_FALSE(second_job_ran);
   EXPECT_FALSE(execution.active());
@@ -88,7 +91,8 @@ TEST(ExecutionJob, DestructionCancelsBeforeJoining)
             canceled = true;
           }
           condition.notify_one();
-        }));
+        },
+        [](ExecutionJob::Generation, std::exception_ptr) {}));
   }
 
   EXPECT_TRUE(canceled);
@@ -99,7 +103,8 @@ TEST(ExecutionJob, CancelAndWaitInvalidatesCompletion)
 {
   ExecutionJob execution;
   ExecutionJob::Generation generation = 0;
-  ASSERT_TRUE(execution.start([&](ExecutionJob::Generation value) { generation = value; }, [] {}));
+  ASSERT_TRUE(execution.start([&](ExecutionJob::Generation value) { generation = value; }, [] {},
+                              [](ExecutionJob::Generation, std::exception_ptr) {}));
 
   execution.wait();
   ASSERT_TRUE(execution.isCurrent(generation));
@@ -112,14 +117,59 @@ TEST(ExecutionJob, NewJobInvalidatesPreviousCompletion)
   ExecutionJob execution;
   ExecutionJob::Generation first_generation = 0;
   ExecutionJob::Generation second_generation = 0;
-  ASSERT_TRUE(execution.start([&](ExecutionJob::Generation value) { first_generation = value; }, [] {}));
+  ASSERT_TRUE(execution.start([&](ExecutionJob::Generation value) { first_generation = value; }, [] {},
+                              [](ExecutionJob::Generation, std::exception_ptr) {}));
   execution.wait();
   ASSERT_TRUE(execution.isCurrent(first_generation));
 
-  ASSERT_TRUE(execution.start([&](ExecutionJob::Generation value) { second_generation = value; }, [] {}));
+  ASSERT_TRUE(execution.start([&](ExecutionJob::Generation value) { second_generation = value; }, [] {},
+                              [](ExecutionJob::Generation, std::exception_ptr) {}));
   execution.wait();
 
   EXPECT_FALSE(execution.isCurrent(first_generation));
   EXPECT_TRUE(execution.isCurrent(second_generation));
+}
+
+TEST(ExecutionJob, ReportsExceptionsAndAllowsRestart)
+{
+  ExecutionJob execution;
+  ExecutionJob::Generation job_generation = 0;
+  ExecutionJob::Generation exception_generation = 0;
+  std::exception_ptr exception;
+
+  ASSERT_TRUE(execution.start(
+      [&](ExecutionJob::Generation generation) {
+        job_generation = generation;
+        throw std::runtime_error("execution failed");
+      },
+      [] {},
+      [&](ExecutionJob::Generation generation, std::exception_ptr caught_exception) {
+        exception_generation = generation;
+        exception = caught_exception;
+      }));
+  execution.wait();
+
+  EXPECT_FALSE(execution.active());
+  EXPECT_EQ(job_generation, exception_generation);
+  ASSERT_NE(exception, nullptr);
+  EXPECT_THROW(std::rethrow_exception(exception), std::runtime_error);
+
+  bool restarted_job_ran = false;
+  ASSERT_TRUE(execution.start([&](ExecutionJob::Generation) { restarted_job_ran = true; }, [] {},
+                              [](ExecutionJob::Generation, std::exception_ptr) {}));
+  execution.wait();
+  EXPECT_TRUE(restarted_job_ran);
+}
+
+TEST(ExecutionJob, ContainsExceptionHandlerFailures)
+{
+  ExecutionJob execution;
+  ASSERT_TRUE(execution.start([](ExecutionJob::Generation) { throw std::runtime_error("execution failed"); }, [] {},
+                              [](ExecutionJob::Generation, std::exception_ptr) {
+                                throw std::runtime_error("reporting failed");
+                              }));
+
+  execution.wait();
+  EXPECT_FALSE(execution.active());
 }
 }  // namespace moveit_rviz_plugin

--- a/moveit_ros/visualization/package.xml
+++ b/moveit_ros/visualization/package.xml
@@ -43,6 +43,8 @@
   <depend>rviz2</depend>
   <depend>tf2_eigen</depend>
 
+  <test_depend>ament_cmake_gtest</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
     <rviz plugin="${prefix}/robot_state_rviz_plugin_description.xml"/>


### PR DESCRIPTION
### Description

Fixes #3836.

Replace the detached **Execute** and **Plan & Execute** workers with an owned `ExecutionJob` that:

* retains a cancellation callback and joins the worker before frame/model teardown
* rejects concurrent execution jobs
* invalidates stale queued completions after cancellation, teardown, or a newer execution
* captures the move group, plan, and Cartesian inputs needed by the worker instead of reading mutable UI state
* dispatches completion updates and remote Plan/Execute/Stop commands through Qt queued connections so widget access remains on the GUI thread

`PlanningSceneDisplay::spawnBackgroundJob()` remains available for compatibility, but the motion-planning execution paths no longer use detached workers.

### Testing

* Focused `ExecutionJob` lifecycle/concurrency tests cover concurrent-start rejection, cancel-before-join destruction, and stale-completion invalidation.
* Standalone lifecycle test passed with `-Wall -Wextra -Werror`.
* AddressSanitizer/UndefinedBehaviorSanitizer and ThreadSanitizer runs passed.
* Repository formatting, whitespace, codespell, CMake formatting, and CMake lint checks passed.
* A full ROS/Qt build was not run locally because the required ROS installation is unavailable; CI is expected to provide that integration coverage.

### Checklist

* [x] **Required by CI**: Code is auto formatted using clang-format
* [ ] Extend tutorials/documentation — not applicable; no tutorial behaviour changes
* [ ] Document API changes in MIGRATION.md — not applicable; no user-facing migration
* [x] Create tests that fail without this PR
* [ ] Include a screenshot — not applicable; no visual change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved motion-planning execution with cancellable background jobs.
  * Prevented overlapping executions and ensured outdated results cannot override newer operations.
  * Added safer handling for planning, Cartesian paths, stopping, queued callbacks, and execution failures.

* **Bug Fixes**
  * Active execution jobs are now cancelled and completed safely when closing or clearing the planning view.
  * Failed executions are reported without preventing subsequent jobs from starting.

* **Tests**
  * Added coverage for concurrent starts, cancellation, cleanup, worker joining, failure handling, and execution-generation invalidation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->