### PR TITLE
Fix use-after-free in servo_keyboard_input demo by joining the spin thread

### DIFF
--- a/moveit_ros/moveit_servo/demos/servo_keyboard_input.cpp
+++ b/moveit_ros/moveit_servo/demos/servo_keyboard_input.cpp
@@ -47,6 +47,7 @@
 #include <rclcpp/rclcpp.hpp>
 #include <signal.h>
 #include <stdio.h>
+#include <thread>
 #ifndef WIN32
 #include <termios.h>
 #include <unistd.h>
@@ -137,6 +138,7 @@ class KeyboardServo
 {
 public:
   KeyboardServo();
+  ~KeyboardServo();
   int keyLoop();
 
 private:
@@ -151,6 +153,9 @@ private:
   std::shared_ptr<moveit_msgs::srv::ServoCommandType::Request> request_;
   double joint_vel_cmd_;
   std::string command_frame_id_;
+
+  // Owned by this object so it can be joined before nh_ (and this) are destroyed.
+  std::thread spin_thread_;
 };
 
 KeyboardServo::KeyboardServo() : joint_vel_cmd_(1.0), command_frame_id_{ "panda_link0" }
@@ -162,6 +167,16 @@ KeyboardServo::KeyboardServo() : joint_vel_cmd_(1.0), command_frame_id_{ "panda_
 
   // Client for switching input types
   switch_input_ = nh_->create_client<moveit_msgs::srv::ServoCommandType>("servo_node/switch_command_type");
+}
+
+KeyboardServo::~KeyboardServo()
+{
+  // Ensure the spin thread has fully exited (and is done touching nh_) before
+  // the rest of this object, including nh_, is torn down.
+  if (spin_thread_.joinable())
+  {
+    spin_thread_.join();
+  }
 }
 
 KeyboardReader input;
@@ -204,7 +219,9 @@ int KeyboardServo::keyLoop()
   bool publish_twist = false;
   bool publish_joint = false;
 
-  std::thread{ [this]() { return spin(); } }.detach();
+  // spin_thread_ is a member so it can be joined (in ~KeyboardServo) before this object is
+  // destroyed, avoiding a use-after-free of nh_ if the thread is still running spin_some().
+  spin_thread_ = std::thread{ [this]() { spin(); } };
 
   puts("Reading from keyboard");
   puts("---------------------------");


### PR DESCRIPTION
### Description

`servo_keyboard_input` starts `KeyboardServo::spin()` in a detached thread that
captures the `KeyboardServo` instance through `this`. During shutdown, the
object can be destroyed while that thread is still accessing `nh_`, resulting
in a potential use-after-free.

This change stores the spin thread as a `std::thread` member and joins it in
`KeyboardServo`'s destructor. Since `spin()` runs while `rclcpp::ok()` is true,
shutdown causes the loop to exit and the destructor can safely wait for the
thread before the object's members are destroyed.

Fixes #3838

### Validation

Validated against ROS 2 Rolling and MoveIt2 `main`:

- `moveit_servo` builds and links successfully
- `colcon test --packages-select moveit_servo`
- 9 tests passed, 0 failures
- clang-format clean
- ASan reproduces the original detached-thread use-after-free
- ASan reports no errors with this fix
- TSan reports no data races with this fix

### AI assistance

AI tooling was used during development of the initial implementation. I reviewed
the final diff, validated the concurrency behavior, built it against ROS 2
Rolling / MoveIt2 main, and ran the tests and sanitizer checks above.

### Checklist

- [x] Code is formatted with clang-format
- [ ] Extend the tutorials / documentation
- [ ] Document API changes in MIGRATION.md
- [ ] Create tests that fail without this PR — not applicable here because this
      is a shutdown-lifecycle race in a demo; ASan/TSan validation is described above
- [ ] Include a screenshot if changing a GUI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard servo shutdown behavior by ensuring background processing completes before the component is destroyed.
  * Prevented potential access to released resources during application exit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->