### PR TITLE
Fix exported include path in moveit_setup_assistant

### DIFF
--- a/moveit_setup_assistant/moveit_setup_assistant/CMakeLists.txt
+++ b/moveit_setup_assistant/moveit_setup_assistant/CMakeLists.txt
@@ -92,7 +92,7 @@ install(
   DESTINATION include/moveit_setup_assistant)
 install(DIRECTORY include/ DESTINATION include/moveit_setup_assistant)
 
-ament_export_include_directories(include)
+ament_export_include_directories(include/moveit_setup_assistant)
 install(DIRECTORY launch DESTINATION share/moveit_setup_assistant)
 install(DIRECTORY resources DESTINATION share/moveit_setup_assistant)
 ament_export_targets(moveit_setup_assistantTargets HAS_LIBRARY_TARGET)


### PR DESCRIPTION
## Summary

`moveit_setup_assistant` installs and advertises its headers under the unique path `include/moveit_setup_assistant`, but it still exported the generic `include` root through ament.

This aligns `ament_export_include_directories` with the package's existing `INSTALL_INTERFACE` and install destination. It also matches the convention already used by the sibling setup-assistant packages.

Partial follow-up to #3134.

## Verification

- `git diff --check`
- package-local consistency check across `INSTALL_INTERFACE`, `install(... INCLUDES DESTINATION ...)`, and `ament_export_include_directories`

A local `colcon` build was not available in this Windows environment; the MoveIt CI build remains the compile/install verification gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the exported header include path so downstream builds can locate MoveIt Setup Assistant headers reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->